### PR TITLE
Feature: Protobuf messages

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -23,6 +23,7 @@ analyzer:
     - lib/generated/**
     - lib/**.g.dart
     - lib/**.gr.dart
+    - lib/trezor_protocol/shared/protobuf/messages_compiled/**
 
   language:
     # Value of true ensures that the type inference engine never implicitly casts to a more specific type

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-binance.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-binance.pb.dart
@@ -1,0 +1,939 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-binance.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'messages-binance.pbenum.dart';
+
+export 'messages-binance.pbenum.dart';
+
+/// *
+///  Request: Ask the device for a Binance address.
+///  @start
+///  @next BinanceAddress
+///  @next Failure
+class BinanceGetAddress extends $pb.GeneratedMessage {
+  factory BinanceGetAddress({
+    $core.Iterable<$core.int>? addressN,
+    $core.bool? showDisplay,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  BinanceGetAddress._() : super();
+  factory BinanceGetAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BinanceGetAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinanceGetAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.binance'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aOB(2, _omitFieldNames ? '' : 'showDisplay')
+    ..aOB(3, _omitFieldNames ? '' : 'chunkify')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BinanceGetAddress clone() => BinanceGetAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BinanceGetAddress copyWith(void Function(BinanceGetAddress) updates) => super.copyWith((message) => updates(message as BinanceGetAddress)) as BinanceGetAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BinanceGetAddress create() => BinanceGetAddress._();
+  BinanceGetAddress createEmptyInstance() => create();
+  static $pb.PbList<BinanceGetAddress> createRepeated() => $pb.PbList<BinanceGetAddress>();
+  @$core.pragma('dart2js:noInline')
+  static BinanceGetAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinanceGetAddress>(create);
+  static BinanceGetAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.bool get showDisplay => $_getBF(1);
+  @$pb.TagNumber(2)
+  set showDisplay($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasShowDisplay() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearShowDisplay() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get chunkify => $_getBF(2);
+  @$pb.TagNumber(3)
+  set chunkify($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasChunkify() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearChunkify() => clearField(3);
+}
+
+/// *
+///  Response: A Binance address.
+///  @end
+class BinanceAddress extends $pb.GeneratedMessage {
+  factory BinanceAddress({
+    $core.String? address,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    return $result;
+  }
+  BinanceAddress._() : super();
+  factory BinanceAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BinanceAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinanceAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.binance'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'address')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BinanceAddress clone() => BinanceAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BinanceAddress copyWith(void Function(BinanceAddress) updates) => super.copyWith((message) => updates(message as BinanceAddress)) as BinanceAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BinanceAddress create() => BinanceAddress._();
+  BinanceAddress createEmptyInstance() => create();
+  static $pb.PbList<BinanceAddress> createRepeated() => $pb.PbList<BinanceAddress>();
+  @$core.pragma('dart2js:noInline')
+  static BinanceAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinanceAddress>(create);
+  static BinanceAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+}
+
+/// *
+///  Request: Ask device for a public key corresponding to address_n path.
+///  @start
+///  @next BinancePublicKey
+class BinanceGetPublicKey extends $pb.GeneratedMessage {
+  factory BinanceGetPublicKey({
+    $core.Iterable<$core.int>? addressN,
+    $core.bool? showDisplay,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    return $result;
+  }
+  BinanceGetPublicKey._() : super();
+  factory BinanceGetPublicKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BinanceGetPublicKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinanceGetPublicKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.binance'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aOB(2, _omitFieldNames ? '' : 'showDisplay')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BinanceGetPublicKey clone() => BinanceGetPublicKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BinanceGetPublicKey copyWith(void Function(BinanceGetPublicKey) updates) => super.copyWith((message) => updates(message as BinanceGetPublicKey)) as BinanceGetPublicKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BinanceGetPublicKey create() => BinanceGetPublicKey._();
+  BinanceGetPublicKey createEmptyInstance() => create();
+  static $pb.PbList<BinanceGetPublicKey> createRepeated() => $pb.PbList<BinanceGetPublicKey>();
+  @$core.pragma('dart2js:noInline')
+  static BinanceGetPublicKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinanceGetPublicKey>(create);
+  static BinanceGetPublicKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.bool get showDisplay => $_getBF(1);
+  @$pb.TagNumber(2)
+  set showDisplay($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasShowDisplay() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearShowDisplay() => clearField(2);
+}
+
+/// *
+///  Response: A public key corresponding to address_n path.
+///  @end
+class BinancePublicKey extends $pb.GeneratedMessage {
+  factory BinancePublicKey({
+    $core.List<$core.int>? publicKey,
+  }) {
+    final $result = create();
+    if (publicKey != null) {
+      $result.publicKey = publicKey;
+    }
+    return $result;
+  }
+  BinancePublicKey._() : super();
+  factory BinancePublicKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BinancePublicKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinancePublicKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.binance'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'publicKey', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BinancePublicKey clone() => BinancePublicKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BinancePublicKey copyWith(void Function(BinancePublicKey) updates) => super.copyWith((message) => updates(message as BinancePublicKey)) as BinancePublicKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BinancePublicKey create() => BinancePublicKey._();
+  BinancePublicKey createEmptyInstance() => create();
+  static $pb.PbList<BinancePublicKey> createRepeated() => $pb.PbList<BinancePublicKey>();
+  @$core.pragma('dart2js:noInline')
+  static BinancePublicKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinancePublicKey>(create);
+  static BinancePublicKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get publicKey => $_getN(0);
+  @$pb.TagNumber(1)
+  set publicKey($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPublicKey() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPublicKey() => clearField(1);
+}
+
+/// *
+///  Request: Starts the Binance transaction protocol flow.
+///  A transaction consists of these common fields and a series of Binance<Any>Msg messages.
+///  These parts form a JSON structure (a string) in Trezor's memory, which is signed to produce a BinanceSignedTx.
+///  @start
+///  @next BinanceTxRequest
+///  @next Failure
+class BinanceSignTx extends $pb.GeneratedMessage {
+  factory BinanceSignTx({
+    $core.Iterable<$core.int>? addressN,
+    $core.int? msgCount,
+    $fixnum.Int64? accountNumber,
+    $core.String? chainId,
+    $core.String? memo,
+    $fixnum.Int64? sequence,
+    $fixnum.Int64? source,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (msgCount != null) {
+      $result.msgCount = msgCount;
+    }
+    if (accountNumber != null) {
+      $result.accountNumber = accountNumber;
+    }
+    if (chainId != null) {
+      $result.chainId = chainId;
+    }
+    if (memo != null) {
+      $result.memo = memo;
+    }
+    if (sequence != null) {
+      $result.sequence = sequence;
+    }
+    if (source != null) {
+      $result.source = source;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  BinanceSignTx._() : super();
+  factory BinanceSignTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BinanceSignTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinanceSignTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.binance'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'msgCount', $pb.PbFieldType.QU3)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'accountNumber', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aOS(4, _omitFieldNames ? '' : 'chainId')
+    ..aOS(5, _omitFieldNames ? '' : 'memo')
+    ..a<$fixnum.Int64>(6, _omitFieldNames ? '' : 'sequence', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(7, _omitFieldNames ? '' : 'source', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aOB(8, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BinanceSignTx clone() => BinanceSignTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BinanceSignTx copyWith(void Function(BinanceSignTx) updates) => super.copyWith((message) => updates(message as BinanceSignTx)) as BinanceSignTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BinanceSignTx create() => BinanceSignTx._();
+  BinanceSignTx createEmptyInstance() => create();
+  static $pb.PbList<BinanceSignTx> createRepeated() => $pb.PbList<BinanceSignTx>();
+  @$core.pragma('dart2js:noInline')
+  static BinanceSignTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinanceSignTx>(create);
+  static BinanceSignTx? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.int get msgCount => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set msgCount($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMsgCount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMsgCount() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get accountNumber => $_getI64(2);
+  @$pb.TagNumber(3)
+  set accountNumber($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasAccountNumber() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearAccountNumber() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get chainId => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set chainId($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasChainId() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearChainId() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.String get memo => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set memo($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasMemo() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearMemo() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $fixnum.Int64 get sequence => $_getI64(5);
+  @$pb.TagNumber(6)
+  set sequence($fixnum.Int64 v) { $_setInt64(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasSequence() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearSequence() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $fixnum.Int64 get source => $_getI64(6);
+  @$pb.TagNumber(7)
+  set source($fixnum.Int64 v) { $_setInt64(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasSource() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearSource() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.bool get chunkify => $_getBF(7);
+  @$pb.TagNumber(8)
+  set chunkify($core.bool v) { $_setBool(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasChunkify() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearChunkify() => clearField(8);
+}
+
+/// *
+///  Response: Trezor requests the next message or signals that it is ready to send a BinanceSignedTx.
+///  @next BinanceTransferMsg
+///  @next BinanceOrderMsg
+///  @next BinanceCancelMsg
+class BinanceTxRequest extends $pb.GeneratedMessage {
+  factory BinanceTxRequest() => create();
+  BinanceTxRequest._() : super();
+  factory BinanceTxRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BinanceTxRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinanceTxRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.binance'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BinanceTxRequest clone() => BinanceTxRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BinanceTxRequest copyWith(void Function(BinanceTxRequest) updates) => super.copyWith((message) => updates(message as BinanceTxRequest)) as BinanceTxRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BinanceTxRequest create() => BinanceTxRequest._();
+  BinanceTxRequest createEmptyInstance() => create();
+  static $pb.PbList<BinanceTxRequest> createRepeated() => $pb.PbList<BinanceTxRequest>();
+  @$core.pragma('dart2js:noInline')
+  static BinanceTxRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinanceTxRequest>(create);
+  static BinanceTxRequest? _defaultInstance;
+}
+
+class BinanceTransferMsg_BinanceInputOutput extends $pb.GeneratedMessage {
+  factory BinanceTransferMsg_BinanceInputOutput({
+    $core.String? address,
+    $core.Iterable<BinanceTransferMsg_BinanceCoin>? coins,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    if (coins != null) {
+      $result.coins.addAll(coins);
+    }
+    return $result;
+  }
+  BinanceTransferMsg_BinanceInputOutput._() : super();
+  factory BinanceTransferMsg_BinanceInputOutput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BinanceTransferMsg_BinanceInputOutput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinanceTransferMsg.BinanceInputOutput', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.binance'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'address')
+    ..pc<BinanceTransferMsg_BinanceCoin>(2, _omitFieldNames ? '' : 'coins', $pb.PbFieldType.PM, subBuilder: BinanceTransferMsg_BinanceCoin.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BinanceTransferMsg_BinanceInputOutput clone() => BinanceTransferMsg_BinanceInputOutput()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BinanceTransferMsg_BinanceInputOutput copyWith(void Function(BinanceTransferMsg_BinanceInputOutput) updates) => super.copyWith((message) => updates(message as BinanceTransferMsg_BinanceInputOutput)) as BinanceTransferMsg_BinanceInputOutput;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BinanceTransferMsg_BinanceInputOutput create() => BinanceTransferMsg_BinanceInputOutput._();
+  BinanceTransferMsg_BinanceInputOutput createEmptyInstance() => create();
+  static $pb.PbList<BinanceTransferMsg_BinanceInputOutput> createRepeated() => $pb.PbList<BinanceTransferMsg_BinanceInputOutput>();
+  @$core.pragma('dart2js:noInline')
+  static BinanceTransferMsg_BinanceInputOutput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinanceTransferMsg_BinanceInputOutput>(create);
+  static BinanceTransferMsg_BinanceInputOutput? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<BinanceTransferMsg_BinanceCoin> get coins => $_getList(1);
+}
+
+class BinanceTransferMsg_BinanceCoin extends $pb.GeneratedMessage {
+  factory BinanceTransferMsg_BinanceCoin({
+    $fixnum.Int64? amount,
+    $core.String? denom,
+  }) {
+    final $result = create();
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (denom != null) {
+      $result.denom = denom;
+    }
+    return $result;
+  }
+  BinanceTransferMsg_BinanceCoin._() : super();
+  factory BinanceTransferMsg_BinanceCoin.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BinanceTransferMsg_BinanceCoin.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinanceTransferMsg.BinanceCoin', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.binance'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aQS(2, _omitFieldNames ? '' : 'denom')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BinanceTransferMsg_BinanceCoin clone() => BinanceTransferMsg_BinanceCoin()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BinanceTransferMsg_BinanceCoin copyWith(void Function(BinanceTransferMsg_BinanceCoin) updates) => super.copyWith((message) => updates(message as BinanceTransferMsg_BinanceCoin)) as BinanceTransferMsg_BinanceCoin;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BinanceTransferMsg_BinanceCoin create() => BinanceTransferMsg_BinanceCoin._();
+  BinanceTransferMsg_BinanceCoin createEmptyInstance() => create();
+  static $pb.PbList<BinanceTransferMsg_BinanceCoin> createRepeated() => $pb.PbList<BinanceTransferMsg_BinanceCoin>();
+  @$core.pragma('dart2js:noInline')
+  static BinanceTransferMsg_BinanceCoin getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinanceTransferMsg_BinanceCoin>(create);
+  static BinanceTransferMsg_BinanceCoin? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get amount => $_getI64(0);
+  @$pb.TagNumber(1)
+  set amount($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAmount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAmount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get denom => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set denom($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasDenom() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearDenom() => clearField(2);
+}
+
+/// *
+///  Request: Ask the device to include a Binance transfer msg in the tx.
+///  @next BinanceSignedTx
+///  @next Failure
+class BinanceTransferMsg extends $pb.GeneratedMessage {
+  factory BinanceTransferMsg({
+    $core.Iterable<BinanceTransferMsg_BinanceInputOutput>? inputs,
+    $core.Iterable<BinanceTransferMsg_BinanceInputOutput>? outputs,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (inputs != null) {
+      $result.inputs.addAll(inputs);
+    }
+    if (outputs != null) {
+      $result.outputs.addAll(outputs);
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  BinanceTransferMsg._() : super();
+  factory BinanceTransferMsg.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BinanceTransferMsg.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinanceTransferMsg', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.binance'), createEmptyInstance: create)
+    ..pc<BinanceTransferMsg_BinanceInputOutput>(1, _omitFieldNames ? '' : 'inputs', $pb.PbFieldType.PM, subBuilder: BinanceTransferMsg_BinanceInputOutput.create)
+    ..pc<BinanceTransferMsg_BinanceInputOutput>(2, _omitFieldNames ? '' : 'outputs', $pb.PbFieldType.PM, subBuilder: BinanceTransferMsg_BinanceInputOutput.create)
+    ..aOB(3, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BinanceTransferMsg clone() => BinanceTransferMsg()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BinanceTransferMsg copyWith(void Function(BinanceTransferMsg) updates) => super.copyWith((message) => updates(message as BinanceTransferMsg)) as BinanceTransferMsg;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BinanceTransferMsg create() => BinanceTransferMsg._();
+  BinanceTransferMsg createEmptyInstance() => create();
+  static $pb.PbList<BinanceTransferMsg> createRepeated() => $pb.PbList<BinanceTransferMsg>();
+  @$core.pragma('dart2js:noInline')
+  static BinanceTransferMsg getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinanceTransferMsg>(create);
+  static BinanceTransferMsg? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<BinanceTransferMsg_BinanceInputOutput> get inputs => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<BinanceTransferMsg_BinanceInputOutput> get outputs => $_getList(1);
+
+  @$pb.TagNumber(3)
+  $core.bool get chunkify => $_getBF(2);
+  @$pb.TagNumber(3)
+  set chunkify($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasChunkify() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearChunkify() => clearField(3);
+}
+
+/// *
+///  Request: Ask the device to include a Binance order msg in the tx.
+///  @next BinanceSignedTx
+///  @next Failure
+class BinanceOrderMsg extends $pb.GeneratedMessage {
+  factory BinanceOrderMsg({
+    $core.String? id,
+    BinanceOrderMsg_BinanceOrderType? ordertype,
+    $fixnum.Int64? price,
+    $fixnum.Int64? quantity,
+    $core.String? sender,
+    BinanceOrderMsg_BinanceOrderSide? side,
+    $core.String? symbol,
+    BinanceOrderMsg_BinanceTimeInForce? timeinforce,
+  }) {
+    final $result = create();
+    if (id != null) {
+      $result.id = id;
+    }
+    if (ordertype != null) {
+      $result.ordertype = ordertype;
+    }
+    if (price != null) {
+      $result.price = price;
+    }
+    if (quantity != null) {
+      $result.quantity = quantity;
+    }
+    if (sender != null) {
+      $result.sender = sender;
+    }
+    if (side != null) {
+      $result.side = side;
+    }
+    if (symbol != null) {
+      $result.symbol = symbol;
+    }
+    if (timeinforce != null) {
+      $result.timeinforce = timeinforce;
+    }
+    return $result;
+  }
+  BinanceOrderMsg._() : super();
+  factory BinanceOrderMsg.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BinanceOrderMsg.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinanceOrderMsg', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.binance'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'id')
+    ..e<BinanceOrderMsg_BinanceOrderType>(2, _omitFieldNames ? '' : 'ordertype', $pb.PbFieldType.QE, defaultOrMaker: BinanceOrderMsg_BinanceOrderType.OT_UNKNOWN, valueOf: BinanceOrderMsg_BinanceOrderType.valueOf, enumValues: BinanceOrderMsg_BinanceOrderType.values)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'price', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'quantity', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aOS(5, _omitFieldNames ? '' : 'sender')
+    ..e<BinanceOrderMsg_BinanceOrderSide>(6, _omitFieldNames ? '' : 'side', $pb.PbFieldType.QE, defaultOrMaker: BinanceOrderMsg_BinanceOrderSide.SIDE_UNKNOWN, valueOf: BinanceOrderMsg_BinanceOrderSide.valueOf, enumValues: BinanceOrderMsg_BinanceOrderSide.values)
+    ..aOS(7, _omitFieldNames ? '' : 'symbol')
+    ..e<BinanceOrderMsg_BinanceTimeInForce>(8, _omitFieldNames ? '' : 'timeinforce', $pb.PbFieldType.QE, defaultOrMaker: BinanceOrderMsg_BinanceTimeInForce.TIF_UNKNOWN, valueOf: BinanceOrderMsg_BinanceTimeInForce.valueOf, enumValues: BinanceOrderMsg_BinanceTimeInForce.values)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BinanceOrderMsg clone() => BinanceOrderMsg()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BinanceOrderMsg copyWith(void Function(BinanceOrderMsg) updates) => super.copyWith((message) => updates(message as BinanceOrderMsg)) as BinanceOrderMsg;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BinanceOrderMsg create() => BinanceOrderMsg._();
+  BinanceOrderMsg createEmptyInstance() => create();
+  static $pb.PbList<BinanceOrderMsg> createRepeated() => $pb.PbList<BinanceOrderMsg>();
+  @$core.pragma('dart2js:noInline')
+  static BinanceOrderMsg getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinanceOrderMsg>(create);
+  static BinanceOrderMsg? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get id => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set id($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearId() => clearField(1);
+
+  @$pb.TagNumber(2)
+  BinanceOrderMsg_BinanceOrderType get ordertype => $_getN(1);
+  @$pb.TagNumber(2)
+  set ordertype(BinanceOrderMsg_BinanceOrderType v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasOrdertype() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearOrdertype() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get price => $_getI64(2);
+  @$pb.TagNumber(3)
+  set price($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasPrice() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearPrice() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get quantity => $_getI64(3);
+  @$pb.TagNumber(4)
+  set quantity($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasQuantity() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearQuantity() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.String get sender => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set sender($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasSender() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearSender() => clearField(5);
+
+  @$pb.TagNumber(6)
+  BinanceOrderMsg_BinanceOrderSide get side => $_getN(5);
+  @$pb.TagNumber(6)
+  set side(BinanceOrderMsg_BinanceOrderSide v) { setField(6, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasSide() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearSide() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.String get symbol => $_getSZ(6);
+  @$pb.TagNumber(7)
+  set symbol($core.String v) { $_setString(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasSymbol() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearSymbol() => clearField(7);
+
+  @$pb.TagNumber(8)
+  BinanceOrderMsg_BinanceTimeInForce get timeinforce => $_getN(7);
+  @$pb.TagNumber(8)
+  set timeinforce(BinanceOrderMsg_BinanceTimeInForce v) { setField(8, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasTimeinforce() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearTimeinforce() => clearField(8);
+}
+
+/// *
+///  Request: Ask the device to include a Binance cancel msg in the tx.
+///  @next BinanceSignedTx
+///  @next Failure
+class BinanceCancelMsg extends $pb.GeneratedMessage {
+  factory BinanceCancelMsg({
+    $core.String? refid,
+    $core.String? sender,
+    $core.String? symbol,
+  }) {
+    final $result = create();
+    if (refid != null) {
+      $result.refid = refid;
+    }
+    if (sender != null) {
+      $result.sender = sender;
+    }
+    if (symbol != null) {
+      $result.symbol = symbol;
+    }
+    return $result;
+  }
+  BinanceCancelMsg._() : super();
+  factory BinanceCancelMsg.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BinanceCancelMsg.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinanceCancelMsg', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.binance'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'refid')
+    ..aOS(2, _omitFieldNames ? '' : 'sender')
+    ..aOS(3, _omitFieldNames ? '' : 'symbol')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BinanceCancelMsg clone() => BinanceCancelMsg()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BinanceCancelMsg copyWith(void Function(BinanceCancelMsg) updates) => super.copyWith((message) => updates(message as BinanceCancelMsg)) as BinanceCancelMsg;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BinanceCancelMsg create() => BinanceCancelMsg._();
+  BinanceCancelMsg createEmptyInstance() => create();
+  static $pb.PbList<BinanceCancelMsg> createRepeated() => $pb.PbList<BinanceCancelMsg>();
+  @$core.pragma('dart2js:noInline')
+  static BinanceCancelMsg getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinanceCancelMsg>(create);
+  static BinanceCancelMsg? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get refid => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set refid($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasRefid() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRefid() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get sender => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set sender($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSender() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSender() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get symbol => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set symbol($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSymbol() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSymbol() => clearField(3);
+}
+
+/// *
+///  Response: A transaction signature and public key corresponding to the address_n path in BinanceSignTx.
+///  @end
+class BinanceSignedTx extends $pb.GeneratedMessage {
+  factory BinanceSignedTx({
+    $core.List<$core.int>? signature,
+    $core.List<$core.int>? publicKey,
+  }) {
+    final $result = create();
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    if (publicKey != null) {
+      $result.publicKey = publicKey;
+    }
+    return $result;
+  }
+  BinanceSignedTx._() : super();
+  factory BinanceSignedTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BinanceSignedTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinanceSignedTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.binance'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'publicKey', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BinanceSignedTx clone() => BinanceSignedTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BinanceSignedTx copyWith(void Function(BinanceSignedTx) updates) => super.copyWith((message) => updates(message as BinanceSignedTx)) as BinanceSignedTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BinanceSignedTx create() => BinanceSignedTx._();
+  BinanceSignedTx createEmptyInstance() => create();
+  static $pb.PbList<BinanceSignedTx> createRepeated() => $pb.PbList<BinanceSignedTx>();
+  @$core.pragma('dart2js:noInline')
+  static BinanceSignedTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinanceSignedTx>(create);
+  static BinanceSignedTx? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get signature => $_getN(0);
+  @$pb.TagNumber(1)
+  set signature($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSignature() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSignature() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get publicKey => $_getN(1);
+  @$pb.TagNumber(2)
+  set publicKey($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPublicKey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPublicKey() => clearField(2);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-binance.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-binance.pbenum.dart
@@ -1,0 +1,72 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-binance.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+class BinanceOrderMsg_BinanceOrderType extends $pb.ProtobufEnum {
+  static const BinanceOrderMsg_BinanceOrderType OT_UNKNOWN = BinanceOrderMsg_BinanceOrderType._(0, _omitEnumNames ? '' : 'OT_UNKNOWN');
+  static const BinanceOrderMsg_BinanceOrderType MARKET = BinanceOrderMsg_BinanceOrderType._(1, _omitEnumNames ? '' : 'MARKET');
+  static const BinanceOrderMsg_BinanceOrderType LIMIT = BinanceOrderMsg_BinanceOrderType._(2, _omitEnumNames ? '' : 'LIMIT');
+  static const BinanceOrderMsg_BinanceOrderType OT_RESERVED = BinanceOrderMsg_BinanceOrderType._(3, _omitEnumNames ? '' : 'OT_RESERVED');
+
+  static const $core.List<BinanceOrderMsg_BinanceOrderType> values = <BinanceOrderMsg_BinanceOrderType> [
+    OT_UNKNOWN,
+    MARKET,
+    LIMIT,
+    OT_RESERVED,
+  ];
+
+  static final $core.Map<$core.int, BinanceOrderMsg_BinanceOrderType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static BinanceOrderMsg_BinanceOrderType? valueOf($core.int value) => _byValue[value];
+
+  const BinanceOrderMsg_BinanceOrderType._($core.int v, $core.String n) : super(v, n);
+}
+
+class BinanceOrderMsg_BinanceOrderSide extends $pb.ProtobufEnum {
+  static const BinanceOrderMsg_BinanceOrderSide SIDE_UNKNOWN = BinanceOrderMsg_BinanceOrderSide._(0, _omitEnumNames ? '' : 'SIDE_UNKNOWN');
+  static const BinanceOrderMsg_BinanceOrderSide BUY = BinanceOrderMsg_BinanceOrderSide._(1, _omitEnumNames ? '' : 'BUY');
+  static const BinanceOrderMsg_BinanceOrderSide SELL = BinanceOrderMsg_BinanceOrderSide._(2, _omitEnumNames ? '' : 'SELL');
+
+  static const $core.List<BinanceOrderMsg_BinanceOrderSide> values = <BinanceOrderMsg_BinanceOrderSide> [
+    SIDE_UNKNOWN,
+    BUY,
+    SELL,
+  ];
+
+  static final $core.Map<$core.int, BinanceOrderMsg_BinanceOrderSide> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static BinanceOrderMsg_BinanceOrderSide? valueOf($core.int value) => _byValue[value];
+
+  const BinanceOrderMsg_BinanceOrderSide._($core.int v, $core.String n) : super(v, n);
+}
+
+class BinanceOrderMsg_BinanceTimeInForce extends $pb.ProtobufEnum {
+  static const BinanceOrderMsg_BinanceTimeInForce TIF_UNKNOWN = BinanceOrderMsg_BinanceTimeInForce._(0, _omitEnumNames ? '' : 'TIF_UNKNOWN');
+  static const BinanceOrderMsg_BinanceTimeInForce GTE = BinanceOrderMsg_BinanceTimeInForce._(1, _omitEnumNames ? '' : 'GTE');
+  static const BinanceOrderMsg_BinanceTimeInForce TIF_RESERVED = BinanceOrderMsg_BinanceTimeInForce._(2, _omitEnumNames ? '' : 'TIF_RESERVED');
+  static const BinanceOrderMsg_BinanceTimeInForce IOC = BinanceOrderMsg_BinanceTimeInForce._(3, _omitEnumNames ? '' : 'IOC');
+
+  static const $core.List<BinanceOrderMsg_BinanceTimeInForce> values = <BinanceOrderMsg_BinanceTimeInForce> [
+    TIF_UNKNOWN,
+    GTE,
+    TIF_RESERVED,
+    IOC,
+  ];
+
+  static final $core.Map<$core.int, BinanceOrderMsg_BinanceTimeInForce> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static BinanceOrderMsg_BinanceTimeInForce? valueOf($core.int value) => _byValue[value];
+
+  const BinanceOrderMsg_BinanceTimeInForce._($core.int v, $core.String n) : super(v, n);
+}
+
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-binance.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-binance.pbjson.dart
@@ -1,0 +1,232 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-binance.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use binanceGetAddressDescriptor instead')
+const BinanceGetAddress$json = {
+  '1': 'BinanceGetAddress',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'show_display', '3': 2, '4': 1, '5': 8, '10': 'showDisplay'},
+    {'1': 'chunkify', '3': 3, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `BinanceGetAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List binanceGetAddressDescriptor = $convert.base64Decode(
+    'ChFCaW5hbmNlR2V0QWRkcmVzcxIbCglhZGRyZXNzX24YASADKA1SCGFkZHJlc3NOEiEKDHNob3'
+    'dfZGlzcGxheRgCIAEoCFILc2hvd0Rpc3BsYXkSGgoIY2h1bmtpZnkYAyABKAhSCGNodW5raWZ5');
+
+@$core.Deprecated('Use binanceAddressDescriptor instead')
+const BinanceAddress$json = {
+  '1': 'BinanceAddress',
+  '2': [
+    {'1': 'address', '3': 1, '4': 2, '5': 9, '10': 'address'},
+  ],
+};
+
+/// Descriptor for `BinanceAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List binanceAddressDescriptor = $convert.base64Decode(
+    'Cg5CaW5hbmNlQWRkcmVzcxIYCgdhZGRyZXNzGAEgAigJUgdhZGRyZXNz');
+
+@$core.Deprecated('Use binanceGetPublicKeyDescriptor instead')
+const BinanceGetPublicKey$json = {
+  '1': 'BinanceGetPublicKey',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'show_display', '3': 2, '4': 1, '5': 8, '10': 'showDisplay'},
+  ],
+};
+
+/// Descriptor for `BinanceGetPublicKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List binanceGetPublicKeyDescriptor = $convert.base64Decode(
+    'ChNCaW5hbmNlR2V0UHVibGljS2V5EhsKCWFkZHJlc3NfbhgBIAMoDVIIYWRkcmVzc04SIQoMc2'
+    'hvd19kaXNwbGF5GAIgASgIUgtzaG93RGlzcGxheQ==');
+
+@$core.Deprecated('Use binancePublicKeyDescriptor instead')
+const BinancePublicKey$json = {
+  '1': 'BinancePublicKey',
+  '2': [
+    {'1': 'public_key', '3': 1, '4': 2, '5': 12, '10': 'publicKey'},
+  ],
+};
+
+/// Descriptor for `BinancePublicKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List binancePublicKeyDescriptor = $convert.base64Decode(
+    'ChBCaW5hbmNlUHVibGljS2V5Eh0KCnB1YmxpY19rZXkYASACKAxSCXB1YmxpY0tleQ==');
+
+@$core.Deprecated('Use binanceSignTxDescriptor instead')
+const BinanceSignTx$json = {
+  '1': 'BinanceSignTx',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'msg_count', '3': 2, '4': 2, '5': 13, '10': 'msgCount'},
+    {'1': 'account_number', '3': 3, '4': 2, '5': 18, '10': 'accountNumber'},
+    {'1': 'chain_id', '3': 4, '4': 1, '5': 9, '10': 'chainId'},
+    {'1': 'memo', '3': 5, '4': 1, '5': 9, '10': 'memo'},
+    {'1': 'sequence', '3': 6, '4': 2, '5': 18, '10': 'sequence'},
+    {'1': 'source', '3': 7, '4': 2, '5': 18, '10': 'source'},
+    {'1': 'chunkify', '3': 8, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `BinanceSignTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List binanceSignTxDescriptor = $convert.base64Decode(
+    'Cg1CaW5hbmNlU2lnblR4EhsKCWFkZHJlc3NfbhgBIAMoDVIIYWRkcmVzc04SGwoJbXNnX2NvdW'
+    '50GAIgAigNUghtc2dDb3VudBIlCg5hY2NvdW50X251bWJlchgDIAIoElINYWNjb3VudE51bWJl'
+    'chIZCghjaGFpbl9pZBgEIAEoCVIHY2hhaW5JZBISCgRtZW1vGAUgASgJUgRtZW1vEhoKCHNlcX'
+    'VlbmNlGAYgAigSUghzZXF1ZW5jZRIWCgZzb3VyY2UYByACKBJSBnNvdXJjZRIaCghjaHVua2lm'
+    'eRgIIAEoCFIIY2h1bmtpZnk=');
+
+@$core.Deprecated('Use binanceTxRequestDescriptor instead')
+const BinanceTxRequest$json = {
+  '1': 'BinanceTxRequest',
+};
+
+/// Descriptor for `BinanceTxRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List binanceTxRequestDescriptor = $convert.base64Decode(
+    'ChBCaW5hbmNlVHhSZXF1ZXN0');
+
+@$core.Deprecated('Use binanceTransferMsgDescriptor instead')
+const BinanceTransferMsg$json = {
+  '1': 'BinanceTransferMsg',
+  '2': [
+    {'1': 'inputs', '3': 1, '4': 3, '5': 11, '6': '.hw.trezor.messages.binance.BinanceTransferMsg.BinanceInputOutput', '10': 'inputs'},
+    {'1': 'outputs', '3': 2, '4': 3, '5': 11, '6': '.hw.trezor.messages.binance.BinanceTransferMsg.BinanceInputOutput', '10': 'outputs'},
+    {'1': 'chunkify', '3': 3, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+  '3': [BinanceTransferMsg_BinanceInputOutput$json, BinanceTransferMsg_BinanceCoin$json],
+};
+
+@$core.Deprecated('Use binanceTransferMsgDescriptor instead')
+const BinanceTransferMsg_BinanceInputOutput$json = {
+  '1': 'BinanceInputOutput',
+  '2': [
+    {'1': 'address', '3': 1, '4': 2, '5': 9, '10': 'address'},
+    {'1': 'coins', '3': 2, '4': 3, '5': 11, '6': '.hw.trezor.messages.binance.BinanceTransferMsg.BinanceCoin', '10': 'coins'},
+  ],
+};
+
+@$core.Deprecated('Use binanceTransferMsgDescriptor instead')
+const BinanceTransferMsg_BinanceCoin$json = {
+  '1': 'BinanceCoin',
+  '2': [
+    {'1': 'amount', '3': 1, '4': 2, '5': 18, '10': 'amount'},
+    {'1': 'denom', '3': 2, '4': 2, '5': 9, '10': 'denom'},
+  ],
+};
+
+/// Descriptor for `BinanceTransferMsg`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List binanceTransferMsgDescriptor = $convert.base64Decode(
+    'ChJCaW5hbmNlVHJhbnNmZXJNc2cSWQoGaW5wdXRzGAEgAygLMkEuaHcudHJlem9yLm1lc3NhZ2'
+    'VzLmJpbmFuY2UuQmluYW5jZVRyYW5zZmVyTXNnLkJpbmFuY2VJbnB1dE91dHB1dFIGaW5wdXRz'
+    'ElsKB291dHB1dHMYAiADKAsyQS5ody50cmV6b3IubWVzc2FnZXMuYmluYW5jZS5CaW5hbmNlVH'
+    'JhbnNmZXJNc2cuQmluYW5jZUlucHV0T3V0cHV0UgdvdXRwdXRzEhoKCGNodW5raWZ5GAMgASgI'
+    'UghjaHVua2lmeRqAAQoSQmluYW5jZUlucHV0T3V0cHV0EhgKB2FkZHJlc3MYASACKAlSB2FkZH'
+    'Jlc3MSUAoFY29pbnMYAiADKAsyOi5ody50cmV6b3IubWVzc2FnZXMuYmluYW5jZS5CaW5hbmNl'
+    'VHJhbnNmZXJNc2cuQmluYW5jZUNvaW5SBWNvaW5zGjsKC0JpbmFuY2VDb2luEhYKBmFtb3VudB'
+    'gBIAIoElIGYW1vdW50EhQKBWRlbm9tGAIgAigJUgVkZW5vbQ==');
+
+@$core.Deprecated('Use binanceOrderMsgDescriptor instead')
+const BinanceOrderMsg$json = {
+  '1': 'BinanceOrderMsg',
+  '2': [
+    {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
+    {'1': 'ordertype', '3': 2, '4': 2, '5': 14, '6': '.hw.trezor.messages.binance.BinanceOrderMsg.BinanceOrderType', '10': 'ordertype'},
+    {'1': 'price', '3': 3, '4': 2, '5': 18, '10': 'price'},
+    {'1': 'quantity', '3': 4, '4': 2, '5': 18, '10': 'quantity'},
+    {'1': 'sender', '3': 5, '4': 1, '5': 9, '10': 'sender'},
+    {'1': 'side', '3': 6, '4': 2, '5': 14, '6': '.hw.trezor.messages.binance.BinanceOrderMsg.BinanceOrderSide', '10': 'side'},
+    {'1': 'symbol', '3': 7, '4': 1, '5': 9, '10': 'symbol'},
+    {'1': 'timeinforce', '3': 8, '4': 2, '5': 14, '6': '.hw.trezor.messages.binance.BinanceOrderMsg.BinanceTimeInForce', '10': 'timeinforce'},
+  ],
+  '4': [BinanceOrderMsg_BinanceOrderType$json, BinanceOrderMsg_BinanceOrderSide$json, BinanceOrderMsg_BinanceTimeInForce$json],
+};
+
+@$core.Deprecated('Use binanceOrderMsgDescriptor instead')
+const BinanceOrderMsg_BinanceOrderType$json = {
+  '1': 'BinanceOrderType',
+  '2': [
+    {'1': 'OT_UNKNOWN', '2': 0},
+    {'1': 'MARKET', '2': 1},
+    {'1': 'LIMIT', '2': 2},
+    {'1': 'OT_RESERVED', '2': 3},
+  ],
+};
+
+@$core.Deprecated('Use binanceOrderMsgDescriptor instead')
+const BinanceOrderMsg_BinanceOrderSide$json = {
+  '1': 'BinanceOrderSide',
+  '2': [
+    {'1': 'SIDE_UNKNOWN', '2': 0},
+    {'1': 'BUY', '2': 1},
+    {'1': 'SELL', '2': 2},
+  ],
+};
+
+@$core.Deprecated('Use binanceOrderMsgDescriptor instead')
+const BinanceOrderMsg_BinanceTimeInForce$json = {
+  '1': 'BinanceTimeInForce',
+  '2': [
+    {'1': 'TIF_UNKNOWN', '2': 0},
+    {'1': 'GTE', '2': 1},
+    {'1': 'TIF_RESERVED', '2': 2},
+    {'1': 'IOC', '2': 3},
+  ],
+};
+
+/// Descriptor for `BinanceOrderMsg`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List binanceOrderMsgDescriptor = $convert.base64Decode(
+    'Cg9CaW5hbmNlT3JkZXJNc2cSDgoCaWQYASABKAlSAmlkEloKCW9yZGVydHlwZRgCIAIoDjI8Lm'
+    'h3LnRyZXpvci5tZXNzYWdlcy5iaW5hbmNlLkJpbmFuY2VPcmRlck1zZy5CaW5hbmNlT3JkZXJU'
+    'eXBlUglvcmRlcnR5cGUSFAoFcHJpY2UYAyACKBJSBXByaWNlEhoKCHF1YW50aXR5GAQgAigSUg'
+    'hxdWFudGl0eRIWCgZzZW5kZXIYBSABKAlSBnNlbmRlchJQCgRzaWRlGAYgAigOMjwuaHcudHJl'
+    'em9yLm1lc3NhZ2VzLmJpbmFuY2UuQmluYW5jZU9yZGVyTXNnLkJpbmFuY2VPcmRlclNpZGVSBH'
+    'NpZGUSFgoGc3ltYm9sGAcgASgJUgZzeW1ib2wSYAoLdGltZWluZm9yY2UYCCACKA4yPi5ody50'
+    'cmV6b3IubWVzc2FnZXMuYmluYW5jZS5CaW5hbmNlT3JkZXJNc2cuQmluYW5jZVRpbWVJbkZvcm'
+    'NlUgt0aW1laW5mb3JjZSJKChBCaW5hbmNlT3JkZXJUeXBlEg4KCk9UX1VOS05PV04QABIKCgZN'
+    'QVJLRVQQARIJCgVMSU1JVBACEg8KC09UX1JFU0VSVkVEEAMiNwoQQmluYW5jZU9yZGVyU2lkZR'
+    'IQCgxTSURFX1VOS05PV04QABIHCgNCVVkQARIICgRTRUxMEAIiSQoSQmluYW5jZVRpbWVJbkZv'
+    'cmNlEg8KC1RJRl9VTktOT1dOEAASBwoDR1RFEAESEAoMVElGX1JFU0VSVkVEEAISBwoDSU9DEA'
+    'M=');
+
+@$core.Deprecated('Use binanceCancelMsgDescriptor instead')
+const BinanceCancelMsg$json = {
+  '1': 'BinanceCancelMsg',
+  '2': [
+    {'1': 'refid', '3': 1, '4': 1, '5': 9, '10': 'refid'},
+    {'1': 'sender', '3': 2, '4': 1, '5': 9, '10': 'sender'},
+    {'1': 'symbol', '3': 3, '4': 1, '5': 9, '10': 'symbol'},
+  ],
+};
+
+/// Descriptor for `BinanceCancelMsg`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List binanceCancelMsgDescriptor = $convert.base64Decode(
+    'ChBCaW5hbmNlQ2FuY2VsTXNnEhQKBXJlZmlkGAEgASgJUgVyZWZpZBIWCgZzZW5kZXIYAiABKA'
+    'lSBnNlbmRlchIWCgZzeW1ib2wYAyABKAlSBnN5bWJvbA==');
+
+@$core.Deprecated('Use binanceSignedTxDescriptor instead')
+const BinanceSignedTx$json = {
+  '1': 'BinanceSignedTx',
+  '2': [
+    {'1': 'signature', '3': 1, '4': 2, '5': 12, '10': 'signature'},
+    {'1': 'public_key', '3': 2, '4': 2, '5': 12, '10': 'publicKey'},
+  ],
+};
+
+/// Descriptor for `BinanceSignedTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List binanceSignedTxDescriptor = $convert.base64Decode(
+    'Cg9CaW5hbmNlU2lnbmVkVHgSHAoJc2lnbmF0dXJlGAEgAigMUglzaWduYXR1cmUSHQoKcHVibG'
+    'ljX2tleRgCIAIoDFIJcHVibGljS2V5');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-binance.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-binance.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-binance.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-binance.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bitcoin.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bitcoin.pb.dart
@@ -1,0 +1,4570 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-bitcoin.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'messages-bitcoin.pbenum.dart';
+import 'messages-common.pb.dart' as $0;
+
+export 'messages-bitcoin.pbenum.dart';
+
+/// *
+///  Structure representing HDNode + Path
+class MultisigRedeemScriptType_HDNodePathType extends $pb.GeneratedMessage {
+  factory MultisigRedeemScriptType_HDNodePathType({
+    $0.HDNodeType? node,
+    $core.Iterable<$core.int>? addressN,
+  }) {
+    final $result = create();
+    if (node != null) {
+      $result.node = node;
+    }
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    return $result;
+  }
+  MultisigRedeemScriptType_HDNodePathType._() : super();
+  factory MultisigRedeemScriptType_HDNodePathType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MultisigRedeemScriptType_HDNodePathType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MultisigRedeemScriptType.HDNodePathType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQM<$0.HDNodeType>(1, _omitFieldNames ? '' : 'node', subBuilder: $0.HDNodeType.create)
+    ..p<$core.int>(2, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MultisigRedeemScriptType_HDNodePathType clone() => MultisigRedeemScriptType_HDNodePathType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MultisigRedeemScriptType_HDNodePathType copyWith(void Function(MultisigRedeemScriptType_HDNodePathType) updates) => super.copyWith((message) => updates(message as MultisigRedeemScriptType_HDNodePathType)) as MultisigRedeemScriptType_HDNodePathType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MultisigRedeemScriptType_HDNodePathType create() => MultisigRedeemScriptType_HDNodePathType._();
+  MultisigRedeemScriptType_HDNodePathType createEmptyInstance() => create();
+  static $pb.PbList<MultisigRedeemScriptType_HDNodePathType> createRepeated() => $pb.PbList<MultisigRedeemScriptType_HDNodePathType>();
+  @$core.pragma('dart2js:noInline')
+  static MultisigRedeemScriptType_HDNodePathType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MultisigRedeemScriptType_HDNodePathType>(create);
+  static MultisigRedeemScriptType_HDNodePathType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $0.HDNodeType get node => $_getN(0);
+  @$pb.TagNumber(1)
+  set node($0.HDNodeType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasNode() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearNode() => clearField(1);
+  @$pb.TagNumber(1)
+  $0.HDNodeType ensureNode() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get addressN => $_getList(1);
+}
+
+/// *
+///  Type of redeem script used in input
+///  @embed
+class MultisigRedeemScriptType extends $pb.GeneratedMessage {
+  factory MultisigRedeemScriptType({
+    $core.Iterable<MultisigRedeemScriptType_HDNodePathType>? pubkeys,
+    $core.Iterable<$core.List<$core.int>>? signatures,
+    $core.int? m,
+    $core.Iterable<$0.HDNodeType>? nodes,
+    $core.Iterable<$core.int>? addressN,
+  }) {
+    final $result = create();
+    if (pubkeys != null) {
+      $result.pubkeys.addAll(pubkeys);
+    }
+    if (signatures != null) {
+      $result.signatures.addAll(signatures);
+    }
+    if (m != null) {
+      $result.m = m;
+    }
+    if (nodes != null) {
+      $result.nodes.addAll(nodes);
+    }
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    return $result;
+  }
+  MultisigRedeemScriptType._() : super();
+  factory MultisigRedeemScriptType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MultisigRedeemScriptType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MultisigRedeemScriptType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..pc<MultisigRedeemScriptType_HDNodePathType>(1, _omitFieldNames ? '' : 'pubkeys', $pb.PbFieldType.PM, subBuilder: MultisigRedeemScriptType_HDNodePathType.create)
+    ..p<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'signatures', $pb.PbFieldType.PY)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'm', $pb.PbFieldType.QU3)
+    ..pc<$0.HDNodeType>(4, _omitFieldNames ? '' : 'nodes', $pb.PbFieldType.PM, subBuilder: $0.HDNodeType.create)
+    ..p<$core.int>(5, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MultisigRedeemScriptType clone() => MultisigRedeemScriptType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MultisigRedeemScriptType copyWith(void Function(MultisigRedeemScriptType) updates) => super.copyWith((message) => updates(message as MultisigRedeemScriptType)) as MultisigRedeemScriptType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MultisigRedeemScriptType create() => MultisigRedeemScriptType._();
+  MultisigRedeemScriptType createEmptyInstance() => create();
+  static $pb.PbList<MultisigRedeemScriptType> createRepeated() => $pb.PbList<MultisigRedeemScriptType>();
+  @$core.pragma('dart2js:noInline')
+  static MultisigRedeemScriptType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MultisigRedeemScriptType>(create);
+  static MultisigRedeemScriptType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<MultisigRedeemScriptType_HDNodePathType> get pubkeys => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.List<$core.int>> get signatures => $_getList(1);
+
+  @$pb.TagNumber(3)
+  $core.int get m => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set m($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasM() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearM() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$0.HDNodeType> get nodes => $_getList(3);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get addressN => $_getList(4);
+}
+
+/// *
+///  Request: Ask device for public key corresponding to address_n path
+///  @start
+///  @next PublicKey
+///  @next Failure
+class GetPublicKey extends $pb.GeneratedMessage {
+  factory GetPublicKey({
+    $core.Iterable<$core.int>? addressN,
+    $core.String? ecdsaCurveName,
+    $core.bool? showDisplay,
+    $core.String? coinName,
+    InputScriptType? scriptType,
+    $core.bool? ignoreXpubMagic,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (ecdsaCurveName != null) {
+      $result.ecdsaCurveName = ecdsaCurveName;
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    if (coinName != null) {
+      $result.coinName = coinName;
+    }
+    if (scriptType != null) {
+      $result.scriptType = scriptType;
+    }
+    if (ignoreXpubMagic != null) {
+      $result.ignoreXpubMagic = ignoreXpubMagic;
+    }
+    return $result;
+  }
+  GetPublicKey._() : super();
+  factory GetPublicKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPublicKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPublicKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aOS(2, _omitFieldNames ? '' : 'ecdsaCurveName')
+    ..aOB(3, _omitFieldNames ? '' : 'showDisplay')
+    ..a<$core.String>(4, _omitFieldNames ? '' : 'coinName', $pb.PbFieldType.OS, defaultOrMaker: 'Bitcoin')
+    ..e<InputScriptType>(5, _omitFieldNames ? '' : 'scriptType', $pb.PbFieldType.OE, defaultOrMaker: InputScriptType.SPENDADDRESS, valueOf: InputScriptType.valueOf, enumValues: InputScriptType.values)
+    ..aOB(6, _omitFieldNames ? '' : 'ignoreXpubMagic')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetPublicKey clone() => GetPublicKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPublicKey copyWith(void Function(GetPublicKey) updates) => super.copyWith((message) => updates(message as GetPublicKey)) as GetPublicKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetPublicKey create() => GetPublicKey._();
+  GetPublicKey createEmptyInstance() => create();
+  static $pb.PbList<GetPublicKey> createRepeated() => $pb.PbList<GetPublicKey>();
+  @$core.pragma('dart2js:noInline')
+  static GetPublicKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPublicKey>(create);
+  static GetPublicKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.String get ecdsaCurveName => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set ecdsaCurveName($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasEcdsaCurveName() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearEcdsaCurveName() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get showDisplay => $_getBF(2);
+  @$pb.TagNumber(3)
+  set showDisplay($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasShowDisplay() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearShowDisplay() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get coinName => $_getS(3, 'Bitcoin');
+  @$pb.TagNumber(4)
+  set coinName($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasCoinName() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearCoinName() => clearField(4);
+
+  @$pb.TagNumber(5)
+  InputScriptType get scriptType => $_getN(4);
+  @$pb.TagNumber(5)
+  set scriptType(InputScriptType v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasScriptType() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearScriptType() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.bool get ignoreXpubMagic => $_getBF(5);
+  @$pb.TagNumber(6)
+  set ignoreXpubMagic($core.bool v) { $_setBool(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasIgnoreXpubMagic() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearIgnoreXpubMagic() => clearField(6);
+}
+
+/// *
+///  Response: Contains public key derived from device private seed
+///  @end
+class PublicKey extends $pb.GeneratedMessage {
+  factory PublicKey({
+    $0.HDNodeType? node,
+    $core.String? xpub,
+    $core.int? rootFingerprint,
+    $core.String? descriptor,
+  }) {
+    final $result = create();
+    if (node != null) {
+      $result.node = node;
+    }
+    if (xpub != null) {
+      $result.xpub = xpub;
+    }
+    if (rootFingerprint != null) {
+      $result.rootFingerprint = rootFingerprint;
+    }
+    if (descriptor != null) {
+      $result.descriptor = descriptor;
+    }
+    return $result;
+  }
+  PublicKey._() : super();
+  factory PublicKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PublicKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PublicKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQM<$0.HDNodeType>(1, _omitFieldNames ? '' : 'node', subBuilder: $0.HDNodeType.create)
+    ..aQS(2, _omitFieldNames ? '' : 'xpub')
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'rootFingerprint', $pb.PbFieldType.OU3)
+    ..aOS(4, _omitFieldNames ? '' : 'descriptor')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PublicKey clone() => PublicKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PublicKey copyWith(void Function(PublicKey) updates) => super.copyWith((message) => updates(message as PublicKey)) as PublicKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PublicKey create() => PublicKey._();
+  PublicKey createEmptyInstance() => create();
+  static $pb.PbList<PublicKey> createRepeated() => $pb.PbList<PublicKey>();
+  @$core.pragma('dart2js:noInline')
+  static PublicKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PublicKey>(create);
+  static PublicKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $0.HDNodeType get node => $_getN(0);
+  @$pb.TagNumber(1)
+  set node($0.HDNodeType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasNode() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearNode() => clearField(1);
+  @$pb.TagNumber(1)
+  $0.HDNodeType ensureNode() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $core.String get xpub => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set xpub($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasXpub() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearXpub() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get rootFingerprint => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set rootFingerprint($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasRootFingerprint() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearRootFingerprint() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get descriptor => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set descriptor($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasDescriptor() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearDescriptor() => clearField(4);
+}
+
+/// *
+///  Request: Ask device for address corresponding to address_n path
+///  @start
+///  @next Address
+///  @next Failure
+class GetAddress extends $pb.GeneratedMessage {
+  factory GetAddress({
+    $core.Iterable<$core.int>? addressN,
+    $core.String? coinName,
+    $core.bool? showDisplay,
+    MultisigRedeemScriptType? multisig,
+    InputScriptType? scriptType,
+    $core.bool? ignoreXpubMagic,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (coinName != null) {
+      $result.coinName = coinName;
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    if (multisig != null) {
+      $result.multisig = multisig;
+    }
+    if (scriptType != null) {
+      $result.scriptType = scriptType;
+    }
+    if (ignoreXpubMagic != null) {
+      $result.ignoreXpubMagic = ignoreXpubMagic;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  GetAddress._() : super();
+  factory GetAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.String>(2, _omitFieldNames ? '' : 'coinName', $pb.PbFieldType.OS, defaultOrMaker: 'Bitcoin')
+    ..aOB(3, _omitFieldNames ? '' : 'showDisplay')
+    ..aOM<MultisigRedeemScriptType>(4, _omitFieldNames ? '' : 'multisig', subBuilder: MultisigRedeemScriptType.create)
+    ..e<InputScriptType>(5, _omitFieldNames ? '' : 'scriptType', $pb.PbFieldType.OE, defaultOrMaker: InputScriptType.SPENDADDRESS, valueOf: InputScriptType.valueOf, enumValues: InputScriptType.values)
+    ..aOB(6, _omitFieldNames ? '' : 'ignoreXpubMagic')
+    ..aOB(7, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetAddress clone() => GetAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetAddress copyWith(void Function(GetAddress) updates) => super.copyWith((message) => updates(message as GetAddress)) as GetAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetAddress create() => GetAddress._();
+  GetAddress createEmptyInstance() => create();
+  static $pb.PbList<GetAddress> createRepeated() => $pb.PbList<GetAddress>();
+  @$core.pragma('dart2js:noInline')
+  static GetAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetAddress>(create);
+  static GetAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.String get coinName => $_getS(1, 'Bitcoin');
+  @$pb.TagNumber(2)
+  set coinName($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasCoinName() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCoinName() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get showDisplay => $_getBF(2);
+  @$pb.TagNumber(3)
+  set showDisplay($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasShowDisplay() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearShowDisplay() => clearField(3);
+
+  @$pb.TagNumber(4)
+  MultisigRedeemScriptType get multisig => $_getN(3);
+  @$pb.TagNumber(4)
+  set multisig(MultisigRedeemScriptType v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasMultisig() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMultisig() => clearField(4);
+  @$pb.TagNumber(4)
+  MultisigRedeemScriptType ensureMultisig() => $_ensure(3);
+
+  @$pb.TagNumber(5)
+  InputScriptType get scriptType => $_getN(4);
+  @$pb.TagNumber(5)
+  set scriptType(InputScriptType v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasScriptType() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearScriptType() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.bool get ignoreXpubMagic => $_getBF(5);
+  @$pb.TagNumber(6)
+  set ignoreXpubMagic($core.bool v) { $_setBool(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasIgnoreXpubMagic() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearIgnoreXpubMagic() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.bool get chunkify => $_getBF(6);
+  @$pb.TagNumber(7)
+  set chunkify($core.bool v) { $_setBool(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasChunkify() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearChunkify() => clearField(7);
+}
+
+/// *
+///  Response: Contains address derived from device private seed
+///  @end
+class Address extends $pb.GeneratedMessage {
+  factory Address({
+    $core.String? address,
+    $core.List<$core.int>? mac,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    if (mac != null) {
+      $result.mac = mac;
+    }
+    return $result;
+  }
+  Address._() : super();
+  factory Address.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Address.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Address', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'address')
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'mac', $pb.PbFieldType.OY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Address clone() => Address()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Address copyWith(void Function(Address) updates) => super.copyWith((message) => updates(message as Address)) as Address;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Address create() => Address._();
+  Address createEmptyInstance() => create();
+  static $pb.PbList<Address> createRepeated() => $pb.PbList<Address>();
+  @$core.pragma('dart2js:noInline')
+  static Address getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Address>(create);
+  static Address? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get mac => $_getN(1);
+  @$pb.TagNumber(2)
+  set mac($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMac() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMac() => clearField(2);
+}
+
+/// *
+///  Request: Ask device for ownership identifier corresponding to scriptPubKey for address_n path
+///  @start
+///  @next OwnershipId
+///  @next Failure
+class GetOwnershipId extends $pb.GeneratedMessage {
+  factory GetOwnershipId({
+    $core.Iterable<$core.int>? addressN,
+    $core.String? coinName,
+    MultisigRedeemScriptType? multisig,
+    InputScriptType? scriptType,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (coinName != null) {
+      $result.coinName = coinName;
+    }
+    if (multisig != null) {
+      $result.multisig = multisig;
+    }
+    if (scriptType != null) {
+      $result.scriptType = scriptType;
+    }
+    return $result;
+  }
+  GetOwnershipId._() : super();
+  factory GetOwnershipId.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetOwnershipId.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetOwnershipId', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.String>(2, _omitFieldNames ? '' : 'coinName', $pb.PbFieldType.OS, defaultOrMaker: 'Bitcoin')
+    ..aOM<MultisigRedeemScriptType>(3, _omitFieldNames ? '' : 'multisig', subBuilder: MultisigRedeemScriptType.create)
+    ..e<InputScriptType>(4, _omitFieldNames ? '' : 'scriptType', $pb.PbFieldType.OE, defaultOrMaker: InputScriptType.SPENDADDRESS, valueOf: InputScriptType.valueOf, enumValues: InputScriptType.values)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetOwnershipId clone() => GetOwnershipId()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetOwnershipId copyWith(void Function(GetOwnershipId) updates) => super.copyWith((message) => updates(message as GetOwnershipId)) as GetOwnershipId;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetOwnershipId create() => GetOwnershipId._();
+  GetOwnershipId createEmptyInstance() => create();
+  static $pb.PbList<GetOwnershipId> createRepeated() => $pb.PbList<GetOwnershipId>();
+  @$core.pragma('dart2js:noInline')
+  static GetOwnershipId getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetOwnershipId>(create);
+  static GetOwnershipId? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.String get coinName => $_getS(1, 'Bitcoin');
+  @$pb.TagNumber(2)
+  set coinName($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasCoinName() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCoinName() => clearField(2);
+
+  @$pb.TagNumber(3)
+  MultisigRedeemScriptType get multisig => $_getN(2);
+  @$pb.TagNumber(3)
+  set multisig(MultisigRedeemScriptType v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasMultisig() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearMultisig() => clearField(3);
+  @$pb.TagNumber(3)
+  MultisigRedeemScriptType ensureMultisig() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  InputScriptType get scriptType => $_getN(3);
+  @$pb.TagNumber(4)
+  set scriptType(InputScriptType v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasScriptType() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearScriptType() => clearField(4);
+}
+
+/// *
+///  Response: Contains the ownership identifier for the scriptPubKey and device private seed
+///  @end
+class OwnershipId extends $pb.GeneratedMessage {
+  factory OwnershipId({
+    $core.List<$core.int>? ownershipId,
+  }) {
+    final $result = create();
+    if (ownershipId != null) {
+      $result.ownershipId = ownershipId;
+    }
+    return $result;
+  }
+  OwnershipId._() : super();
+  factory OwnershipId.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory OwnershipId.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'OwnershipId', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'ownershipId', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  OwnershipId clone() => OwnershipId()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  OwnershipId copyWith(void Function(OwnershipId) updates) => super.copyWith((message) => updates(message as OwnershipId)) as OwnershipId;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static OwnershipId create() => OwnershipId._();
+  OwnershipId createEmptyInstance() => create();
+  static $pb.PbList<OwnershipId> createRepeated() => $pb.PbList<OwnershipId>();
+  @$core.pragma('dart2js:noInline')
+  static OwnershipId getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OwnershipId>(create);
+  static OwnershipId? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get ownershipId => $_getN(0);
+  @$pb.TagNumber(1)
+  set ownershipId($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasOwnershipId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearOwnershipId() => clearField(1);
+}
+
+/// *
+///  Request: Ask device to sign message
+///  @start
+///  @next MessageSignature
+///  @next Failure
+class SignMessage extends $pb.GeneratedMessage {
+  factory SignMessage({
+    $core.Iterable<$core.int>? addressN,
+    $core.List<$core.int>? message,
+    $core.String? coinName,
+    InputScriptType? scriptType,
+    $core.bool? noScriptType,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (message != null) {
+      $result.message = message;
+    }
+    if (coinName != null) {
+      $result.coinName = coinName;
+    }
+    if (scriptType != null) {
+      $result.scriptType = scriptType;
+    }
+    if (noScriptType != null) {
+      $result.noScriptType = noScriptType;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  SignMessage._() : super();
+  factory SignMessage.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignMessage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignMessage', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'message', $pb.PbFieldType.QY)
+    ..a<$core.String>(3, _omitFieldNames ? '' : 'coinName', $pb.PbFieldType.OS, defaultOrMaker: 'Bitcoin')
+    ..e<InputScriptType>(4, _omitFieldNames ? '' : 'scriptType', $pb.PbFieldType.OE, defaultOrMaker: InputScriptType.SPENDADDRESS, valueOf: InputScriptType.valueOf, enumValues: InputScriptType.values)
+    ..aOB(5, _omitFieldNames ? '' : 'noScriptType')
+    ..aOB(6, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SignMessage clone() => SignMessage()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignMessage copyWith(void Function(SignMessage) updates) => super.copyWith((message) => updates(message as SignMessage)) as SignMessage;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SignMessage create() => SignMessage._();
+  SignMessage createEmptyInstance() => create();
+  static $pb.PbList<SignMessage> createRepeated() => $pb.PbList<SignMessage>();
+  @$core.pragma('dart2js:noInline')
+  static SignMessage getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignMessage>(create);
+  static SignMessage? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get message => $_getN(1);
+  @$pb.TagNumber(2)
+  set message($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMessage() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMessage() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get coinName => $_getS(2, 'Bitcoin');
+  @$pb.TagNumber(3)
+  set coinName($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasCoinName() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearCoinName() => clearField(3);
+
+  @$pb.TagNumber(4)
+  InputScriptType get scriptType => $_getN(3);
+  @$pb.TagNumber(4)
+  set scriptType(InputScriptType v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasScriptType() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearScriptType() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.bool get noScriptType => $_getBF(4);
+  @$pb.TagNumber(5)
+  set noScriptType($core.bool v) { $_setBool(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasNoScriptType() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearNoScriptType() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.bool get chunkify => $_getBF(5);
+  @$pb.TagNumber(6)
+  set chunkify($core.bool v) { $_setBool(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasChunkify() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearChunkify() => clearField(6);
+}
+
+/// *
+///  Response: Signed message
+///  @end
+class MessageSignature extends $pb.GeneratedMessage {
+  factory MessageSignature({
+    $core.String? address,
+    $core.List<$core.int>? signature,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    return $result;
+  }
+  MessageSignature._() : super();
+  factory MessageSignature.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MessageSignature.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MessageSignature', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'address')
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MessageSignature clone() => MessageSignature()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MessageSignature copyWith(void Function(MessageSignature) updates) => super.copyWith((message) => updates(message as MessageSignature)) as MessageSignature;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MessageSignature create() => MessageSignature._();
+  MessageSignature createEmptyInstance() => create();
+  static $pb.PbList<MessageSignature> createRepeated() => $pb.PbList<MessageSignature>();
+  @$core.pragma('dart2js:noInline')
+  static MessageSignature getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MessageSignature>(create);
+  static MessageSignature? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get signature => $_getN(1);
+  @$pb.TagNumber(2)
+  set signature($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSignature() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSignature() => clearField(2);
+}
+
+/// *
+///  Request: Ask device to verify message
+///  @start
+///  @next Success
+///  @next Failure
+class VerifyMessage extends $pb.GeneratedMessage {
+  factory VerifyMessage({
+    $core.String? address,
+    $core.List<$core.int>? signature,
+    $core.List<$core.int>? message,
+    $core.String? coinName,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    if (message != null) {
+      $result.message = message;
+    }
+    if (coinName != null) {
+      $result.coinName = coinName;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  VerifyMessage._() : super();
+  factory VerifyMessage.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VerifyMessage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VerifyMessage', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'address')
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'message', $pb.PbFieldType.QY)
+    ..a<$core.String>(4, _omitFieldNames ? '' : 'coinName', $pb.PbFieldType.OS, defaultOrMaker: 'Bitcoin')
+    ..aOB(5, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  VerifyMessage clone() => VerifyMessage()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VerifyMessage copyWith(void Function(VerifyMessage) updates) => super.copyWith((message) => updates(message as VerifyMessage)) as VerifyMessage;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static VerifyMessage create() => VerifyMessage._();
+  VerifyMessage createEmptyInstance() => create();
+  static $pb.PbList<VerifyMessage> createRepeated() => $pb.PbList<VerifyMessage>();
+  @$core.pragma('dart2js:noInline')
+  static VerifyMessage getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VerifyMessage>(create);
+  static VerifyMessage? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get signature => $_getN(1);
+  @$pb.TagNumber(2)
+  set signature($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSignature() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSignature() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get message => $_getN(2);
+  @$pb.TagNumber(3)
+  set message($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasMessage() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearMessage() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get coinName => $_getS(3, 'Bitcoin');
+  @$pb.TagNumber(4)
+  set coinName($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasCoinName() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearCoinName() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.bool get chunkify => $_getBF(4);
+  @$pb.TagNumber(5)
+  set chunkify($core.bool v) { $_setBool(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasChunkify() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearChunkify() => clearField(5);
+}
+
+/// *
+///  Signing request for a CoinJoin transaction.
+class SignTx_CoinJoinRequest extends $pb.GeneratedMessage {
+  factory SignTx_CoinJoinRequest({
+    $core.int? feeRate,
+    $fixnum.Int64? noFeeThreshold,
+    $fixnum.Int64? minRegistrableAmount,
+    $core.List<$core.int>? maskPublicKey,
+    $core.List<$core.int>? signature,
+  }) {
+    final $result = create();
+    if (feeRate != null) {
+      $result.feeRate = feeRate;
+    }
+    if (noFeeThreshold != null) {
+      $result.noFeeThreshold = noFeeThreshold;
+    }
+    if (minRegistrableAmount != null) {
+      $result.minRegistrableAmount = minRegistrableAmount;
+    }
+    if (maskPublicKey != null) {
+      $result.maskPublicKey = maskPublicKey;
+    }
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    return $result;
+  }
+  SignTx_CoinJoinRequest._() : super();
+  factory SignTx_CoinJoinRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignTx_CoinJoinRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignTx.CoinJoinRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'feeRate', $pb.PbFieldType.QU3)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'noFeeThreshold', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'minRegistrableAmount', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'maskPublicKey', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SignTx_CoinJoinRequest clone() => SignTx_CoinJoinRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignTx_CoinJoinRequest copyWith(void Function(SignTx_CoinJoinRequest) updates) => super.copyWith((message) => updates(message as SignTx_CoinJoinRequest)) as SignTx_CoinJoinRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SignTx_CoinJoinRequest create() => SignTx_CoinJoinRequest._();
+  SignTx_CoinJoinRequest createEmptyInstance() => create();
+  static $pb.PbList<SignTx_CoinJoinRequest> createRepeated() => $pb.PbList<SignTx_CoinJoinRequest>();
+  @$core.pragma('dart2js:noInline')
+  static SignTx_CoinJoinRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignTx_CoinJoinRequest>(create);
+  static SignTx_CoinJoinRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get feeRate => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set feeRate($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasFeeRate() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearFeeRate() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get noFeeThreshold => $_getI64(1);
+  @$pb.TagNumber(2)
+  set noFeeThreshold($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasNoFeeThreshold() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNoFeeThreshold() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get minRegistrableAmount => $_getI64(2);
+  @$pb.TagNumber(3)
+  set minRegistrableAmount($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasMinRegistrableAmount() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearMinRegistrableAmount() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get maskPublicKey => $_getN(3);
+  @$pb.TagNumber(4)
+  set maskPublicKey($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasMaskPublicKey() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMaskPublicKey() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get signature => $_getN(4);
+  @$pb.TagNumber(5)
+  set signature($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasSignature() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearSignature() => clearField(5);
+}
+
+/// *
+///  Request: Ask device to sign transaction
+///  @start
+///  @next TxRequest
+///  @next Failure
+class SignTx extends $pb.GeneratedMessage {
+  factory SignTx({
+    $core.int? outputsCount,
+    $core.int? inputsCount,
+    $core.String? coinName,
+    $core.int? version,
+    $core.int? lockTime,
+    $core.int? expiry,
+  @$core.Deprecated('This field is deprecated.')
+    $core.bool? overwintered,
+    $core.int? versionGroupId,
+    $core.int? timestamp,
+    $core.int? branchId,
+    AmountUnit? amountUnit,
+    $core.bool? decredStakingTicket,
+    $core.bool? serialize,
+    SignTx_CoinJoinRequest? coinjoinRequest,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (outputsCount != null) {
+      $result.outputsCount = outputsCount;
+    }
+    if (inputsCount != null) {
+      $result.inputsCount = inputsCount;
+    }
+    if (coinName != null) {
+      $result.coinName = coinName;
+    }
+    if (version != null) {
+      $result.version = version;
+    }
+    if (lockTime != null) {
+      $result.lockTime = lockTime;
+    }
+    if (expiry != null) {
+      $result.expiry = expiry;
+    }
+    if (overwintered != null) {
+      // ignore: deprecated_member_use_from_same_package
+      $result.overwintered = overwintered;
+    }
+    if (versionGroupId != null) {
+      $result.versionGroupId = versionGroupId;
+    }
+    if (timestamp != null) {
+      $result.timestamp = timestamp;
+    }
+    if (branchId != null) {
+      $result.branchId = branchId;
+    }
+    if (amountUnit != null) {
+      $result.amountUnit = amountUnit;
+    }
+    if (decredStakingTicket != null) {
+      $result.decredStakingTicket = decredStakingTicket;
+    }
+    if (serialize != null) {
+      $result.serialize = serialize;
+    }
+    if (coinjoinRequest != null) {
+      $result.coinjoinRequest = coinjoinRequest;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  SignTx._() : super();
+  factory SignTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'outputsCount', $pb.PbFieldType.QU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'inputsCount', $pb.PbFieldType.QU3)
+    ..a<$core.String>(3, _omitFieldNames ? '' : 'coinName', $pb.PbFieldType.OS, defaultOrMaker: 'Bitcoin')
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'version', $pb.PbFieldType.OU3, defaultOrMaker: 1)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'lockTime', $pb.PbFieldType.OU3)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'expiry', $pb.PbFieldType.OU3)
+    ..aOB(7, _omitFieldNames ? '' : 'overwintered')
+    ..a<$core.int>(8, _omitFieldNames ? '' : 'versionGroupId', $pb.PbFieldType.OU3)
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'timestamp', $pb.PbFieldType.OU3)
+    ..a<$core.int>(10, _omitFieldNames ? '' : 'branchId', $pb.PbFieldType.OU3)
+    ..e<AmountUnit>(11, _omitFieldNames ? '' : 'amountUnit', $pb.PbFieldType.OE, defaultOrMaker: AmountUnit.BITCOIN, valueOf: AmountUnit.valueOf, enumValues: AmountUnit.values)
+    ..aOB(12, _omitFieldNames ? '' : 'decredStakingTicket')
+    ..a<$core.bool>(13, _omitFieldNames ? '' : 'serialize', $pb.PbFieldType.OB, defaultOrMaker: true)
+    ..aOM<SignTx_CoinJoinRequest>(14, _omitFieldNames ? '' : 'coinjoinRequest', subBuilder: SignTx_CoinJoinRequest.create)
+    ..aOB(15, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SignTx clone() => SignTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignTx copyWith(void Function(SignTx) updates) => super.copyWith((message) => updates(message as SignTx)) as SignTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SignTx create() => SignTx._();
+  SignTx createEmptyInstance() => create();
+  static $pb.PbList<SignTx> createRepeated() => $pb.PbList<SignTx>();
+  @$core.pragma('dart2js:noInline')
+  static SignTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignTx>(create);
+  static SignTx? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get outputsCount => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set outputsCount($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasOutputsCount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearOutputsCount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get inputsCount => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set inputsCount($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasInputsCount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearInputsCount() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get coinName => $_getS(2, 'Bitcoin');
+  @$pb.TagNumber(3)
+  set coinName($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasCoinName() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearCoinName() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get version => $_getI(3, 1);
+  @$pb.TagNumber(4)
+  set version($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasVersion() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearVersion() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get lockTime => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set lockTime($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasLockTime() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearLockTime() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.int get expiry => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set expiry($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasExpiry() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearExpiry() => clearField(6);
+
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(7)
+  $core.bool get overwintered => $_getBF(6);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(7)
+  set overwintered($core.bool v) { $_setBool(6, v); }
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(7)
+  $core.bool hasOverwintered() => $_has(6);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(7)
+  void clearOverwintered() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.int get versionGroupId => $_getIZ(7);
+  @$pb.TagNumber(8)
+  set versionGroupId($core.int v) { $_setUnsignedInt32(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasVersionGroupId() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearVersionGroupId() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.int get timestamp => $_getIZ(8);
+  @$pb.TagNumber(9)
+  set timestamp($core.int v) { $_setUnsignedInt32(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasTimestamp() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearTimestamp() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.int get branchId => $_getIZ(9);
+  @$pb.TagNumber(10)
+  set branchId($core.int v) { $_setUnsignedInt32(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasBranchId() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearBranchId() => clearField(10);
+
+  @$pb.TagNumber(11)
+  AmountUnit get amountUnit => $_getN(10);
+  @$pb.TagNumber(11)
+  set amountUnit(AmountUnit v) { setField(11, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasAmountUnit() => $_has(10);
+  @$pb.TagNumber(11)
+  void clearAmountUnit() => clearField(11);
+
+  @$pb.TagNumber(12)
+  $core.bool get decredStakingTicket => $_getBF(11);
+  @$pb.TagNumber(12)
+  set decredStakingTicket($core.bool v) { $_setBool(11, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasDecredStakingTicket() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearDecredStakingTicket() => clearField(12);
+
+  @$pb.TagNumber(13)
+  $core.bool get serialize => $_getB(12, true);
+  @$pb.TagNumber(13)
+  set serialize($core.bool v) { $_setBool(12, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasSerialize() => $_has(12);
+  @$pb.TagNumber(13)
+  void clearSerialize() => clearField(13);
+
+  @$pb.TagNumber(14)
+  SignTx_CoinJoinRequest get coinjoinRequest => $_getN(13);
+  @$pb.TagNumber(14)
+  set coinjoinRequest(SignTx_CoinJoinRequest v) { setField(14, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasCoinjoinRequest() => $_has(13);
+  @$pb.TagNumber(14)
+  void clearCoinjoinRequest() => clearField(14);
+  @$pb.TagNumber(14)
+  SignTx_CoinJoinRequest ensureCoinjoinRequest() => $_ensure(13);
+
+  @$pb.TagNumber(15)
+  $core.bool get chunkify => $_getBF(14);
+  @$pb.TagNumber(15)
+  set chunkify($core.bool v) { $_setBool(14, v); }
+  @$pb.TagNumber(15)
+  $core.bool hasChunkify() => $_has(14);
+  @$pb.TagNumber(15)
+  void clearChunkify() => clearField(15);
+}
+
+/// *
+///  Structure representing request details
+class TxRequest_TxRequestDetailsType extends $pb.GeneratedMessage {
+  factory TxRequest_TxRequestDetailsType({
+    $core.int? requestIndex,
+    $core.List<$core.int>? txHash,
+    $core.int? extraDataLen,
+    $core.int? extraDataOffset,
+  }) {
+    final $result = create();
+    if (requestIndex != null) {
+      $result.requestIndex = requestIndex;
+    }
+    if (txHash != null) {
+      $result.txHash = txHash;
+    }
+    if (extraDataLen != null) {
+      $result.extraDataLen = extraDataLen;
+    }
+    if (extraDataOffset != null) {
+      $result.extraDataOffset = extraDataOffset;
+    }
+    return $result;
+  }
+  TxRequest_TxRequestDetailsType._() : super();
+  factory TxRequest_TxRequestDetailsType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxRequest_TxRequestDetailsType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxRequest.TxRequestDetailsType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'requestIndex', $pb.PbFieldType.OU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'txHash', $pb.PbFieldType.OY)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'extraDataLen', $pb.PbFieldType.OU3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'extraDataOffset', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxRequest_TxRequestDetailsType clone() => TxRequest_TxRequestDetailsType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxRequest_TxRequestDetailsType copyWith(void Function(TxRequest_TxRequestDetailsType) updates) => super.copyWith((message) => updates(message as TxRequest_TxRequestDetailsType)) as TxRequest_TxRequestDetailsType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxRequest_TxRequestDetailsType create() => TxRequest_TxRequestDetailsType._();
+  TxRequest_TxRequestDetailsType createEmptyInstance() => create();
+  static $pb.PbList<TxRequest_TxRequestDetailsType> createRepeated() => $pb.PbList<TxRequest_TxRequestDetailsType>();
+  @$core.pragma('dart2js:noInline')
+  static TxRequest_TxRequestDetailsType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxRequest_TxRequestDetailsType>(create);
+  static TxRequest_TxRequestDetailsType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get requestIndex => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set requestIndex($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasRequestIndex() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRequestIndex() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get txHash => $_getN(1);
+  @$pb.TagNumber(2)
+  set txHash($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTxHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTxHash() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get extraDataLen => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set extraDataLen($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasExtraDataLen() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearExtraDataLen() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get extraDataOffset => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set extraDataOffset($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasExtraDataOffset() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearExtraDataOffset() => clearField(4);
+}
+
+/// *
+///  Structure representing serialized data
+class TxRequest_TxRequestSerializedType extends $pb.GeneratedMessage {
+  factory TxRequest_TxRequestSerializedType({
+    $core.int? signatureIndex,
+    $core.List<$core.int>? signature,
+    $core.List<$core.int>? serializedTx,
+  }) {
+    final $result = create();
+    if (signatureIndex != null) {
+      $result.signatureIndex = signatureIndex;
+    }
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    if (serializedTx != null) {
+      $result.serializedTx = serializedTx;
+    }
+    return $result;
+  }
+  TxRequest_TxRequestSerializedType._() : super();
+  factory TxRequest_TxRequestSerializedType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxRequest_TxRequestSerializedType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxRequest.TxRequestSerializedType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'signatureIndex', $pb.PbFieldType.OU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'serializedTx', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxRequest_TxRequestSerializedType clone() => TxRequest_TxRequestSerializedType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxRequest_TxRequestSerializedType copyWith(void Function(TxRequest_TxRequestSerializedType) updates) => super.copyWith((message) => updates(message as TxRequest_TxRequestSerializedType)) as TxRequest_TxRequestSerializedType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxRequest_TxRequestSerializedType create() => TxRequest_TxRequestSerializedType._();
+  TxRequest_TxRequestSerializedType createEmptyInstance() => create();
+  static $pb.PbList<TxRequest_TxRequestSerializedType> createRepeated() => $pb.PbList<TxRequest_TxRequestSerializedType>();
+  @$core.pragma('dart2js:noInline')
+  static TxRequest_TxRequestSerializedType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxRequest_TxRequestSerializedType>(create);
+  static TxRequest_TxRequestSerializedType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get signatureIndex => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set signatureIndex($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSignatureIndex() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSignatureIndex() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get signature => $_getN(1);
+  @$pb.TagNumber(2)
+  set signature($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSignature() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSignature() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get serializedTx => $_getN(2);
+  @$pb.TagNumber(3)
+  set serializedTx($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSerializedTx() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSerializedTx() => clearField(3);
+}
+
+/// *
+///  Response: Device asks for information for signing transaction or returns the last result
+///  If request_index is set, device awaits TxAck<any> matching the request type.
+///  If signature_index is set, 'signature' contains signed input of signature_index's input
+///  @end
+///  @next TxAckInput
+///  @next TxAckOutput
+///  @next TxAckPrevMeta
+///  @next TxAckPrevInput
+///  @next TxAckPrevOutput
+///  @next TxAckPrevExtraData
+///  @next TxAckPaymentRequest
+class TxRequest extends $pb.GeneratedMessage {
+  factory TxRequest({
+    TxRequest_RequestType? requestType,
+    TxRequest_TxRequestDetailsType? details,
+    TxRequest_TxRequestSerializedType? serialized,
+  }) {
+    final $result = create();
+    if (requestType != null) {
+      $result.requestType = requestType;
+    }
+    if (details != null) {
+      $result.details = details;
+    }
+    if (serialized != null) {
+      $result.serialized = serialized;
+    }
+    return $result;
+  }
+  TxRequest._() : super();
+  factory TxRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..e<TxRequest_RequestType>(1, _omitFieldNames ? '' : 'requestType', $pb.PbFieldType.OE, defaultOrMaker: TxRequest_RequestType.TXINPUT, valueOf: TxRequest_RequestType.valueOf, enumValues: TxRequest_RequestType.values)
+    ..aOM<TxRequest_TxRequestDetailsType>(2, _omitFieldNames ? '' : 'details', subBuilder: TxRequest_TxRequestDetailsType.create)
+    ..aOM<TxRequest_TxRequestSerializedType>(3, _omitFieldNames ? '' : 'serialized', subBuilder: TxRequest_TxRequestSerializedType.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxRequest clone() => TxRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxRequest copyWith(void Function(TxRequest) updates) => super.copyWith((message) => updates(message as TxRequest)) as TxRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxRequest create() => TxRequest._();
+  TxRequest createEmptyInstance() => create();
+  static $pb.PbList<TxRequest> createRepeated() => $pb.PbList<TxRequest>();
+  @$core.pragma('dart2js:noInline')
+  static TxRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxRequest>(create);
+  static TxRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  TxRequest_RequestType get requestType => $_getN(0);
+  @$pb.TagNumber(1)
+  set requestType(TxRequest_RequestType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasRequestType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRequestType() => clearField(1);
+
+  @$pb.TagNumber(2)
+  TxRequest_TxRequestDetailsType get details => $_getN(1);
+  @$pb.TagNumber(2)
+  set details(TxRequest_TxRequestDetailsType v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasDetails() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearDetails() => clearField(2);
+  @$pb.TagNumber(2)
+  TxRequest_TxRequestDetailsType ensureDetails() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  TxRequest_TxRequestSerializedType get serialized => $_getN(2);
+  @$pb.TagNumber(3)
+  set serialized(TxRequest_TxRequestSerializedType v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSerialized() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSerialized() => clearField(3);
+  @$pb.TagNumber(3)
+  TxRequest_TxRequestSerializedType ensureSerialized() => $_ensure(2);
+}
+
+/// *
+///  Structure representing transaction input
+class TxAck_TransactionType_TxInputType extends $pb.GeneratedMessage {
+  factory TxAck_TransactionType_TxInputType({
+    $core.Iterable<$core.int>? addressN,
+    $core.List<$core.int>? prevHash,
+    $core.int? prevIndex,
+    $core.List<$core.int>? scriptSig,
+    $core.int? sequence,
+    InputScriptType? scriptType,
+    MultisigRedeemScriptType? multisig,
+    $fixnum.Int64? amount,
+    $core.int? decredTree,
+    $core.List<$core.int>? witness,
+    $core.List<$core.int>? ownershipProof,
+    $core.List<$core.int>? commitmentData,
+    $core.List<$core.int>? origHash,
+    $core.int? origIndex,
+    DecredStakingSpendType? decredStakingSpend,
+    $core.List<$core.int>? scriptPubkey,
+    $core.int? coinjoinFlags,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (prevHash != null) {
+      $result.prevHash = prevHash;
+    }
+    if (prevIndex != null) {
+      $result.prevIndex = prevIndex;
+    }
+    if (scriptSig != null) {
+      $result.scriptSig = scriptSig;
+    }
+    if (sequence != null) {
+      $result.sequence = sequence;
+    }
+    if (scriptType != null) {
+      $result.scriptType = scriptType;
+    }
+    if (multisig != null) {
+      $result.multisig = multisig;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (decredTree != null) {
+      $result.decredTree = decredTree;
+    }
+    if (witness != null) {
+      $result.witness = witness;
+    }
+    if (ownershipProof != null) {
+      $result.ownershipProof = ownershipProof;
+    }
+    if (commitmentData != null) {
+      $result.commitmentData = commitmentData;
+    }
+    if (origHash != null) {
+      $result.origHash = origHash;
+    }
+    if (origIndex != null) {
+      $result.origIndex = origIndex;
+    }
+    if (decredStakingSpend != null) {
+      $result.decredStakingSpend = decredStakingSpend;
+    }
+    if (scriptPubkey != null) {
+      $result.scriptPubkey = scriptPubkey;
+    }
+    if (coinjoinFlags != null) {
+      $result.coinjoinFlags = coinjoinFlags;
+    }
+    return $result;
+  }
+  TxAck_TransactionType_TxInputType._() : super();
+  factory TxAck_TransactionType_TxInputType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAck_TransactionType_TxInputType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAck.TransactionType.TxInputType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'prevHash', $pb.PbFieldType.QY)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'prevIndex', $pb.PbFieldType.QU3)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'scriptSig', $pb.PbFieldType.OY)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'sequence', $pb.PbFieldType.OU3, defaultOrMaker: 4294967295)
+    ..e<InputScriptType>(6, _omitFieldNames ? '' : 'scriptType', $pb.PbFieldType.OE, defaultOrMaker: InputScriptType.SPENDADDRESS, valueOf: InputScriptType.valueOf, enumValues: InputScriptType.values)
+    ..aOM<MultisigRedeemScriptType>(7, _omitFieldNames ? '' : 'multisig', subBuilder: MultisigRedeemScriptType.create)
+    ..a<$fixnum.Int64>(8, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'decredTree', $pb.PbFieldType.OU3)
+    ..a<$core.List<$core.int>>(13, _omitFieldNames ? '' : 'witness', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(14, _omitFieldNames ? '' : 'ownershipProof', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(15, _omitFieldNames ? '' : 'commitmentData', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(16, _omitFieldNames ? '' : 'origHash', $pb.PbFieldType.OY)
+    ..a<$core.int>(17, _omitFieldNames ? '' : 'origIndex', $pb.PbFieldType.OU3)
+    ..e<DecredStakingSpendType>(18, _omitFieldNames ? '' : 'decredStakingSpend', $pb.PbFieldType.OE, defaultOrMaker: DecredStakingSpendType.SSGen, valueOf: DecredStakingSpendType.valueOf, enumValues: DecredStakingSpendType.values)
+    ..a<$core.List<$core.int>>(19, _omitFieldNames ? '' : 'scriptPubkey', $pb.PbFieldType.OY)
+    ..a<$core.int>(20, _omitFieldNames ? '' : 'coinjoinFlags', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAck_TransactionType_TxInputType clone() => TxAck_TransactionType_TxInputType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAck_TransactionType_TxInputType copyWith(void Function(TxAck_TransactionType_TxInputType) updates) => super.copyWith((message) => updates(message as TxAck_TransactionType_TxInputType)) as TxAck_TransactionType_TxInputType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAck_TransactionType_TxInputType create() => TxAck_TransactionType_TxInputType._();
+  TxAck_TransactionType_TxInputType createEmptyInstance() => create();
+  static $pb.PbList<TxAck_TransactionType_TxInputType> createRepeated() => $pb.PbList<TxAck_TransactionType_TxInputType>();
+  @$core.pragma('dart2js:noInline')
+  static TxAck_TransactionType_TxInputType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAck_TransactionType_TxInputType>(create);
+  static TxAck_TransactionType_TxInputType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get prevHash => $_getN(1);
+  @$pb.TagNumber(2)
+  set prevHash($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPrevHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPrevHash() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get prevIndex => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set prevIndex($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasPrevIndex() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearPrevIndex() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get scriptSig => $_getN(3);
+  @$pb.TagNumber(4)
+  set scriptSig($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasScriptSig() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearScriptSig() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get sequence => $_getI(4, 4294967295);
+  @$pb.TagNumber(5)
+  set sequence($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasSequence() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearSequence() => clearField(5);
+
+  @$pb.TagNumber(6)
+  InputScriptType get scriptType => $_getN(5);
+  @$pb.TagNumber(6)
+  set scriptType(InputScriptType v) { setField(6, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasScriptType() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearScriptType() => clearField(6);
+
+  @$pb.TagNumber(7)
+  MultisigRedeemScriptType get multisig => $_getN(6);
+  @$pb.TagNumber(7)
+  set multisig(MultisigRedeemScriptType v) { setField(7, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasMultisig() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearMultisig() => clearField(7);
+  @$pb.TagNumber(7)
+  MultisigRedeemScriptType ensureMultisig() => $_ensure(6);
+
+  @$pb.TagNumber(8)
+  $fixnum.Int64 get amount => $_getI64(7);
+  @$pb.TagNumber(8)
+  set amount($fixnum.Int64 v) { $_setInt64(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasAmount() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearAmount() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.int get decredTree => $_getIZ(8);
+  @$pb.TagNumber(9)
+  set decredTree($core.int v) { $_setUnsignedInt32(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasDecredTree() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearDecredTree() => clearField(9);
+
+  /// optional uint32 decred_script_version = 10;                         // only for Decred  // deprecated -> only 0 is supported
+  /// optional bytes prev_block_hash_bip115 = 11;     // BIP-115 support dropped
+  /// optional uint32 prev_block_height_bip115 = 12;  // BIP-115 support dropped
+  @$pb.TagNumber(13)
+  $core.List<$core.int> get witness => $_getN(9);
+  @$pb.TagNumber(13)
+  set witness($core.List<$core.int> v) { $_setBytes(9, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasWitness() => $_has(9);
+  @$pb.TagNumber(13)
+  void clearWitness() => clearField(13);
+
+  @$pb.TagNumber(14)
+  $core.List<$core.int> get ownershipProof => $_getN(10);
+  @$pb.TagNumber(14)
+  set ownershipProof($core.List<$core.int> v) { $_setBytes(10, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasOwnershipProof() => $_has(10);
+  @$pb.TagNumber(14)
+  void clearOwnershipProof() => clearField(14);
+
+  @$pb.TagNumber(15)
+  $core.List<$core.int> get commitmentData => $_getN(11);
+  @$pb.TagNumber(15)
+  set commitmentData($core.List<$core.int> v) { $_setBytes(11, v); }
+  @$pb.TagNumber(15)
+  $core.bool hasCommitmentData() => $_has(11);
+  @$pb.TagNumber(15)
+  void clearCommitmentData() => clearField(15);
+
+  @$pb.TagNumber(16)
+  $core.List<$core.int> get origHash => $_getN(12);
+  @$pb.TagNumber(16)
+  set origHash($core.List<$core.int> v) { $_setBytes(12, v); }
+  @$pb.TagNumber(16)
+  $core.bool hasOrigHash() => $_has(12);
+  @$pb.TagNumber(16)
+  void clearOrigHash() => clearField(16);
+
+  @$pb.TagNumber(17)
+  $core.int get origIndex => $_getIZ(13);
+  @$pb.TagNumber(17)
+  set origIndex($core.int v) { $_setUnsignedInt32(13, v); }
+  @$pb.TagNumber(17)
+  $core.bool hasOrigIndex() => $_has(13);
+  @$pb.TagNumber(17)
+  void clearOrigIndex() => clearField(17);
+
+  @$pb.TagNumber(18)
+  DecredStakingSpendType get decredStakingSpend => $_getN(14);
+  @$pb.TagNumber(18)
+  set decredStakingSpend(DecredStakingSpendType v) { setField(18, v); }
+  @$pb.TagNumber(18)
+  $core.bool hasDecredStakingSpend() => $_has(14);
+  @$pb.TagNumber(18)
+  void clearDecredStakingSpend() => clearField(18);
+
+  @$pb.TagNumber(19)
+  $core.List<$core.int> get scriptPubkey => $_getN(15);
+  @$pb.TagNumber(19)
+  set scriptPubkey($core.List<$core.int> v) { $_setBytes(15, v); }
+  @$pb.TagNumber(19)
+  $core.bool hasScriptPubkey() => $_has(15);
+  @$pb.TagNumber(19)
+  void clearScriptPubkey() => clearField(19);
+
+  @$pb.TagNumber(20)
+  $core.int get coinjoinFlags => $_getIZ(16);
+  @$pb.TagNumber(20)
+  set coinjoinFlags($core.int v) { $_setUnsignedInt32(16, v); }
+  @$pb.TagNumber(20)
+  $core.bool hasCoinjoinFlags() => $_has(16);
+  @$pb.TagNumber(20)
+  void clearCoinjoinFlags() => clearField(20);
+}
+
+/// *
+///  Structure representing compiled transaction output
+class TxAck_TransactionType_TxOutputBinType extends $pb.GeneratedMessage {
+  factory TxAck_TransactionType_TxOutputBinType({
+    $fixnum.Int64? amount,
+    $core.List<$core.int>? scriptPubkey,
+    $core.int? decredScriptVersion,
+  }) {
+    final $result = create();
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (scriptPubkey != null) {
+      $result.scriptPubkey = scriptPubkey;
+    }
+    if (decredScriptVersion != null) {
+      $result.decredScriptVersion = decredScriptVersion;
+    }
+    return $result;
+  }
+  TxAck_TransactionType_TxOutputBinType._() : super();
+  factory TxAck_TransactionType_TxOutputBinType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAck_TransactionType_TxOutputBinType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAck.TransactionType.TxOutputBinType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'scriptPubkey', $pb.PbFieldType.QY)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'decredScriptVersion', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAck_TransactionType_TxOutputBinType clone() => TxAck_TransactionType_TxOutputBinType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAck_TransactionType_TxOutputBinType copyWith(void Function(TxAck_TransactionType_TxOutputBinType) updates) => super.copyWith((message) => updates(message as TxAck_TransactionType_TxOutputBinType)) as TxAck_TransactionType_TxOutputBinType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAck_TransactionType_TxOutputBinType create() => TxAck_TransactionType_TxOutputBinType._();
+  TxAck_TransactionType_TxOutputBinType createEmptyInstance() => create();
+  static $pb.PbList<TxAck_TransactionType_TxOutputBinType> createRepeated() => $pb.PbList<TxAck_TransactionType_TxOutputBinType>();
+  @$core.pragma('dart2js:noInline')
+  static TxAck_TransactionType_TxOutputBinType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAck_TransactionType_TxOutputBinType>(create);
+  static TxAck_TransactionType_TxOutputBinType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get amount => $_getI64(0);
+  @$pb.TagNumber(1)
+  set amount($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAmount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAmount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get scriptPubkey => $_getN(1);
+  @$pb.TagNumber(2)
+  set scriptPubkey($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasScriptPubkey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearScriptPubkey() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get decredScriptVersion => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set decredScriptVersion($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasDecredScriptVersion() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearDecredScriptVersion() => clearField(3);
+}
+
+/// *
+///  Structure representing transaction output
+class TxAck_TransactionType_TxOutputType extends $pb.GeneratedMessage {
+  factory TxAck_TransactionType_TxOutputType({
+    $core.String? address,
+    $core.Iterable<$core.int>? addressN,
+    $fixnum.Int64? amount,
+    OutputScriptType? scriptType,
+    MultisigRedeemScriptType? multisig,
+    $core.List<$core.int>? opReturnData,
+    $core.List<$core.int>? origHash,
+    $core.int? origIndex,
+    $core.int? paymentReqIndex,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (scriptType != null) {
+      $result.scriptType = scriptType;
+    }
+    if (multisig != null) {
+      $result.multisig = multisig;
+    }
+    if (opReturnData != null) {
+      $result.opReturnData = opReturnData;
+    }
+    if (origHash != null) {
+      $result.origHash = origHash;
+    }
+    if (origIndex != null) {
+      $result.origIndex = origIndex;
+    }
+    if (paymentReqIndex != null) {
+      $result.paymentReqIndex = paymentReqIndex;
+    }
+    return $result;
+  }
+  TxAck_TransactionType_TxOutputType._() : super();
+  factory TxAck_TransactionType_TxOutputType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAck_TransactionType_TxOutputType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAck.TransactionType.TxOutputType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'address')
+    ..p<$core.int>(2, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..e<OutputScriptType>(4, _omitFieldNames ? '' : 'scriptType', $pb.PbFieldType.OE, defaultOrMaker: OutputScriptType.PAYTOADDRESS, valueOf: OutputScriptType.valueOf, enumValues: OutputScriptType.values)
+    ..aOM<MultisigRedeemScriptType>(5, _omitFieldNames ? '' : 'multisig', subBuilder: MultisigRedeemScriptType.create)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'opReturnData', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(10, _omitFieldNames ? '' : 'origHash', $pb.PbFieldType.OY)
+    ..a<$core.int>(11, _omitFieldNames ? '' : 'origIndex', $pb.PbFieldType.OU3)
+    ..a<$core.int>(12, _omitFieldNames ? '' : 'paymentReqIndex', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAck_TransactionType_TxOutputType clone() => TxAck_TransactionType_TxOutputType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAck_TransactionType_TxOutputType copyWith(void Function(TxAck_TransactionType_TxOutputType) updates) => super.copyWith((message) => updates(message as TxAck_TransactionType_TxOutputType)) as TxAck_TransactionType_TxOutputType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAck_TransactionType_TxOutputType create() => TxAck_TransactionType_TxOutputType._();
+  TxAck_TransactionType_TxOutputType createEmptyInstance() => create();
+  static $pb.PbList<TxAck_TransactionType_TxOutputType> createRepeated() => $pb.PbList<TxAck_TransactionType_TxOutputType>();
+  @$core.pragma('dart2js:noInline')
+  static TxAck_TransactionType_TxOutputType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAck_TransactionType_TxOutputType>(create);
+  static TxAck_TransactionType_TxOutputType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get addressN => $_getList(1);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get amount => $_getI64(2);
+  @$pb.TagNumber(3)
+  set amount($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasAmount() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearAmount() => clearField(3);
+
+  @$pb.TagNumber(4)
+  OutputScriptType get scriptType => $_getN(3);
+  @$pb.TagNumber(4)
+  set scriptType(OutputScriptType v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasScriptType() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearScriptType() => clearField(4);
+
+  @$pb.TagNumber(5)
+  MultisigRedeemScriptType get multisig => $_getN(4);
+  @$pb.TagNumber(5)
+  set multisig(MultisigRedeemScriptType v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasMultisig() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearMultisig() => clearField(5);
+  @$pb.TagNumber(5)
+  MultisigRedeemScriptType ensureMultisig() => $_ensure(4);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get opReturnData => $_getN(5);
+  @$pb.TagNumber(6)
+  set opReturnData($core.List<$core.int> v) { $_setBytes(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasOpReturnData() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearOpReturnData() => clearField(6);
+
+  /// optional uint32 decred_script_version = 7;      // only for Decred  // deprecated -> only 0 is supported
+  /// optional bytes block_hash_bip115 = 8;        // BIP-115 support dropped
+  /// optional uint32 block_height_bip115 = 9;     // BIP-115 support dropped
+  @$pb.TagNumber(10)
+  $core.List<$core.int> get origHash => $_getN(6);
+  @$pb.TagNumber(10)
+  set origHash($core.List<$core.int> v) { $_setBytes(6, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasOrigHash() => $_has(6);
+  @$pb.TagNumber(10)
+  void clearOrigHash() => clearField(10);
+
+  @$pb.TagNumber(11)
+  $core.int get origIndex => $_getIZ(7);
+  @$pb.TagNumber(11)
+  set origIndex($core.int v) { $_setUnsignedInt32(7, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasOrigIndex() => $_has(7);
+  @$pb.TagNumber(11)
+  void clearOrigIndex() => clearField(11);
+
+  @$pb.TagNumber(12)
+  $core.int get paymentReqIndex => $_getIZ(8);
+  @$pb.TagNumber(12)
+  set paymentReqIndex($core.int v) { $_setUnsignedInt32(8, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasPaymentReqIndex() => $_has(8);
+  @$pb.TagNumber(12)
+  void clearPaymentReqIndex() => clearField(12);
+}
+
+/// *
+///  Structure representing transaction
+class TxAck_TransactionType extends $pb.GeneratedMessage {
+  factory TxAck_TransactionType({
+    $core.int? version,
+    $core.Iterable<TxAck_TransactionType_TxInputType>? inputs,
+    $core.Iterable<TxAck_TransactionType_TxOutputBinType>? binOutputs,
+    $core.int? lockTime,
+    $core.Iterable<TxAck_TransactionType_TxOutputType>? outputs,
+    $core.int? inputsCnt,
+    $core.int? outputsCnt,
+    $core.List<$core.int>? extraData,
+    $core.int? extraDataLen,
+    $core.int? expiry,
+  @$core.Deprecated('This field is deprecated.')
+    $core.bool? overwintered,
+    $core.int? versionGroupId,
+    $core.int? timestamp,
+    $core.int? branchId,
+  }) {
+    final $result = create();
+    if (version != null) {
+      $result.version = version;
+    }
+    if (inputs != null) {
+      $result.inputs.addAll(inputs);
+    }
+    if (binOutputs != null) {
+      $result.binOutputs.addAll(binOutputs);
+    }
+    if (lockTime != null) {
+      $result.lockTime = lockTime;
+    }
+    if (outputs != null) {
+      $result.outputs.addAll(outputs);
+    }
+    if (inputsCnt != null) {
+      $result.inputsCnt = inputsCnt;
+    }
+    if (outputsCnt != null) {
+      $result.outputsCnt = outputsCnt;
+    }
+    if (extraData != null) {
+      $result.extraData = extraData;
+    }
+    if (extraDataLen != null) {
+      $result.extraDataLen = extraDataLen;
+    }
+    if (expiry != null) {
+      $result.expiry = expiry;
+    }
+    if (overwintered != null) {
+      // ignore: deprecated_member_use_from_same_package
+      $result.overwintered = overwintered;
+    }
+    if (versionGroupId != null) {
+      $result.versionGroupId = versionGroupId;
+    }
+    if (timestamp != null) {
+      $result.timestamp = timestamp;
+    }
+    if (branchId != null) {
+      $result.branchId = branchId;
+    }
+    return $result;
+  }
+  TxAck_TransactionType._() : super();
+  factory TxAck_TransactionType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAck_TransactionType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAck.TransactionType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'version', $pb.PbFieldType.OU3)
+    ..pc<TxAck_TransactionType_TxInputType>(2, _omitFieldNames ? '' : 'inputs', $pb.PbFieldType.PM, subBuilder: TxAck_TransactionType_TxInputType.create)
+    ..pc<TxAck_TransactionType_TxOutputBinType>(3, _omitFieldNames ? '' : 'binOutputs', $pb.PbFieldType.PM, subBuilder: TxAck_TransactionType_TxOutputBinType.create)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'lockTime', $pb.PbFieldType.OU3)
+    ..pc<TxAck_TransactionType_TxOutputType>(5, _omitFieldNames ? '' : 'outputs', $pb.PbFieldType.PM, subBuilder: TxAck_TransactionType_TxOutputType.create)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'inputsCnt', $pb.PbFieldType.OU3)
+    ..a<$core.int>(7, _omitFieldNames ? '' : 'outputsCnt', $pb.PbFieldType.OU3)
+    ..a<$core.List<$core.int>>(8, _omitFieldNames ? '' : 'extraData', $pb.PbFieldType.OY)
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'extraDataLen', $pb.PbFieldType.OU3)
+    ..a<$core.int>(10, _omitFieldNames ? '' : 'expiry', $pb.PbFieldType.OU3)
+    ..aOB(11, _omitFieldNames ? '' : 'overwintered')
+    ..a<$core.int>(12, _omitFieldNames ? '' : 'versionGroupId', $pb.PbFieldType.OU3)
+    ..a<$core.int>(13, _omitFieldNames ? '' : 'timestamp', $pb.PbFieldType.OU3)
+    ..a<$core.int>(14, _omitFieldNames ? '' : 'branchId', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAck_TransactionType clone() => TxAck_TransactionType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAck_TransactionType copyWith(void Function(TxAck_TransactionType) updates) => super.copyWith((message) => updates(message as TxAck_TransactionType)) as TxAck_TransactionType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAck_TransactionType create() => TxAck_TransactionType._();
+  TxAck_TransactionType createEmptyInstance() => create();
+  static $pb.PbList<TxAck_TransactionType> createRepeated() => $pb.PbList<TxAck_TransactionType>();
+  @$core.pragma('dart2js:noInline')
+  static TxAck_TransactionType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAck_TransactionType>(create);
+  static TxAck_TransactionType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get version => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set version($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasVersion() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearVersion() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<TxAck_TransactionType_TxInputType> get inputs => $_getList(1);
+
+  @$pb.TagNumber(3)
+  $core.List<TxAck_TransactionType_TxOutputBinType> get binOutputs => $_getList(2);
+
+  @$pb.TagNumber(4)
+  $core.int get lockTime => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set lockTime($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasLockTime() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearLockTime() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<TxAck_TransactionType_TxOutputType> get outputs => $_getList(4);
+
+  @$pb.TagNumber(6)
+  $core.int get inputsCnt => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set inputsCnt($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasInputsCnt() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearInputsCnt() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.int get outputsCnt => $_getIZ(6);
+  @$pb.TagNumber(7)
+  set outputsCnt($core.int v) { $_setUnsignedInt32(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasOutputsCnt() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearOutputsCnt() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.List<$core.int> get extraData => $_getN(7);
+  @$pb.TagNumber(8)
+  set extraData($core.List<$core.int> v) { $_setBytes(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasExtraData() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearExtraData() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.int get extraDataLen => $_getIZ(8);
+  @$pb.TagNumber(9)
+  set extraDataLen($core.int v) { $_setUnsignedInt32(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasExtraDataLen() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearExtraDataLen() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.int get expiry => $_getIZ(9);
+  @$pb.TagNumber(10)
+  set expiry($core.int v) { $_setUnsignedInt32(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasExpiry() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearExpiry() => clearField(10);
+
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(11)
+  $core.bool get overwintered => $_getBF(10);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(11)
+  set overwintered($core.bool v) { $_setBool(10, v); }
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(11)
+  $core.bool hasOverwintered() => $_has(10);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(11)
+  void clearOverwintered() => clearField(11);
+
+  @$pb.TagNumber(12)
+  $core.int get versionGroupId => $_getIZ(11);
+  @$pb.TagNumber(12)
+  set versionGroupId($core.int v) { $_setUnsignedInt32(11, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasVersionGroupId() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearVersionGroupId() => clearField(12);
+
+  @$pb.TagNumber(13)
+  $core.int get timestamp => $_getIZ(12);
+  @$pb.TagNumber(13)
+  set timestamp($core.int v) { $_setUnsignedInt32(12, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasTimestamp() => $_has(12);
+  @$pb.TagNumber(13)
+  void clearTimestamp() => clearField(13);
+
+  @$pb.TagNumber(14)
+  $core.int get branchId => $_getIZ(13);
+  @$pb.TagNumber(14)
+  set branchId($core.int v) { $_setUnsignedInt32(13, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasBranchId() => $_has(13);
+  @$pb.TagNumber(14)
+  void clearBranchId() => clearField(14);
+}
+
+/// *
+///  Request: Reported transaction data (legacy)
+///
+///  This message contains all possible field that can be sent in response to a TxRequest.
+///  Depending on the request_type, the host is supposed to fill some of these fields.
+///
+///  The interface is wire-compatible with the new method of specialized TxAck subtypes,
+///  so it can be used in the old way. However, it is now recommended to use more
+///  specialized messages, which have better-configured constraints on field values.
+///
+///  @next TxRequest
+class TxAck extends $pb.GeneratedMessage {
+  factory TxAck({
+    TxAck_TransactionType? tx,
+  }) {
+    final $result = create();
+    if (tx != null) {
+      $result.tx = tx;
+    }
+    return $result;
+  }
+  TxAck._() : super();
+  factory TxAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aOM<TxAck_TransactionType>(1, _omitFieldNames ? '' : 'tx', subBuilder: TxAck_TransactionType.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAck clone() => TxAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAck copyWith(void Function(TxAck) updates) => super.copyWith((message) => updates(message as TxAck)) as TxAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAck create() => TxAck._();
+  TxAck createEmptyInstance() => create();
+  static $pb.PbList<TxAck> createRepeated() => $pb.PbList<TxAck>();
+  @$core.pragma('dart2js:noInline')
+  static TxAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAck>(create);
+  static TxAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  TxAck_TransactionType get tx => $_getN(0);
+  @$pb.TagNumber(1)
+  set tx(TxAck_TransactionType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTx() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTx() => clearField(1);
+  @$pb.TagNumber(1)
+  TxAck_TransactionType ensureTx() => $_ensure(0);
+}
+
+/// * Data type for transaction input to be signed.
+///
+///  When adding fields, take care to not conflict with PrevInput
+///
+///  @embed
+class TxInput extends $pb.GeneratedMessage {
+  factory TxInput({
+    $core.Iterable<$core.int>? addressN,
+    $core.List<$core.int>? prevHash,
+    $core.int? prevIndex,
+    $core.List<$core.int>? scriptSig,
+    $core.int? sequence,
+    InputScriptType? scriptType,
+    MultisigRedeemScriptType? multisig,
+    $fixnum.Int64? amount,
+    $core.int? decredTree,
+    $core.List<$core.int>? witness,
+    $core.List<$core.int>? ownershipProof,
+    $core.List<$core.int>? commitmentData,
+    $core.List<$core.int>? origHash,
+    $core.int? origIndex,
+    DecredStakingSpendType? decredStakingSpend,
+    $core.List<$core.int>? scriptPubkey,
+    $core.int? coinjoinFlags,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (prevHash != null) {
+      $result.prevHash = prevHash;
+    }
+    if (prevIndex != null) {
+      $result.prevIndex = prevIndex;
+    }
+    if (scriptSig != null) {
+      $result.scriptSig = scriptSig;
+    }
+    if (sequence != null) {
+      $result.sequence = sequence;
+    }
+    if (scriptType != null) {
+      $result.scriptType = scriptType;
+    }
+    if (multisig != null) {
+      $result.multisig = multisig;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (decredTree != null) {
+      $result.decredTree = decredTree;
+    }
+    if (witness != null) {
+      $result.witness = witness;
+    }
+    if (ownershipProof != null) {
+      $result.ownershipProof = ownershipProof;
+    }
+    if (commitmentData != null) {
+      $result.commitmentData = commitmentData;
+    }
+    if (origHash != null) {
+      $result.origHash = origHash;
+    }
+    if (origIndex != null) {
+      $result.origIndex = origIndex;
+    }
+    if (decredStakingSpend != null) {
+      $result.decredStakingSpend = decredStakingSpend;
+    }
+    if (scriptPubkey != null) {
+      $result.scriptPubkey = scriptPubkey;
+    }
+    if (coinjoinFlags != null) {
+      $result.coinjoinFlags = coinjoinFlags;
+    }
+    return $result;
+  }
+  TxInput._() : super();
+  factory TxInput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxInput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxInput', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'prevHash', $pb.PbFieldType.QY)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'prevIndex', $pb.PbFieldType.QU3)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'scriptSig', $pb.PbFieldType.OY)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'sequence', $pb.PbFieldType.OU3, defaultOrMaker: 4294967295)
+    ..e<InputScriptType>(6, _omitFieldNames ? '' : 'scriptType', $pb.PbFieldType.OE, defaultOrMaker: InputScriptType.SPENDADDRESS, valueOf: InputScriptType.valueOf, enumValues: InputScriptType.values)
+    ..aOM<MultisigRedeemScriptType>(7, _omitFieldNames ? '' : 'multisig', subBuilder: MultisigRedeemScriptType.create)
+    ..a<$fixnum.Int64>(8, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'decredTree', $pb.PbFieldType.OU3)
+    ..a<$core.List<$core.int>>(13, _omitFieldNames ? '' : 'witness', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(14, _omitFieldNames ? '' : 'ownershipProof', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(15, _omitFieldNames ? '' : 'commitmentData', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(16, _omitFieldNames ? '' : 'origHash', $pb.PbFieldType.OY)
+    ..a<$core.int>(17, _omitFieldNames ? '' : 'origIndex', $pb.PbFieldType.OU3)
+    ..e<DecredStakingSpendType>(18, _omitFieldNames ? '' : 'decredStakingSpend', $pb.PbFieldType.OE, defaultOrMaker: DecredStakingSpendType.SSGen, valueOf: DecredStakingSpendType.valueOf, enumValues: DecredStakingSpendType.values)
+    ..a<$core.List<$core.int>>(19, _omitFieldNames ? '' : 'scriptPubkey', $pb.PbFieldType.OY)
+    ..a<$core.int>(20, _omitFieldNames ? '' : 'coinjoinFlags', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxInput clone() => TxInput()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxInput copyWith(void Function(TxInput) updates) => super.copyWith((message) => updates(message as TxInput)) as TxInput;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxInput create() => TxInput._();
+  TxInput createEmptyInstance() => create();
+  static $pb.PbList<TxInput> createRepeated() => $pb.PbList<TxInput>();
+  @$core.pragma('dart2js:noInline')
+  static TxInput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxInput>(create);
+  static TxInput? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get prevHash => $_getN(1);
+  @$pb.TagNumber(2)
+  set prevHash($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPrevHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPrevHash() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get prevIndex => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set prevIndex($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasPrevIndex() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearPrevIndex() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get scriptSig => $_getN(3);
+  @$pb.TagNumber(4)
+  set scriptSig($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasScriptSig() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearScriptSig() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get sequence => $_getI(4, 4294967295);
+  @$pb.TagNumber(5)
+  set sequence($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasSequence() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearSequence() => clearField(5);
+
+  @$pb.TagNumber(6)
+  InputScriptType get scriptType => $_getN(5);
+  @$pb.TagNumber(6)
+  set scriptType(InputScriptType v) { setField(6, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasScriptType() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearScriptType() => clearField(6);
+
+  @$pb.TagNumber(7)
+  MultisigRedeemScriptType get multisig => $_getN(6);
+  @$pb.TagNumber(7)
+  set multisig(MultisigRedeemScriptType v) { setField(7, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasMultisig() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearMultisig() => clearField(7);
+  @$pb.TagNumber(7)
+  MultisigRedeemScriptType ensureMultisig() => $_ensure(6);
+
+  @$pb.TagNumber(8)
+  $fixnum.Int64 get amount => $_getI64(7);
+  @$pb.TagNumber(8)
+  set amount($fixnum.Int64 v) { $_setInt64(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasAmount() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearAmount() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.int get decredTree => $_getIZ(8);
+  @$pb.TagNumber(9)
+  set decredTree($core.int v) { $_setUnsignedInt32(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasDecredTree() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearDecredTree() => clearField(9);
+
+  @$pb.TagNumber(13)
+  $core.List<$core.int> get witness => $_getN(9);
+  @$pb.TagNumber(13)
+  set witness($core.List<$core.int> v) { $_setBytes(9, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasWitness() => $_has(9);
+  @$pb.TagNumber(13)
+  void clearWitness() => clearField(13);
+
+  @$pb.TagNumber(14)
+  $core.List<$core.int> get ownershipProof => $_getN(10);
+  @$pb.TagNumber(14)
+  set ownershipProof($core.List<$core.int> v) { $_setBytes(10, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasOwnershipProof() => $_has(10);
+  @$pb.TagNumber(14)
+  void clearOwnershipProof() => clearField(14);
+
+  @$pb.TagNumber(15)
+  $core.List<$core.int> get commitmentData => $_getN(11);
+  @$pb.TagNumber(15)
+  set commitmentData($core.List<$core.int> v) { $_setBytes(11, v); }
+  @$pb.TagNumber(15)
+  $core.bool hasCommitmentData() => $_has(11);
+  @$pb.TagNumber(15)
+  void clearCommitmentData() => clearField(15);
+
+  @$pb.TagNumber(16)
+  $core.List<$core.int> get origHash => $_getN(12);
+  @$pb.TagNumber(16)
+  set origHash($core.List<$core.int> v) { $_setBytes(12, v); }
+  @$pb.TagNumber(16)
+  $core.bool hasOrigHash() => $_has(12);
+  @$pb.TagNumber(16)
+  void clearOrigHash() => clearField(16);
+
+  @$pb.TagNumber(17)
+  $core.int get origIndex => $_getIZ(13);
+  @$pb.TagNumber(17)
+  set origIndex($core.int v) { $_setUnsignedInt32(13, v); }
+  @$pb.TagNumber(17)
+  $core.bool hasOrigIndex() => $_has(13);
+  @$pb.TagNumber(17)
+  void clearOrigIndex() => clearField(17);
+
+  @$pb.TagNumber(18)
+  DecredStakingSpendType get decredStakingSpend => $_getN(14);
+  @$pb.TagNumber(18)
+  set decredStakingSpend(DecredStakingSpendType v) { setField(18, v); }
+  @$pb.TagNumber(18)
+  $core.bool hasDecredStakingSpend() => $_has(14);
+  @$pb.TagNumber(18)
+  void clearDecredStakingSpend() => clearField(18);
+
+  @$pb.TagNumber(19)
+  $core.List<$core.int> get scriptPubkey => $_getN(15);
+  @$pb.TagNumber(19)
+  set scriptPubkey($core.List<$core.int> v) { $_setBytes(15, v); }
+  @$pb.TagNumber(19)
+  $core.bool hasScriptPubkey() => $_has(15);
+  @$pb.TagNumber(19)
+  void clearScriptPubkey() => clearField(19);
+
+  @$pb.TagNumber(20)
+  $core.int get coinjoinFlags => $_getIZ(16);
+  @$pb.TagNumber(20)
+  set coinjoinFlags($core.int v) { $_setUnsignedInt32(16, v); }
+  @$pb.TagNumber(20)
+  $core.bool hasCoinjoinFlags() => $_has(16);
+  @$pb.TagNumber(20)
+  void clearCoinjoinFlags() => clearField(20);
+}
+
+/// * Data type for transaction output to be signed.
+///  @embed
+class TxOutput extends $pb.GeneratedMessage {
+  factory TxOutput({
+    $core.String? address,
+    $core.Iterable<$core.int>? addressN,
+    $fixnum.Int64? amount,
+    OutputScriptType? scriptType,
+    MultisigRedeemScriptType? multisig,
+    $core.List<$core.int>? opReturnData,
+    $core.List<$core.int>? origHash,
+    $core.int? origIndex,
+    $core.int? paymentReqIndex,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (scriptType != null) {
+      $result.scriptType = scriptType;
+    }
+    if (multisig != null) {
+      $result.multisig = multisig;
+    }
+    if (opReturnData != null) {
+      $result.opReturnData = opReturnData;
+    }
+    if (origHash != null) {
+      $result.origHash = origHash;
+    }
+    if (origIndex != null) {
+      $result.origIndex = origIndex;
+    }
+    if (paymentReqIndex != null) {
+      $result.paymentReqIndex = paymentReqIndex;
+    }
+    return $result;
+  }
+  TxOutput._() : super();
+  factory TxOutput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxOutput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxOutput', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'address')
+    ..p<$core.int>(2, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..e<OutputScriptType>(4, _omitFieldNames ? '' : 'scriptType', $pb.PbFieldType.OE, defaultOrMaker: OutputScriptType.PAYTOADDRESS, valueOf: OutputScriptType.valueOf, enumValues: OutputScriptType.values)
+    ..aOM<MultisigRedeemScriptType>(5, _omitFieldNames ? '' : 'multisig', subBuilder: MultisigRedeemScriptType.create)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'opReturnData', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(10, _omitFieldNames ? '' : 'origHash', $pb.PbFieldType.OY)
+    ..a<$core.int>(11, _omitFieldNames ? '' : 'origIndex', $pb.PbFieldType.OU3)
+    ..a<$core.int>(12, _omitFieldNames ? '' : 'paymentReqIndex', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxOutput clone() => TxOutput()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxOutput copyWith(void Function(TxOutput) updates) => super.copyWith((message) => updates(message as TxOutput)) as TxOutput;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxOutput create() => TxOutput._();
+  TxOutput createEmptyInstance() => create();
+  static $pb.PbList<TxOutput> createRepeated() => $pb.PbList<TxOutput>();
+  @$core.pragma('dart2js:noInline')
+  static TxOutput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxOutput>(create);
+  static TxOutput? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get addressN => $_getList(1);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get amount => $_getI64(2);
+  @$pb.TagNumber(3)
+  set amount($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasAmount() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearAmount() => clearField(3);
+
+  @$pb.TagNumber(4)
+  OutputScriptType get scriptType => $_getN(3);
+  @$pb.TagNumber(4)
+  set scriptType(OutputScriptType v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasScriptType() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearScriptType() => clearField(4);
+
+  @$pb.TagNumber(5)
+  MultisigRedeemScriptType get multisig => $_getN(4);
+  @$pb.TagNumber(5)
+  set multisig(MultisigRedeemScriptType v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasMultisig() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearMultisig() => clearField(5);
+  @$pb.TagNumber(5)
+  MultisigRedeemScriptType ensureMultisig() => $_ensure(4);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get opReturnData => $_getN(5);
+  @$pb.TagNumber(6)
+  set opReturnData($core.List<$core.int> v) { $_setBytes(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasOpReturnData() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearOpReturnData() => clearField(6);
+
+  @$pb.TagNumber(10)
+  $core.List<$core.int> get origHash => $_getN(6);
+  @$pb.TagNumber(10)
+  set origHash($core.List<$core.int> v) { $_setBytes(6, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasOrigHash() => $_has(6);
+  @$pb.TagNumber(10)
+  void clearOrigHash() => clearField(10);
+
+  @$pb.TagNumber(11)
+  $core.int get origIndex => $_getIZ(7);
+  @$pb.TagNumber(11)
+  set origIndex($core.int v) { $_setUnsignedInt32(7, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasOrigIndex() => $_has(7);
+  @$pb.TagNumber(11)
+  void clearOrigIndex() => clearField(11);
+
+  @$pb.TagNumber(12)
+  $core.int get paymentReqIndex => $_getIZ(8);
+  @$pb.TagNumber(12)
+  set paymentReqIndex($core.int v) { $_setUnsignedInt32(8, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasPaymentReqIndex() => $_has(8);
+  @$pb.TagNumber(12)
+  void clearPaymentReqIndex() => clearField(12);
+}
+
+/// * Data type for metadata about previous transaction which contains the UTXO being spent.
+///  @embed
+class PrevTx extends $pb.GeneratedMessage {
+  factory PrevTx({
+    $core.int? version,
+    $core.int? lockTime,
+    $core.int? inputsCount,
+    $core.int? outputsCount,
+    $core.int? extraDataLen,
+    $core.int? expiry,
+    $core.int? versionGroupId,
+    $core.int? timestamp,
+    $core.int? branchId,
+  }) {
+    final $result = create();
+    if (version != null) {
+      $result.version = version;
+    }
+    if (lockTime != null) {
+      $result.lockTime = lockTime;
+    }
+    if (inputsCount != null) {
+      $result.inputsCount = inputsCount;
+    }
+    if (outputsCount != null) {
+      $result.outputsCount = outputsCount;
+    }
+    if (extraDataLen != null) {
+      $result.extraDataLen = extraDataLen;
+    }
+    if (expiry != null) {
+      $result.expiry = expiry;
+    }
+    if (versionGroupId != null) {
+      $result.versionGroupId = versionGroupId;
+    }
+    if (timestamp != null) {
+      $result.timestamp = timestamp;
+    }
+    if (branchId != null) {
+      $result.branchId = branchId;
+    }
+    return $result;
+  }
+  PrevTx._() : super();
+  factory PrevTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PrevTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PrevTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'version', $pb.PbFieldType.QU3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'lockTime', $pb.PbFieldType.QU3)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'inputsCount', $pb.PbFieldType.QU3)
+    ..a<$core.int>(7, _omitFieldNames ? '' : 'outputsCount', $pb.PbFieldType.QU3)
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'extraDataLen', $pb.PbFieldType.OU3)
+    ..a<$core.int>(10, _omitFieldNames ? '' : 'expiry', $pb.PbFieldType.OU3)
+    ..a<$core.int>(12, _omitFieldNames ? '' : 'versionGroupId', $pb.PbFieldType.OU3)
+    ..a<$core.int>(13, _omitFieldNames ? '' : 'timestamp', $pb.PbFieldType.OU3)
+    ..a<$core.int>(14, _omitFieldNames ? '' : 'branchId', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PrevTx clone() => PrevTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PrevTx copyWith(void Function(PrevTx) updates) => super.copyWith((message) => updates(message as PrevTx)) as PrevTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PrevTx create() => PrevTx._();
+  PrevTx createEmptyInstance() => create();
+  static $pb.PbList<PrevTx> createRepeated() => $pb.PbList<PrevTx>();
+  @$core.pragma('dart2js:noInline')
+  static PrevTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PrevTx>(create);
+  static PrevTx? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get version => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set version($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasVersion() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearVersion() => clearField(1);
+
+  @$pb.TagNumber(4)
+  $core.int get lockTime => $_getIZ(1);
+  @$pb.TagNumber(4)
+  set lockTime($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasLockTime() => $_has(1);
+  @$pb.TagNumber(4)
+  void clearLockTime() => clearField(4);
+
+  @$pb.TagNumber(6)
+  $core.int get inputsCount => $_getIZ(2);
+  @$pb.TagNumber(6)
+  set inputsCount($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasInputsCount() => $_has(2);
+  @$pb.TagNumber(6)
+  void clearInputsCount() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.int get outputsCount => $_getIZ(3);
+  @$pb.TagNumber(7)
+  set outputsCount($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasOutputsCount() => $_has(3);
+  @$pb.TagNumber(7)
+  void clearOutputsCount() => clearField(7);
+
+  @$pb.TagNumber(9)
+  $core.int get extraDataLen => $_getIZ(4);
+  @$pb.TagNumber(9)
+  set extraDataLen($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasExtraDataLen() => $_has(4);
+  @$pb.TagNumber(9)
+  void clearExtraDataLen() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.int get expiry => $_getIZ(5);
+  @$pb.TagNumber(10)
+  set expiry($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasExpiry() => $_has(5);
+  @$pb.TagNumber(10)
+  void clearExpiry() => clearField(10);
+
+  @$pb.TagNumber(12)
+  $core.int get versionGroupId => $_getIZ(6);
+  @$pb.TagNumber(12)
+  set versionGroupId($core.int v) { $_setUnsignedInt32(6, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasVersionGroupId() => $_has(6);
+  @$pb.TagNumber(12)
+  void clearVersionGroupId() => clearField(12);
+
+  @$pb.TagNumber(13)
+  $core.int get timestamp => $_getIZ(7);
+  @$pb.TagNumber(13)
+  set timestamp($core.int v) { $_setUnsignedInt32(7, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasTimestamp() => $_has(7);
+  @$pb.TagNumber(13)
+  void clearTimestamp() => clearField(13);
+
+  @$pb.TagNumber(14)
+  $core.int get branchId => $_getIZ(8);
+  @$pb.TagNumber(14)
+  set branchId($core.int v) { $_setUnsignedInt32(8, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasBranchId() => $_has(8);
+  @$pb.TagNumber(14)
+  void clearBranchId() => clearField(14);
+}
+
+/// * Data type for inputs of previous transactions.
+///
+///  When adding fields, take care to not conflict with TxInput
+///  @embed
+class PrevInput extends $pb.GeneratedMessage {
+  factory PrevInput({
+    $core.List<$core.int>? prevHash,
+    $core.int? prevIndex,
+    $core.List<$core.int>? scriptSig,
+    $core.int? sequence,
+    $core.int? decredTree,
+  }) {
+    final $result = create();
+    if (prevHash != null) {
+      $result.prevHash = prevHash;
+    }
+    if (prevIndex != null) {
+      $result.prevIndex = prevIndex;
+    }
+    if (scriptSig != null) {
+      $result.scriptSig = scriptSig;
+    }
+    if (sequence != null) {
+      $result.sequence = sequence;
+    }
+    if (decredTree != null) {
+      $result.decredTree = decredTree;
+    }
+    return $result;
+  }
+  PrevInput._() : super();
+  factory PrevInput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PrevInput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PrevInput', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'prevHash', $pb.PbFieldType.QY)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'prevIndex', $pb.PbFieldType.QU3)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'scriptSig', $pb.PbFieldType.QY)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'sequence', $pb.PbFieldType.QU3)
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'decredTree', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PrevInput clone() => PrevInput()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PrevInput copyWith(void Function(PrevInput) updates) => super.copyWith((message) => updates(message as PrevInput)) as PrevInput;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PrevInput create() => PrevInput._();
+  PrevInput createEmptyInstance() => create();
+  static $pb.PbList<PrevInput> createRepeated() => $pb.PbList<PrevInput>();
+  @$core.pragma('dart2js:noInline')
+  static PrevInput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PrevInput>(create);
+  static PrevInput? _defaultInstance;
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get prevHash => $_getN(0);
+  @$pb.TagNumber(2)
+  set prevHash($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPrevHash() => $_has(0);
+  @$pb.TagNumber(2)
+  void clearPrevHash() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get prevIndex => $_getIZ(1);
+  @$pb.TagNumber(3)
+  set prevIndex($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasPrevIndex() => $_has(1);
+  @$pb.TagNumber(3)
+  void clearPrevIndex() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get scriptSig => $_getN(2);
+  @$pb.TagNumber(4)
+  set scriptSig($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasScriptSig() => $_has(2);
+  @$pb.TagNumber(4)
+  void clearScriptSig() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get sequence => $_getIZ(3);
+  @$pb.TagNumber(5)
+  set sequence($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasSequence() => $_has(3);
+  @$pb.TagNumber(5)
+  void clearSequence() => clearField(5);
+
+  @$pb.TagNumber(9)
+  $core.int get decredTree => $_getIZ(4);
+  @$pb.TagNumber(9)
+  set decredTree($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasDecredTree() => $_has(4);
+  @$pb.TagNumber(9)
+  void clearDecredTree() => clearField(9);
+}
+
+/// * Data type for outputs of previous transactions.
+///  @embed
+class PrevOutput extends $pb.GeneratedMessage {
+  factory PrevOutput({
+    $fixnum.Int64? amount,
+    $core.List<$core.int>? scriptPubkey,
+    $core.int? decredScriptVersion,
+  }) {
+    final $result = create();
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (scriptPubkey != null) {
+      $result.scriptPubkey = scriptPubkey;
+    }
+    if (decredScriptVersion != null) {
+      $result.decredScriptVersion = decredScriptVersion;
+    }
+    return $result;
+  }
+  PrevOutput._() : super();
+  factory PrevOutput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PrevOutput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PrevOutput', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'scriptPubkey', $pb.PbFieldType.QY)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'decredScriptVersion', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PrevOutput clone() => PrevOutput()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PrevOutput copyWith(void Function(PrevOutput) updates) => super.copyWith((message) => updates(message as PrevOutput)) as PrevOutput;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PrevOutput create() => PrevOutput._();
+  PrevOutput createEmptyInstance() => create();
+  static $pb.PbList<PrevOutput> createRepeated() => $pb.PbList<PrevOutput>();
+  @$core.pragma('dart2js:noInline')
+  static PrevOutput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PrevOutput>(create);
+  static PrevOutput? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get amount => $_getI64(0);
+  @$pb.TagNumber(1)
+  set amount($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAmount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAmount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get scriptPubkey => $_getN(1);
+  @$pb.TagNumber(2)
+  set scriptPubkey($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasScriptPubkey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearScriptPubkey() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get decredScriptVersion => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set decredScriptVersion($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasDecredScriptVersion() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearDecredScriptVersion() => clearField(3);
+}
+
+class TxAckPaymentRequest_PaymentRequestMemo extends $pb.GeneratedMessage {
+  factory TxAckPaymentRequest_PaymentRequestMemo({
+    TxAckPaymentRequest_TextMemo? textMemo,
+    TxAckPaymentRequest_RefundMemo? refundMemo,
+    TxAckPaymentRequest_CoinPurchaseMemo? coinPurchaseMemo,
+  }) {
+    final $result = create();
+    if (textMemo != null) {
+      $result.textMemo = textMemo;
+    }
+    if (refundMemo != null) {
+      $result.refundMemo = refundMemo;
+    }
+    if (coinPurchaseMemo != null) {
+      $result.coinPurchaseMemo = coinPurchaseMemo;
+    }
+    return $result;
+  }
+  TxAckPaymentRequest_PaymentRequestMemo._() : super();
+  factory TxAckPaymentRequest_PaymentRequestMemo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckPaymentRequest_PaymentRequestMemo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckPaymentRequest.PaymentRequestMemo', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aOM<TxAckPaymentRequest_TextMemo>(1, _omitFieldNames ? '' : 'textMemo', subBuilder: TxAckPaymentRequest_TextMemo.create)
+    ..aOM<TxAckPaymentRequest_RefundMemo>(2, _omitFieldNames ? '' : 'refundMemo', subBuilder: TxAckPaymentRequest_RefundMemo.create)
+    ..aOM<TxAckPaymentRequest_CoinPurchaseMemo>(3, _omitFieldNames ? '' : 'coinPurchaseMemo', subBuilder: TxAckPaymentRequest_CoinPurchaseMemo.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckPaymentRequest_PaymentRequestMemo clone() => TxAckPaymentRequest_PaymentRequestMemo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckPaymentRequest_PaymentRequestMemo copyWith(void Function(TxAckPaymentRequest_PaymentRequestMemo) updates) => super.copyWith((message) => updates(message as TxAckPaymentRequest_PaymentRequestMemo)) as TxAckPaymentRequest_PaymentRequestMemo;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckPaymentRequest_PaymentRequestMemo create() => TxAckPaymentRequest_PaymentRequestMemo._();
+  TxAckPaymentRequest_PaymentRequestMemo createEmptyInstance() => create();
+  static $pb.PbList<TxAckPaymentRequest_PaymentRequestMemo> createRepeated() => $pb.PbList<TxAckPaymentRequest_PaymentRequestMemo>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckPaymentRequest_PaymentRequestMemo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckPaymentRequest_PaymentRequestMemo>(create);
+  static TxAckPaymentRequest_PaymentRequestMemo? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  TxAckPaymentRequest_TextMemo get textMemo => $_getN(0);
+  @$pb.TagNumber(1)
+  set textMemo(TxAckPaymentRequest_TextMemo v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTextMemo() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTextMemo() => clearField(1);
+  @$pb.TagNumber(1)
+  TxAckPaymentRequest_TextMemo ensureTextMemo() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  TxAckPaymentRequest_RefundMemo get refundMemo => $_getN(1);
+  @$pb.TagNumber(2)
+  set refundMemo(TxAckPaymentRequest_RefundMemo v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasRefundMemo() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearRefundMemo() => clearField(2);
+  @$pb.TagNumber(2)
+  TxAckPaymentRequest_RefundMemo ensureRefundMemo() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  TxAckPaymentRequest_CoinPurchaseMemo get coinPurchaseMemo => $_getN(2);
+  @$pb.TagNumber(3)
+  set coinPurchaseMemo(TxAckPaymentRequest_CoinPurchaseMemo v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasCoinPurchaseMemo() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearCoinPurchaseMemo() => clearField(3);
+  @$pb.TagNumber(3)
+  TxAckPaymentRequest_CoinPurchaseMemo ensureCoinPurchaseMemo() => $_ensure(2);
+}
+
+class TxAckPaymentRequest_TextMemo extends $pb.GeneratedMessage {
+  factory TxAckPaymentRequest_TextMemo({
+    $core.String? text,
+  }) {
+    final $result = create();
+    if (text != null) {
+      $result.text = text;
+    }
+    return $result;
+  }
+  TxAckPaymentRequest_TextMemo._() : super();
+  factory TxAckPaymentRequest_TextMemo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckPaymentRequest_TextMemo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckPaymentRequest.TextMemo', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'text')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckPaymentRequest_TextMemo clone() => TxAckPaymentRequest_TextMemo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckPaymentRequest_TextMemo copyWith(void Function(TxAckPaymentRequest_TextMemo) updates) => super.copyWith((message) => updates(message as TxAckPaymentRequest_TextMemo)) as TxAckPaymentRequest_TextMemo;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckPaymentRequest_TextMemo create() => TxAckPaymentRequest_TextMemo._();
+  TxAckPaymentRequest_TextMemo createEmptyInstance() => create();
+  static $pb.PbList<TxAckPaymentRequest_TextMemo> createRepeated() => $pb.PbList<TxAckPaymentRequest_TextMemo>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckPaymentRequest_TextMemo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckPaymentRequest_TextMemo>(create);
+  static TxAckPaymentRequest_TextMemo? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get text => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set text($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasText() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearText() => clearField(1);
+}
+
+class TxAckPaymentRequest_RefundMemo extends $pb.GeneratedMessage {
+  factory TxAckPaymentRequest_RefundMemo({
+    $core.String? address,
+    $core.List<$core.int>? mac,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    if (mac != null) {
+      $result.mac = mac;
+    }
+    return $result;
+  }
+  TxAckPaymentRequest_RefundMemo._() : super();
+  factory TxAckPaymentRequest_RefundMemo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckPaymentRequest_RefundMemo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckPaymentRequest.RefundMemo', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'address')
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'mac', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckPaymentRequest_RefundMemo clone() => TxAckPaymentRequest_RefundMemo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckPaymentRequest_RefundMemo copyWith(void Function(TxAckPaymentRequest_RefundMemo) updates) => super.copyWith((message) => updates(message as TxAckPaymentRequest_RefundMemo)) as TxAckPaymentRequest_RefundMemo;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckPaymentRequest_RefundMemo create() => TxAckPaymentRequest_RefundMemo._();
+  TxAckPaymentRequest_RefundMemo createEmptyInstance() => create();
+  static $pb.PbList<TxAckPaymentRequest_RefundMemo> createRepeated() => $pb.PbList<TxAckPaymentRequest_RefundMemo>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckPaymentRequest_RefundMemo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckPaymentRequest_RefundMemo>(create);
+  static TxAckPaymentRequest_RefundMemo? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get mac => $_getN(1);
+  @$pb.TagNumber(2)
+  set mac($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMac() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMac() => clearField(2);
+}
+
+class TxAckPaymentRequest_CoinPurchaseMemo extends $pb.GeneratedMessage {
+  factory TxAckPaymentRequest_CoinPurchaseMemo({
+    $core.int? coinType,
+    $core.String? amount,
+    $core.String? address,
+    $core.List<$core.int>? mac,
+  }) {
+    final $result = create();
+    if (coinType != null) {
+      $result.coinType = coinType;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (address != null) {
+      $result.address = address;
+    }
+    if (mac != null) {
+      $result.mac = mac;
+    }
+    return $result;
+  }
+  TxAckPaymentRequest_CoinPurchaseMemo._() : super();
+  factory TxAckPaymentRequest_CoinPurchaseMemo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckPaymentRequest_CoinPurchaseMemo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckPaymentRequest.CoinPurchaseMemo', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'coinType', $pb.PbFieldType.QU3)
+    ..aQS(2, _omitFieldNames ? '' : 'amount')
+    ..aQS(3, _omitFieldNames ? '' : 'address')
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'mac', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckPaymentRequest_CoinPurchaseMemo clone() => TxAckPaymentRequest_CoinPurchaseMemo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckPaymentRequest_CoinPurchaseMemo copyWith(void Function(TxAckPaymentRequest_CoinPurchaseMemo) updates) => super.copyWith((message) => updates(message as TxAckPaymentRequest_CoinPurchaseMemo)) as TxAckPaymentRequest_CoinPurchaseMemo;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckPaymentRequest_CoinPurchaseMemo create() => TxAckPaymentRequest_CoinPurchaseMemo._();
+  TxAckPaymentRequest_CoinPurchaseMemo createEmptyInstance() => create();
+  static $pb.PbList<TxAckPaymentRequest_CoinPurchaseMemo> createRepeated() => $pb.PbList<TxAckPaymentRequest_CoinPurchaseMemo>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckPaymentRequest_CoinPurchaseMemo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckPaymentRequest_CoinPurchaseMemo>(create);
+  static TxAckPaymentRequest_CoinPurchaseMemo? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get coinType => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set coinType($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasCoinType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCoinType() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get amount => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set amount($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAmount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAmount() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get address => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set address($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasAddress() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearAddress() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get mac => $_getN(3);
+  @$pb.TagNumber(4)
+  set mac($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasMac() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMac() => clearField(4);
+}
+
+/// * Data type of a payment request for a set of outputs.
+///  @next TxRequest
+class TxAckPaymentRequest extends $pb.GeneratedMessage {
+  factory TxAckPaymentRequest({
+    $core.List<$core.int>? nonce,
+    $core.String? recipientName,
+    $core.Iterable<TxAckPaymentRequest_PaymentRequestMemo>? memos,
+    $fixnum.Int64? amount,
+    $core.List<$core.int>? signature,
+  }) {
+    final $result = create();
+    if (nonce != null) {
+      $result.nonce = nonce;
+    }
+    if (recipientName != null) {
+      $result.recipientName = recipientName;
+    }
+    if (memos != null) {
+      $result.memos.addAll(memos);
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    return $result;
+  }
+  TxAckPaymentRequest._() : super();
+  factory TxAckPaymentRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckPaymentRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckPaymentRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'nonce', $pb.PbFieldType.OY)
+    ..aQS(2, _omitFieldNames ? '' : 'recipientName')
+    ..pc<TxAckPaymentRequest_PaymentRequestMemo>(3, _omitFieldNames ? '' : 'memos', $pb.PbFieldType.PM, subBuilder: TxAckPaymentRequest_PaymentRequestMemo.create)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckPaymentRequest clone() => TxAckPaymentRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckPaymentRequest copyWith(void Function(TxAckPaymentRequest) updates) => super.copyWith((message) => updates(message as TxAckPaymentRequest)) as TxAckPaymentRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckPaymentRequest create() => TxAckPaymentRequest._();
+  TxAckPaymentRequest createEmptyInstance() => create();
+  static $pb.PbList<TxAckPaymentRequest> createRepeated() => $pb.PbList<TxAckPaymentRequest>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckPaymentRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckPaymentRequest>(create);
+  static TxAckPaymentRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get nonce => $_getN(0);
+  @$pb.TagNumber(1)
+  set nonce($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasNonce() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearNonce() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get recipientName => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set recipientName($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasRecipientName() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearRecipientName() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<TxAckPaymentRequest_PaymentRequestMemo> get memos => $_getList(2);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get amount => $_getI64(3);
+  @$pb.TagNumber(4)
+  set amount($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasAmount() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearAmount() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get signature => $_getN(4);
+  @$pb.TagNumber(5)
+  set signature($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasSignature() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearSignature() => clearField(5);
+}
+
+class TxAckInput_TxAckInputWrapper extends $pb.GeneratedMessage {
+  factory TxAckInput_TxAckInputWrapper({
+    TxInput? input,
+  }) {
+    final $result = create();
+    if (input != null) {
+      $result.input = input;
+    }
+    return $result;
+  }
+  TxAckInput_TxAckInputWrapper._() : super();
+  factory TxAckInput_TxAckInputWrapper.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckInput_TxAckInputWrapper.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckInput.TxAckInputWrapper', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQM<TxInput>(2, _omitFieldNames ? '' : 'input', subBuilder: TxInput.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckInput_TxAckInputWrapper clone() => TxAckInput_TxAckInputWrapper()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckInput_TxAckInputWrapper copyWith(void Function(TxAckInput_TxAckInputWrapper) updates) => super.copyWith((message) => updates(message as TxAckInput_TxAckInputWrapper)) as TxAckInput_TxAckInputWrapper;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckInput_TxAckInputWrapper create() => TxAckInput_TxAckInputWrapper._();
+  TxAckInput_TxAckInputWrapper createEmptyInstance() => create();
+  static $pb.PbList<TxAckInput_TxAckInputWrapper> createRepeated() => $pb.PbList<TxAckInput_TxAckInputWrapper>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckInput_TxAckInputWrapper getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckInput_TxAckInputWrapper>(create);
+  static TxAckInput_TxAckInputWrapper? _defaultInstance;
+
+  @$pb.TagNumber(2)
+  TxInput get input => $_getN(0);
+  @$pb.TagNumber(2)
+  set input(TxInput v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasInput() => $_has(0);
+  @$pb.TagNumber(2)
+  void clearInput() => clearField(2);
+  @$pb.TagNumber(2)
+  TxInput ensureInput() => $_ensure(0);
+}
+
+/// *
+///  Request: Data about input to be signed.
+///  Wire-alias of TxAck.
+///
+///  Do not edit this type without considering compatibility with TxAck.
+///  Prefer to modify the inner TxInput type.
+///
+///  @next TxRequest
+class TxAckInput extends $pb.GeneratedMessage {
+  factory TxAckInput({
+    TxAckInput_TxAckInputWrapper? tx,
+  }) {
+    final $result = create();
+    if (tx != null) {
+      $result.tx = tx;
+    }
+    return $result;
+  }
+  TxAckInput._() : super();
+  factory TxAckInput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckInput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckInput', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQM<TxAckInput_TxAckInputWrapper>(1, _omitFieldNames ? '' : 'tx', subBuilder: TxAckInput_TxAckInputWrapper.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckInput clone() => TxAckInput()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckInput copyWith(void Function(TxAckInput) updates) => super.copyWith((message) => updates(message as TxAckInput)) as TxAckInput;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckInput create() => TxAckInput._();
+  TxAckInput createEmptyInstance() => create();
+  static $pb.PbList<TxAckInput> createRepeated() => $pb.PbList<TxAckInput>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckInput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckInput>(create);
+  static TxAckInput? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  TxAckInput_TxAckInputWrapper get tx => $_getN(0);
+  @$pb.TagNumber(1)
+  set tx(TxAckInput_TxAckInputWrapper v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTx() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTx() => clearField(1);
+  @$pb.TagNumber(1)
+  TxAckInput_TxAckInputWrapper ensureTx() => $_ensure(0);
+}
+
+class TxAckOutput_TxAckOutputWrapper extends $pb.GeneratedMessage {
+  factory TxAckOutput_TxAckOutputWrapper({
+    TxOutput? output,
+  }) {
+    final $result = create();
+    if (output != null) {
+      $result.output = output;
+    }
+    return $result;
+  }
+  TxAckOutput_TxAckOutputWrapper._() : super();
+  factory TxAckOutput_TxAckOutputWrapper.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckOutput_TxAckOutputWrapper.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckOutput.TxAckOutputWrapper', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQM<TxOutput>(5, _omitFieldNames ? '' : 'output', subBuilder: TxOutput.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckOutput_TxAckOutputWrapper clone() => TxAckOutput_TxAckOutputWrapper()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckOutput_TxAckOutputWrapper copyWith(void Function(TxAckOutput_TxAckOutputWrapper) updates) => super.copyWith((message) => updates(message as TxAckOutput_TxAckOutputWrapper)) as TxAckOutput_TxAckOutputWrapper;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckOutput_TxAckOutputWrapper create() => TxAckOutput_TxAckOutputWrapper._();
+  TxAckOutput_TxAckOutputWrapper createEmptyInstance() => create();
+  static $pb.PbList<TxAckOutput_TxAckOutputWrapper> createRepeated() => $pb.PbList<TxAckOutput_TxAckOutputWrapper>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckOutput_TxAckOutputWrapper getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckOutput_TxAckOutputWrapper>(create);
+  static TxAckOutput_TxAckOutputWrapper? _defaultInstance;
+
+  @$pb.TagNumber(5)
+  TxOutput get output => $_getN(0);
+  @$pb.TagNumber(5)
+  set output(TxOutput v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasOutput() => $_has(0);
+  @$pb.TagNumber(5)
+  void clearOutput() => clearField(5);
+  @$pb.TagNumber(5)
+  TxOutput ensureOutput() => $_ensure(0);
+}
+
+/// *
+///  Request: Data about output to be signed.
+///  Wire-alias of TxAck.
+///
+///  Do not edit this type without considering compatibility with TxAck.
+///  Prefer to modify the inner TxOutput type.
+///
+///  @next TxRequest
+class TxAckOutput extends $pb.GeneratedMessage {
+  factory TxAckOutput({
+    TxAckOutput_TxAckOutputWrapper? tx,
+  }) {
+    final $result = create();
+    if (tx != null) {
+      $result.tx = tx;
+    }
+    return $result;
+  }
+  TxAckOutput._() : super();
+  factory TxAckOutput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckOutput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckOutput', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQM<TxAckOutput_TxAckOutputWrapper>(1, _omitFieldNames ? '' : 'tx', subBuilder: TxAckOutput_TxAckOutputWrapper.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckOutput clone() => TxAckOutput()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckOutput copyWith(void Function(TxAckOutput) updates) => super.copyWith((message) => updates(message as TxAckOutput)) as TxAckOutput;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckOutput create() => TxAckOutput._();
+  TxAckOutput createEmptyInstance() => create();
+  static $pb.PbList<TxAckOutput> createRepeated() => $pb.PbList<TxAckOutput>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckOutput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckOutput>(create);
+  static TxAckOutput? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  TxAckOutput_TxAckOutputWrapper get tx => $_getN(0);
+  @$pb.TagNumber(1)
+  set tx(TxAckOutput_TxAckOutputWrapper v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTx() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTx() => clearField(1);
+  @$pb.TagNumber(1)
+  TxAckOutput_TxAckOutputWrapper ensureTx() => $_ensure(0);
+}
+
+/// *
+///  Request: Data about previous transaction metadata
+///  Wire-alias of TxAck.
+///
+///  Do not edit this type without considering compatibility with TxAck.
+///  Prefer to modify the inner PrevTx type.
+///
+///  @next TxRequest
+class TxAckPrevMeta extends $pb.GeneratedMessage {
+  factory TxAckPrevMeta({
+    PrevTx? tx,
+  }) {
+    final $result = create();
+    if (tx != null) {
+      $result.tx = tx;
+    }
+    return $result;
+  }
+  TxAckPrevMeta._() : super();
+  factory TxAckPrevMeta.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckPrevMeta.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckPrevMeta', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQM<PrevTx>(1, _omitFieldNames ? '' : 'tx', subBuilder: PrevTx.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckPrevMeta clone() => TxAckPrevMeta()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckPrevMeta copyWith(void Function(TxAckPrevMeta) updates) => super.copyWith((message) => updates(message as TxAckPrevMeta)) as TxAckPrevMeta;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckPrevMeta create() => TxAckPrevMeta._();
+  TxAckPrevMeta createEmptyInstance() => create();
+  static $pb.PbList<TxAckPrevMeta> createRepeated() => $pb.PbList<TxAckPrevMeta>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckPrevMeta getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckPrevMeta>(create);
+  static TxAckPrevMeta? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  PrevTx get tx => $_getN(0);
+  @$pb.TagNumber(1)
+  set tx(PrevTx v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTx() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTx() => clearField(1);
+  @$pb.TagNumber(1)
+  PrevTx ensureTx() => $_ensure(0);
+}
+
+class TxAckPrevInput_TxAckPrevInputWrapper extends $pb.GeneratedMessage {
+  factory TxAckPrevInput_TxAckPrevInputWrapper({
+    PrevInput? input,
+  }) {
+    final $result = create();
+    if (input != null) {
+      $result.input = input;
+    }
+    return $result;
+  }
+  TxAckPrevInput_TxAckPrevInputWrapper._() : super();
+  factory TxAckPrevInput_TxAckPrevInputWrapper.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckPrevInput_TxAckPrevInputWrapper.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckPrevInput.TxAckPrevInputWrapper', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQM<PrevInput>(2, _omitFieldNames ? '' : 'input', subBuilder: PrevInput.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckPrevInput_TxAckPrevInputWrapper clone() => TxAckPrevInput_TxAckPrevInputWrapper()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckPrevInput_TxAckPrevInputWrapper copyWith(void Function(TxAckPrevInput_TxAckPrevInputWrapper) updates) => super.copyWith((message) => updates(message as TxAckPrevInput_TxAckPrevInputWrapper)) as TxAckPrevInput_TxAckPrevInputWrapper;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckPrevInput_TxAckPrevInputWrapper create() => TxAckPrevInput_TxAckPrevInputWrapper._();
+  TxAckPrevInput_TxAckPrevInputWrapper createEmptyInstance() => create();
+  static $pb.PbList<TxAckPrevInput_TxAckPrevInputWrapper> createRepeated() => $pb.PbList<TxAckPrevInput_TxAckPrevInputWrapper>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckPrevInput_TxAckPrevInputWrapper getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckPrevInput_TxAckPrevInputWrapper>(create);
+  static TxAckPrevInput_TxAckPrevInputWrapper? _defaultInstance;
+
+  @$pb.TagNumber(2)
+  PrevInput get input => $_getN(0);
+  @$pb.TagNumber(2)
+  set input(PrevInput v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasInput() => $_has(0);
+  @$pb.TagNumber(2)
+  void clearInput() => clearField(2);
+  @$pb.TagNumber(2)
+  PrevInput ensureInput() => $_ensure(0);
+}
+
+/// *
+///  Request: Data about previous transaction input
+///  Wire-alias of TxAck.
+///
+///  Do not edit this type without considering compatibility with TxAck.
+///  Prefer to modify the inner PrevInput type.
+///
+///  @next TxRequest
+class TxAckPrevInput extends $pb.GeneratedMessage {
+  factory TxAckPrevInput({
+    TxAckPrevInput_TxAckPrevInputWrapper? tx,
+  }) {
+    final $result = create();
+    if (tx != null) {
+      $result.tx = tx;
+    }
+    return $result;
+  }
+  TxAckPrevInput._() : super();
+  factory TxAckPrevInput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckPrevInput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckPrevInput', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQM<TxAckPrevInput_TxAckPrevInputWrapper>(1, _omitFieldNames ? '' : 'tx', subBuilder: TxAckPrevInput_TxAckPrevInputWrapper.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckPrevInput clone() => TxAckPrevInput()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckPrevInput copyWith(void Function(TxAckPrevInput) updates) => super.copyWith((message) => updates(message as TxAckPrevInput)) as TxAckPrevInput;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckPrevInput create() => TxAckPrevInput._();
+  TxAckPrevInput createEmptyInstance() => create();
+  static $pb.PbList<TxAckPrevInput> createRepeated() => $pb.PbList<TxAckPrevInput>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckPrevInput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckPrevInput>(create);
+  static TxAckPrevInput? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  TxAckPrevInput_TxAckPrevInputWrapper get tx => $_getN(0);
+  @$pb.TagNumber(1)
+  set tx(TxAckPrevInput_TxAckPrevInputWrapper v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTx() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTx() => clearField(1);
+  @$pb.TagNumber(1)
+  TxAckPrevInput_TxAckPrevInputWrapper ensureTx() => $_ensure(0);
+}
+
+class TxAckPrevOutput_TxAckPrevOutputWrapper extends $pb.GeneratedMessage {
+  factory TxAckPrevOutput_TxAckPrevOutputWrapper({
+    PrevOutput? output,
+  }) {
+    final $result = create();
+    if (output != null) {
+      $result.output = output;
+    }
+    return $result;
+  }
+  TxAckPrevOutput_TxAckPrevOutputWrapper._() : super();
+  factory TxAckPrevOutput_TxAckPrevOutputWrapper.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckPrevOutput_TxAckPrevOutputWrapper.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckPrevOutput.TxAckPrevOutputWrapper', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQM<PrevOutput>(3, _omitFieldNames ? '' : 'output', subBuilder: PrevOutput.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckPrevOutput_TxAckPrevOutputWrapper clone() => TxAckPrevOutput_TxAckPrevOutputWrapper()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckPrevOutput_TxAckPrevOutputWrapper copyWith(void Function(TxAckPrevOutput_TxAckPrevOutputWrapper) updates) => super.copyWith((message) => updates(message as TxAckPrevOutput_TxAckPrevOutputWrapper)) as TxAckPrevOutput_TxAckPrevOutputWrapper;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckPrevOutput_TxAckPrevOutputWrapper create() => TxAckPrevOutput_TxAckPrevOutputWrapper._();
+  TxAckPrevOutput_TxAckPrevOutputWrapper createEmptyInstance() => create();
+  static $pb.PbList<TxAckPrevOutput_TxAckPrevOutputWrapper> createRepeated() => $pb.PbList<TxAckPrevOutput_TxAckPrevOutputWrapper>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckPrevOutput_TxAckPrevOutputWrapper getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckPrevOutput_TxAckPrevOutputWrapper>(create);
+  static TxAckPrevOutput_TxAckPrevOutputWrapper? _defaultInstance;
+
+  @$pb.TagNumber(3)
+  PrevOutput get output => $_getN(0);
+  @$pb.TagNumber(3)
+  set output(PrevOutput v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasOutput() => $_has(0);
+  @$pb.TagNumber(3)
+  void clearOutput() => clearField(3);
+  @$pb.TagNumber(3)
+  PrevOutput ensureOutput() => $_ensure(0);
+}
+
+/// *
+///  Request: Data about previous transaction output
+///  Wire-alias of TxAck.
+///
+///  Do not edit this type without considering compatibility with TxAck.
+///  Prefer to modify the inner PrevOutput type.
+///
+///  @next TxRequest
+class TxAckPrevOutput extends $pb.GeneratedMessage {
+  factory TxAckPrevOutput({
+    TxAckPrevOutput_TxAckPrevOutputWrapper? tx,
+  }) {
+    final $result = create();
+    if (tx != null) {
+      $result.tx = tx;
+    }
+    return $result;
+  }
+  TxAckPrevOutput._() : super();
+  factory TxAckPrevOutput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckPrevOutput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckPrevOutput', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQM<TxAckPrevOutput_TxAckPrevOutputWrapper>(1, _omitFieldNames ? '' : 'tx', subBuilder: TxAckPrevOutput_TxAckPrevOutputWrapper.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckPrevOutput clone() => TxAckPrevOutput()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckPrevOutput copyWith(void Function(TxAckPrevOutput) updates) => super.copyWith((message) => updates(message as TxAckPrevOutput)) as TxAckPrevOutput;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckPrevOutput create() => TxAckPrevOutput._();
+  TxAckPrevOutput createEmptyInstance() => create();
+  static $pb.PbList<TxAckPrevOutput> createRepeated() => $pb.PbList<TxAckPrevOutput>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckPrevOutput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckPrevOutput>(create);
+  static TxAckPrevOutput? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  TxAckPrevOutput_TxAckPrevOutputWrapper get tx => $_getN(0);
+  @$pb.TagNumber(1)
+  set tx(TxAckPrevOutput_TxAckPrevOutputWrapper v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTx() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTx() => clearField(1);
+  @$pb.TagNumber(1)
+  TxAckPrevOutput_TxAckPrevOutputWrapper ensureTx() => $_ensure(0);
+}
+
+class TxAckPrevExtraData_TxAckPrevExtraDataWrapper extends $pb.GeneratedMessage {
+  factory TxAckPrevExtraData_TxAckPrevExtraDataWrapper({
+    $core.List<$core.int>? extraDataChunk,
+  }) {
+    final $result = create();
+    if (extraDataChunk != null) {
+      $result.extraDataChunk = extraDataChunk;
+    }
+    return $result;
+  }
+  TxAckPrevExtraData_TxAckPrevExtraDataWrapper._() : super();
+  factory TxAckPrevExtraData_TxAckPrevExtraDataWrapper.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckPrevExtraData_TxAckPrevExtraDataWrapper.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckPrevExtraData.TxAckPrevExtraDataWrapper', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(8, _omitFieldNames ? '' : 'extraDataChunk', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckPrevExtraData_TxAckPrevExtraDataWrapper clone() => TxAckPrevExtraData_TxAckPrevExtraDataWrapper()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckPrevExtraData_TxAckPrevExtraDataWrapper copyWith(void Function(TxAckPrevExtraData_TxAckPrevExtraDataWrapper) updates) => super.copyWith((message) => updates(message as TxAckPrevExtraData_TxAckPrevExtraDataWrapper)) as TxAckPrevExtraData_TxAckPrevExtraDataWrapper;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckPrevExtraData_TxAckPrevExtraDataWrapper create() => TxAckPrevExtraData_TxAckPrevExtraDataWrapper._();
+  TxAckPrevExtraData_TxAckPrevExtraDataWrapper createEmptyInstance() => create();
+  static $pb.PbList<TxAckPrevExtraData_TxAckPrevExtraDataWrapper> createRepeated() => $pb.PbList<TxAckPrevExtraData_TxAckPrevExtraDataWrapper>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckPrevExtraData_TxAckPrevExtraDataWrapper getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckPrevExtraData_TxAckPrevExtraDataWrapper>(create);
+  static TxAckPrevExtraData_TxAckPrevExtraDataWrapper? _defaultInstance;
+
+  @$pb.TagNumber(8)
+  $core.List<$core.int> get extraDataChunk => $_getN(0);
+  @$pb.TagNumber(8)
+  set extraDataChunk($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasExtraDataChunk() => $_has(0);
+  @$pb.TagNumber(8)
+  void clearExtraDataChunk() => clearField(8);
+}
+
+/// *
+///  Request: Content of the extra data of a previous transaction
+///  Wire-alias of TxAck.
+///
+///  Do not edit this type without considering compatibility with TxAck.
+///
+///  @next TxRequest
+class TxAckPrevExtraData extends $pb.GeneratedMessage {
+  factory TxAckPrevExtraData({
+    TxAckPrevExtraData_TxAckPrevExtraDataWrapper? tx,
+  }) {
+    final $result = create();
+    if (tx != null) {
+      $result.tx = tx;
+    }
+    return $result;
+  }
+  TxAckPrevExtraData._() : super();
+  factory TxAckPrevExtraData.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxAckPrevExtraData.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TxAckPrevExtraData', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQM<TxAckPrevExtraData_TxAckPrevExtraDataWrapper>(1, _omitFieldNames ? '' : 'tx', subBuilder: TxAckPrevExtraData_TxAckPrevExtraDataWrapper.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TxAckPrevExtraData clone() => TxAckPrevExtraData()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TxAckPrevExtraData copyWith(void Function(TxAckPrevExtraData) updates) => super.copyWith((message) => updates(message as TxAckPrevExtraData)) as TxAckPrevExtraData;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TxAckPrevExtraData create() => TxAckPrevExtraData._();
+  TxAckPrevExtraData createEmptyInstance() => create();
+  static $pb.PbList<TxAckPrevExtraData> createRepeated() => $pb.PbList<TxAckPrevExtraData>();
+  @$core.pragma('dart2js:noInline')
+  static TxAckPrevExtraData getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxAckPrevExtraData>(create);
+  static TxAckPrevExtraData? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  TxAckPrevExtraData_TxAckPrevExtraDataWrapper get tx => $_getN(0);
+  @$pb.TagNumber(1)
+  set tx(TxAckPrevExtraData_TxAckPrevExtraDataWrapper v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTx() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTx() => clearField(1);
+  @$pb.TagNumber(1)
+  TxAckPrevExtraData_TxAckPrevExtraDataWrapper ensureTx() => $_ensure(0);
+}
+
+/// *
+///  Request: Ask device for a proof of ownership corresponding to address_n path
+///  @start
+///  @next OwnershipProof
+///  @next Failure
+class GetOwnershipProof extends $pb.GeneratedMessage {
+  factory GetOwnershipProof({
+    $core.Iterable<$core.int>? addressN,
+    $core.String? coinName,
+    InputScriptType? scriptType,
+    MultisigRedeemScriptType? multisig,
+    $core.bool? userConfirmation,
+    $core.Iterable<$core.List<$core.int>>? ownershipIds,
+    $core.List<$core.int>? commitmentData,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (coinName != null) {
+      $result.coinName = coinName;
+    }
+    if (scriptType != null) {
+      $result.scriptType = scriptType;
+    }
+    if (multisig != null) {
+      $result.multisig = multisig;
+    }
+    if (userConfirmation != null) {
+      $result.userConfirmation = userConfirmation;
+    }
+    if (ownershipIds != null) {
+      $result.ownershipIds.addAll(ownershipIds);
+    }
+    if (commitmentData != null) {
+      $result.commitmentData = commitmentData;
+    }
+    return $result;
+  }
+  GetOwnershipProof._() : super();
+  factory GetOwnershipProof.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetOwnershipProof.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetOwnershipProof', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.String>(2, _omitFieldNames ? '' : 'coinName', $pb.PbFieldType.OS, defaultOrMaker: 'Bitcoin')
+    ..e<InputScriptType>(3, _omitFieldNames ? '' : 'scriptType', $pb.PbFieldType.OE, defaultOrMaker: InputScriptType.SPENDWITNESS, valueOf: InputScriptType.valueOf, enumValues: InputScriptType.values)
+    ..aOM<MultisigRedeemScriptType>(4, _omitFieldNames ? '' : 'multisig', subBuilder: MultisigRedeemScriptType.create)
+    ..aOB(5, _omitFieldNames ? '' : 'userConfirmation')
+    ..p<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'ownershipIds', $pb.PbFieldType.PY)
+    ..a<$core.List<$core.int>>(7, _omitFieldNames ? '' : 'commitmentData', $pb.PbFieldType.OY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetOwnershipProof clone() => GetOwnershipProof()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetOwnershipProof copyWith(void Function(GetOwnershipProof) updates) => super.copyWith((message) => updates(message as GetOwnershipProof)) as GetOwnershipProof;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetOwnershipProof create() => GetOwnershipProof._();
+  GetOwnershipProof createEmptyInstance() => create();
+  static $pb.PbList<GetOwnershipProof> createRepeated() => $pb.PbList<GetOwnershipProof>();
+  @$core.pragma('dart2js:noInline')
+  static GetOwnershipProof getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetOwnershipProof>(create);
+  static GetOwnershipProof? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.String get coinName => $_getS(1, 'Bitcoin');
+  @$pb.TagNumber(2)
+  set coinName($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasCoinName() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCoinName() => clearField(2);
+
+  @$pb.TagNumber(3)
+  InputScriptType get scriptType => $_getN(2);
+  @$pb.TagNumber(3)
+  set scriptType(InputScriptType v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasScriptType() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearScriptType() => clearField(3);
+
+  @$pb.TagNumber(4)
+  MultisigRedeemScriptType get multisig => $_getN(3);
+  @$pb.TagNumber(4)
+  set multisig(MultisigRedeemScriptType v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasMultisig() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMultisig() => clearField(4);
+  @$pb.TagNumber(4)
+  MultisigRedeemScriptType ensureMultisig() => $_ensure(3);
+
+  @$pb.TagNumber(5)
+  $core.bool get userConfirmation => $_getBF(4);
+  @$pb.TagNumber(5)
+  set userConfirmation($core.bool v) { $_setBool(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasUserConfirmation() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearUserConfirmation() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.List<$core.int>> get ownershipIds => $_getList(5);
+
+  @$pb.TagNumber(7)
+  $core.List<$core.int> get commitmentData => $_getN(6);
+  @$pb.TagNumber(7)
+  set commitmentData($core.List<$core.int> v) { $_setBytes(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasCommitmentData() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearCommitmentData() => clearField(7);
+}
+
+/// *
+///  Response: Contains the proof of ownership
+///  @end
+class OwnershipProof extends $pb.GeneratedMessage {
+  factory OwnershipProof({
+    $core.List<$core.int>? ownershipProof,
+    $core.List<$core.int>? signature,
+  }) {
+    final $result = create();
+    if (ownershipProof != null) {
+      $result.ownershipProof = ownershipProof;
+    }
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    return $result;
+  }
+  OwnershipProof._() : super();
+  factory OwnershipProof.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory OwnershipProof.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'OwnershipProof', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'ownershipProof', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  OwnershipProof clone() => OwnershipProof()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  OwnershipProof copyWith(void Function(OwnershipProof) updates) => super.copyWith((message) => updates(message as OwnershipProof)) as OwnershipProof;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static OwnershipProof create() => OwnershipProof._();
+  OwnershipProof createEmptyInstance() => create();
+  static $pb.PbList<OwnershipProof> createRepeated() => $pb.PbList<OwnershipProof>();
+  @$core.pragma('dart2js:noInline')
+  static OwnershipProof getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OwnershipProof>(create);
+  static OwnershipProof? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get ownershipProof => $_getN(0);
+  @$pb.TagNumber(1)
+  set ownershipProof($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasOwnershipProof() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearOwnershipProof() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get signature => $_getN(1);
+  @$pb.TagNumber(2)
+  set signature($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSignature() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSignature() => clearField(2);
+}
+
+/// *
+///  Request: Ask device to prompt the user to authorize a CoinJoin transaction
+///  @start
+///  @next Success
+///  @next Failure
+class AuthorizeCoinJoin extends $pb.GeneratedMessage {
+  factory AuthorizeCoinJoin({
+    $core.String? coordinator,
+    $fixnum.Int64? maxRounds,
+    $core.int? maxCoordinatorFeeRate,
+    $core.int? maxFeePerKvbyte,
+    $core.Iterable<$core.int>? addressN,
+    $core.String? coinName,
+    InputScriptType? scriptType,
+    AmountUnit? amountUnit,
+  }) {
+    final $result = create();
+    if (coordinator != null) {
+      $result.coordinator = coordinator;
+    }
+    if (maxRounds != null) {
+      $result.maxRounds = maxRounds;
+    }
+    if (maxCoordinatorFeeRate != null) {
+      $result.maxCoordinatorFeeRate = maxCoordinatorFeeRate;
+    }
+    if (maxFeePerKvbyte != null) {
+      $result.maxFeePerKvbyte = maxFeePerKvbyte;
+    }
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (coinName != null) {
+      $result.coinName = coinName;
+    }
+    if (scriptType != null) {
+      $result.scriptType = scriptType;
+    }
+    if (amountUnit != null) {
+      $result.amountUnit = amountUnit;
+    }
+    return $result;
+  }
+  AuthorizeCoinJoin._() : super();
+  factory AuthorizeCoinJoin.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AuthorizeCoinJoin.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AuthorizeCoinJoin', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bitcoin'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'coordinator')
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'maxRounds', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'maxCoordinatorFeeRate', $pb.PbFieldType.QU3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'maxFeePerKvbyte', $pb.PbFieldType.QU3)
+    ..p<$core.int>(5, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.String>(6, _omitFieldNames ? '' : 'coinName', $pb.PbFieldType.OS, defaultOrMaker: 'Bitcoin')
+    ..e<InputScriptType>(7, _omitFieldNames ? '' : 'scriptType', $pb.PbFieldType.OE, defaultOrMaker: InputScriptType.SPENDADDRESS, valueOf: InputScriptType.valueOf, enumValues: InputScriptType.values)
+    ..e<AmountUnit>(8, _omitFieldNames ? '' : 'amountUnit', $pb.PbFieldType.OE, defaultOrMaker: AmountUnit.BITCOIN, valueOf: AmountUnit.valueOf, enumValues: AmountUnit.values)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  AuthorizeCoinJoin clone() => AuthorizeCoinJoin()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  AuthorizeCoinJoin copyWith(void Function(AuthorizeCoinJoin) updates) => super.copyWith((message) => updates(message as AuthorizeCoinJoin)) as AuthorizeCoinJoin;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static AuthorizeCoinJoin create() => AuthorizeCoinJoin._();
+  AuthorizeCoinJoin createEmptyInstance() => create();
+  static $pb.PbList<AuthorizeCoinJoin> createRepeated() => $pb.PbList<AuthorizeCoinJoin>();
+  @$core.pragma('dart2js:noInline')
+  static AuthorizeCoinJoin getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AuthorizeCoinJoin>(create);
+  static AuthorizeCoinJoin? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get coordinator => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set coordinator($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasCoordinator() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCoordinator() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get maxRounds => $_getI64(1);
+  @$pb.TagNumber(2)
+  set maxRounds($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMaxRounds() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMaxRounds() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get maxCoordinatorFeeRate => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set maxCoordinatorFeeRate($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasMaxCoordinatorFeeRate() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearMaxCoordinatorFeeRate() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get maxFeePerKvbyte => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set maxFeePerKvbyte($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasMaxFeePerKvbyte() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMaxFeePerKvbyte() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get addressN => $_getList(4);
+
+  @$pb.TagNumber(6)
+  $core.String get coinName => $_getS(5, 'Bitcoin');
+  @$pb.TagNumber(6)
+  set coinName($core.String v) { $_setString(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasCoinName() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearCoinName() => clearField(6);
+
+  @$pb.TagNumber(7)
+  InputScriptType get scriptType => $_getN(6);
+  @$pb.TagNumber(7)
+  set scriptType(InputScriptType v) { setField(7, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasScriptType() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearScriptType() => clearField(7);
+
+  @$pb.TagNumber(8)
+  AmountUnit get amountUnit => $_getN(7);
+  @$pb.TagNumber(8)
+  set amountUnit(AmountUnit v) { setField(8, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasAmountUnit() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearAmountUnit() => clearField(8);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bitcoin.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bitcoin.pbenum.dart
@@ -1,0 +1,136 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-bitcoin.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+/// *
+///  Type of script which will be used for transaction input
+class InputScriptType extends $pb.ProtobufEnum {
+  static const InputScriptType SPENDADDRESS = InputScriptType._(0, _omitEnumNames ? '' : 'SPENDADDRESS');
+  static const InputScriptType SPENDMULTISIG = InputScriptType._(1, _omitEnumNames ? '' : 'SPENDMULTISIG');
+  static const InputScriptType EXTERNAL = InputScriptType._(2, _omitEnumNames ? '' : 'EXTERNAL');
+  static const InputScriptType SPENDWITNESS = InputScriptType._(3, _omitEnumNames ? '' : 'SPENDWITNESS');
+  static const InputScriptType SPENDP2SHWITNESS = InputScriptType._(4, _omitEnumNames ? '' : 'SPENDP2SHWITNESS');
+  static const InputScriptType SPENDTAPROOT = InputScriptType._(5, _omitEnumNames ? '' : 'SPENDTAPROOT');
+
+  static const $core.List<InputScriptType> values = <InputScriptType> [
+    SPENDADDRESS,
+    SPENDMULTISIG,
+    EXTERNAL,
+    SPENDWITNESS,
+    SPENDP2SHWITNESS,
+    SPENDTAPROOT,
+  ];
+
+  static final $core.Map<$core.int, InputScriptType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static InputScriptType? valueOf($core.int value) => _byValue[value];
+
+  const InputScriptType._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Type of script which will be used for transaction output
+class OutputScriptType extends $pb.ProtobufEnum {
+  static const OutputScriptType PAYTOADDRESS = OutputScriptType._(0, _omitEnumNames ? '' : 'PAYTOADDRESS');
+  static const OutputScriptType PAYTOSCRIPTHASH = OutputScriptType._(1, _omitEnumNames ? '' : 'PAYTOSCRIPTHASH');
+  static const OutputScriptType PAYTOMULTISIG = OutputScriptType._(2, _omitEnumNames ? '' : 'PAYTOMULTISIG');
+  static const OutputScriptType PAYTOOPRETURN = OutputScriptType._(3, _omitEnumNames ? '' : 'PAYTOOPRETURN');
+  static const OutputScriptType PAYTOWITNESS = OutputScriptType._(4, _omitEnumNames ? '' : 'PAYTOWITNESS');
+  static const OutputScriptType PAYTOP2SHWITNESS = OutputScriptType._(5, _omitEnumNames ? '' : 'PAYTOP2SHWITNESS');
+  static const OutputScriptType PAYTOTAPROOT = OutputScriptType._(6, _omitEnumNames ? '' : 'PAYTOTAPROOT');
+
+  static const $core.List<OutputScriptType> values = <OutputScriptType> [
+    PAYTOADDRESS,
+    PAYTOSCRIPTHASH,
+    PAYTOMULTISIG,
+    PAYTOOPRETURN,
+    PAYTOWITNESS,
+    PAYTOP2SHWITNESS,
+    PAYTOTAPROOT,
+  ];
+
+  static final $core.Map<$core.int, OutputScriptType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static OutputScriptType? valueOf($core.int value) => _byValue[value];
+
+  const OutputScriptType._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Type of script which will be used for decred stake transaction input
+class DecredStakingSpendType extends $pb.ProtobufEnum {
+  static const DecredStakingSpendType SSGen = DecredStakingSpendType._(0, _omitEnumNames ? '' : 'SSGen');
+  static const DecredStakingSpendType SSRTX = DecredStakingSpendType._(1, _omitEnumNames ? '' : 'SSRTX');
+
+  static const $core.List<DecredStakingSpendType> values = <DecredStakingSpendType> [
+    SSGen,
+    SSRTX,
+  ];
+
+  static final $core.Map<$core.int, DecredStakingSpendType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static DecredStakingSpendType? valueOf($core.int value) => _byValue[value];
+
+  const DecredStakingSpendType._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Unit to be used when showing amounts on the display
+class AmountUnit extends $pb.ProtobufEnum {
+  static const AmountUnit BITCOIN = AmountUnit._(0, _omitEnumNames ? '' : 'BITCOIN');
+  static const AmountUnit MILLIBITCOIN = AmountUnit._(1, _omitEnumNames ? '' : 'MILLIBITCOIN');
+  static const AmountUnit MICROBITCOIN = AmountUnit._(2, _omitEnumNames ? '' : 'MICROBITCOIN');
+  static const AmountUnit SATOSHI = AmountUnit._(3, _omitEnumNames ? '' : 'SATOSHI');
+
+  static const $core.List<AmountUnit> values = <AmountUnit> [
+    BITCOIN,
+    MILLIBITCOIN,
+    MICROBITCOIN,
+    SATOSHI,
+  ];
+
+  static final $core.Map<$core.int, AmountUnit> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static AmountUnit? valueOf($core.int value) => _byValue[value];
+
+  const AmountUnit._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Type of information required by transaction signing process
+class TxRequest_RequestType extends $pb.ProtobufEnum {
+  static const TxRequest_RequestType TXINPUT = TxRequest_RequestType._(0, _omitEnumNames ? '' : 'TXINPUT');
+  static const TxRequest_RequestType TXOUTPUT = TxRequest_RequestType._(1, _omitEnumNames ? '' : 'TXOUTPUT');
+  static const TxRequest_RequestType TXMETA = TxRequest_RequestType._(2, _omitEnumNames ? '' : 'TXMETA');
+  static const TxRequest_RequestType TXFINISHED = TxRequest_RequestType._(3, _omitEnumNames ? '' : 'TXFINISHED');
+  static const TxRequest_RequestType TXEXTRADATA = TxRequest_RequestType._(4, _omitEnumNames ? '' : 'TXEXTRADATA');
+  static const TxRequest_RequestType TXORIGINPUT = TxRequest_RequestType._(5, _omitEnumNames ? '' : 'TXORIGINPUT');
+  static const TxRequest_RequestType TXORIGOUTPUT = TxRequest_RequestType._(6, _omitEnumNames ? '' : 'TXORIGOUTPUT');
+  static const TxRequest_RequestType TXPAYMENTREQ = TxRequest_RequestType._(7, _omitEnumNames ? '' : 'TXPAYMENTREQ');
+
+  static const $core.List<TxRequest_RequestType> values = <TxRequest_RequestType> [
+    TXINPUT,
+    TXOUTPUT,
+    TXMETA,
+    TXFINISHED,
+    TXEXTRADATA,
+    TXORIGINPUT,
+    TXORIGOUTPUT,
+    TXPAYMENTREQ,
+  ];
+
+  static final $core.Map<$core.int, TxRequest_RequestType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static TxRequest_RequestType? valueOf($core.int value) => _byValue[value];
+
+  const TxRequest_RequestType._($core.int v, $core.String n) : super(v, n);
+}
+
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bitcoin.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bitcoin.pbjson.dart
@@ -1,0 +1,965 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-bitcoin.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use inputScriptTypeDescriptor instead')
+const InputScriptType$json = {
+  '1': 'InputScriptType',
+  '2': [
+    {'1': 'SPENDADDRESS', '2': 0},
+    {'1': 'SPENDMULTISIG', '2': 1},
+    {'1': 'EXTERNAL', '2': 2},
+    {'1': 'SPENDWITNESS', '2': 3},
+    {'1': 'SPENDP2SHWITNESS', '2': 4},
+    {'1': 'SPENDTAPROOT', '2': 5},
+  ],
+};
+
+/// Descriptor for `InputScriptType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List inputScriptTypeDescriptor = $convert.base64Decode(
+    'Cg9JbnB1dFNjcmlwdFR5cGUSEAoMU1BFTkRBRERSRVNTEAASEQoNU1BFTkRNVUxUSVNJRxABEg'
+    'wKCEVYVEVSTkFMEAISEAoMU1BFTkRXSVRORVNTEAMSFAoQU1BFTkRQMlNIV0lUTkVTUxAEEhAK'
+    'DFNQRU5EVEFQUk9PVBAF');
+
+@$core.Deprecated('Use outputScriptTypeDescriptor instead')
+const OutputScriptType$json = {
+  '1': 'OutputScriptType',
+  '2': [
+    {'1': 'PAYTOADDRESS', '2': 0},
+    {'1': 'PAYTOSCRIPTHASH', '2': 1},
+    {'1': 'PAYTOMULTISIG', '2': 2},
+    {'1': 'PAYTOOPRETURN', '2': 3},
+    {'1': 'PAYTOWITNESS', '2': 4},
+    {'1': 'PAYTOP2SHWITNESS', '2': 5},
+    {'1': 'PAYTOTAPROOT', '2': 6},
+  ],
+};
+
+/// Descriptor for `OutputScriptType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List outputScriptTypeDescriptor = $convert.base64Decode(
+    'ChBPdXRwdXRTY3JpcHRUeXBlEhAKDFBBWVRPQUREUkVTUxAAEhMKD1BBWVRPU0NSSVBUSEFTSB'
+    'ABEhEKDVBBWVRPTVVMVElTSUcQAhIRCg1QQVlUT09QUkVUVVJOEAMSEAoMUEFZVE9XSVRORVNT'
+    'EAQSFAoQUEFZVE9QMlNIV0lUTkVTUxAFEhAKDFBBWVRPVEFQUk9PVBAG');
+
+@$core.Deprecated('Use decredStakingSpendTypeDescriptor instead')
+const DecredStakingSpendType$json = {
+  '1': 'DecredStakingSpendType',
+  '2': [
+    {'1': 'SSGen', '2': 0},
+    {'1': 'SSRTX', '2': 1},
+  ],
+};
+
+/// Descriptor for `DecredStakingSpendType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List decredStakingSpendTypeDescriptor = $convert.base64Decode(
+    'ChZEZWNyZWRTdGFraW5nU3BlbmRUeXBlEgkKBVNTR2VuEAASCQoFU1NSVFgQAQ==');
+
+@$core.Deprecated('Use amountUnitDescriptor instead')
+const AmountUnit$json = {
+  '1': 'AmountUnit',
+  '2': [
+    {'1': 'BITCOIN', '2': 0},
+    {'1': 'MILLIBITCOIN', '2': 1},
+    {'1': 'MICROBITCOIN', '2': 2},
+    {'1': 'SATOSHI', '2': 3},
+  ],
+};
+
+/// Descriptor for `AmountUnit`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List amountUnitDescriptor = $convert.base64Decode(
+    'CgpBbW91bnRVbml0EgsKB0JJVENPSU4QABIQCgxNSUxMSUJJVENPSU4QARIQCgxNSUNST0JJVE'
+    'NPSU4QAhILCgdTQVRPU0hJEAM=');
+
+@$core.Deprecated('Use multisigRedeemScriptTypeDescriptor instead')
+const MultisigRedeemScriptType$json = {
+  '1': 'MultisigRedeemScriptType',
+  '2': [
+    {'1': 'pubkeys', '3': 1, '4': 3, '5': 11, '6': '.hw.trezor.messages.bitcoin.MultisigRedeemScriptType.HDNodePathType', '10': 'pubkeys'},
+    {'1': 'signatures', '3': 2, '4': 3, '5': 12, '10': 'signatures'},
+    {'1': 'm', '3': 3, '4': 2, '5': 13, '10': 'm'},
+    {'1': 'nodes', '3': 4, '4': 3, '5': 11, '6': '.hw.trezor.messages.common.HDNodeType', '10': 'nodes'},
+    {'1': 'address_n', '3': 5, '4': 3, '5': 13, '10': 'addressN'},
+  ],
+  '3': [MultisigRedeemScriptType_HDNodePathType$json],
+};
+
+@$core.Deprecated('Use multisigRedeemScriptTypeDescriptor instead')
+const MultisigRedeemScriptType_HDNodePathType$json = {
+  '1': 'HDNodePathType',
+  '2': [
+    {'1': 'node', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.common.HDNodeType', '10': 'node'},
+    {'1': 'address_n', '3': 2, '4': 3, '5': 13, '10': 'addressN'},
+  ],
+};
+
+/// Descriptor for `MultisigRedeemScriptType`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List multisigRedeemScriptTypeDescriptor = $convert.base64Decode(
+    'ChhNdWx0aXNpZ1JlZGVlbVNjcmlwdFR5cGUSXQoHcHVia2V5cxgBIAMoCzJDLmh3LnRyZXpvci'
+    '5tZXNzYWdlcy5iaXRjb2luLk11bHRpc2lnUmVkZWVtU2NyaXB0VHlwZS5IRE5vZGVQYXRoVHlw'
+    'ZVIHcHVia2V5cxIeCgpzaWduYXR1cmVzGAIgAygMUgpzaWduYXR1cmVzEgwKAW0YAyACKA1SAW'
+    '0SOwoFbm9kZXMYBCADKAsyJS5ody50cmV6b3IubWVzc2FnZXMuY29tbW9uLkhETm9kZVR5cGVS'
+    'BW5vZGVzEhsKCWFkZHJlc3NfbhgFIAMoDVIIYWRkcmVzc04aaAoOSEROb2RlUGF0aFR5cGUSOQ'
+    'oEbm9kZRgBIAIoCzIlLmh3LnRyZXpvci5tZXNzYWdlcy5jb21tb24uSEROb2RlVHlwZVIEbm9k'
+    'ZRIbCglhZGRyZXNzX24YAiADKA1SCGFkZHJlc3NO');
+
+@$core.Deprecated('Use getPublicKeyDescriptor instead')
+const GetPublicKey$json = {
+  '1': 'GetPublicKey',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'ecdsa_curve_name', '3': 2, '4': 1, '5': 9, '10': 'ecdsaCurveName'},
+    {'1': 'show_display', '3': 3, '4': 1, '5': 8, '10': 'showDisplay'},
+    {'1': 'coin_name', '3': 4, '4': 1, '5': 9, '7': 'Bitcoin', '10': 'coinName'},
+    {'1': 'script_type', '3': 5, '4': 1, '5': 14, '6': '.hw.trezor.messages.bitcoin.InputScriptType', '7': 'SPENDADDRESS', '10': 'scriptType'},
+    {'1': 'ignore_xpub_magic', '3': 6, '4': 1, '5': 8, '10': 'ignoreXpubMagic'},
+  ],
+};
+
+/// Descriptor for `GetPublicKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getPublicKeyDescriptor = $convert.base64Decode(
+    'CgxHZXRQdWJsaWNLZXkSGwoJYWRkcmVzc19uGAEgAygNUghhZGRyZXNzThIoChBlY2RzYV9jdX'
+    'J2ZV9uYW1lGAIgASgJUg5lY2RzYUN1cnZlTmFtZRIhCgxzaG93X2Rpc3BsYXkYAyABKAhSC3No'
+    'b3dEaXNwbGF5EiQKCWNvaW5fbmFtZRgEIAEoCToHQml0Y29pblIIY29pbk5hbWUSWgoLc2NyaX'
+    'B0X3R5cGUYBSABKA4yKy5ody50cmV6b3IubWVzc2FnZXMuYml0Y29pbi5JbnB1dFNjcmlwdFR5'
+    'cGU6DFNQRU5EQUREUkVTU1IKc2NyaXB0VHlwZRIqChFpZ25vcmVfeHB1Yl9tYWdpYxgGIAEoCF'
+    'IPaWdub3JlWHB1Yk1hZ2lj');
+
+@$core.Deprecated('Use publicKeyDescriptor instead')
+const PublicKey$json = {
+  '1': 'PublicKey',
+  '2': [
+    {'1': 'node', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.common.HDNodeType', '10': 'node'},
+    {'1': 'xpub', '3': 2, '4': 2, '5': 9, '10': 'xpub'},
+    {'1': 'root_fingerprint', '3': 3, '4': 1, '5': 13, '10': 'rootFingerprint'},
+    {'1': 'descriptor', '3': 4, '4': 1, '5': 9, '10': 'descriptor'},
+  ],
+};
+
+/// Descriptor for `PublicKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List publicKeyDescriptor = $convert.base64Decode(
+    'CglQdWJsaWNLZXkSOQoEbm9kZRgBIAIoCzIlLmh3LnRyZXpvci5tZXNzYWdlcy5jb21tb24uSE'
+    'ROb2RlVHlwZVIEbm9kZRISCgR4cHViGAIgAigJUgR4cHViEikKEHJvb3RfZmluZ2VycHJpbnQY'
+    'AyABKA1SD3Jvb3RGaW5nZXJwcmludBIeCgpkZXNjcmlwdG9yGAQgASgJUgpkZXNjcmlwdG9y');
+
+@$core.Deprecated('Use getAddressDescriptor instead')
+const GetAddress$json = {
+  '1': 'GetAddress',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'coin_name', '3': 2, '4': 1, '5': 9, '7': 'Bitcoin', '10': 'coinName'},
+    {'1': 'show_display', '3': 3, '4': 1, '5': 8, '10': 'showDisplay'},
+    {'1': 'multisig', '3': 4, '4': 1, '5': 11, '6': '.hw.trezor.messages.bitcoin.MultisigRedeemScriptType', '10': 'multisig'},
+    {'1': 'script_type', '3': 5, '4': 1, '5': 14, '6': '.hw.trezor.messages.bitcoin.InputScriptType', '7': 'SPENDADDRESS', '10': 'scriptType'},
+    {'1': 'ignore_xpub_magic', '3': 6, '4': 1, '5': 8, '10': 'ignoreXpubMagic'},
+    {'1': 'chunkify', '3': 7, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `GetAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getAddressDescriptor = $convert.base64Decode(
+    'CgpHZXRBZGRyZXNzEhsKCWFkZHJlc3NfbhgBIAMoDVIIYWRkcmVzc04SJAoJY29pbl9uYW1lGA'
+    'IgASgJOgdCaXRjb2luUghjb2luTmFtZRIhCgxzaG93X2Rpc3BsYXkYAyABKAhSC3Nob3dEaXNw'
+    'bGF5ElAKCG11bHRpc2lnGAQgASgLMjQuaHcudHJlem9yLm1lc3NhZ2VzLmJpdGNvaW4uTXVsdG'
+    'lzaWdSZWRlZW1TY3JpcHRUeXBlUghtdWx0aXNpZxJaCgtzY3JpcHRfdHlwZRgFIAEoDjIrLmh3'
+    'LnRyZXpvci5tZXNzYWdlcy5iaXRjb2luLklucHV0U2NyaXB0VHlwZToMU1BFTkRBRERSRVNTUg'
+    'pzY3JpcHRUeXBlEioKEWlnbm9yZV94cHViX21hZ2ljGAYgASgIUg9pZ25vcmVYcHViTWFnaWMS'
+    'GgoIY2h1bmtpZnkYByABKAhSCGNodW5raWZ5');
+
+@$core.Deprecated('Use addressDescriptor instead')
+const Address$json = {
+  '1': 'Address',
+  '2': [
+    {'1': 'address', '3': 1, '4': 2, '5': 9, '10': 'address'},
+    {'1': 'mac', '3': 2, '4': 1, '5': 12, '10': 'mac'},
+  ],
+};
+
+/// Descriptor for `Address`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List addressDescriptor = $convert.base64Decode(
+    'CgdBZGRyZXNzEhgKB2FkZHJlc3MYASACKAlSB2FkZHJlc3MSEAoDbWFjGAIgASgMUgNtYWM=');
+
+@$core.Deprecated('Use getOwnershipIdDescriptor instead')
+const GetOwnershipId$json = {
+  '1': 'GetOwnershipId',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'coin_name', '3': 2, '4': 1, '5': 9, '7': 'Bitcoin', '10': 'coinName'},
+    {'1': 'multisig', '3': 3, '4': 1, '5': 11, '6': '.hw.trezor.messages.bitcoin.MultisigRedeemScriptType', '10': 'multisig'},
+    {'1': 'script_type', '3': 4, '4': 1, '5': 14, '6': '.hw.trezor.messages.bitcoin.InputScriptType', '7': 'SPENDADDRESS', '10': 'scriptType'},
+  ],
+};
+
+/// Descriptor for `GetOwnershipId`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getOwnershipIdDescriptor = $convert.base64Decode(
+    'Cg5HZXRPd25lcnNoaXBJZBIbCglhZGRyZXNzX24YASADKA1SCGFkZHJlc3NOEiQKCWNvaW5fbm'
+    'FtZRgCIAEoCToHQml0Y29pblIIY29pbk5hbWUSUAoIbXVsdGlzaWcYAyABKAsyNC5ody50cmV6'
+    'b3IubWVzc2FnZXMuYml0Y29pbi5NdWx0aXNpZ1JlZGVlbVNjcmlwdFR5cGVSCG11bHRpc2lnEl'
+    'oKC3NjcmlwdF90eXBlGAQgASgOMisuaHcudHJlem9yLm1lc3NhZ2VzLmJpdGNvaW4uSW5wdXRT'
+    'Y3JpcHRUeXBlOgxTUEVOREFERFJFU1NSCnNjcmlwdFR5cGU=');
+
+@$core.Deprecated('Use ownershipIdDescriptor instead')
+const OwnershipId$json = {
+  '1': 'OwnershipId',
+  '2': [
+    {'1': 'ownership_id', '3': 1, '4': 2, '5': 12, '10': 'ownershipId'},
+  ],
+};
+
+/// Descriptor for `OwnershipId`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ownershipIdDescriptor = $convert.base64Decode(
+    'CgtPd25lcnNoaXBJZBIhCgxvd25lcnNoaXBfaWQYASACKAxSC293bmVyc2hpcElk');
+
+@$core.Deprecated('Use signMessageDescriptor instead')
+const SignMessage$json = {
+  '1': 'SignMessage',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'message', '3': 2, '4': 2, '5': 12, '10': 'message'},
+    {'1': 'coin_name', '3': 3, '4': 1, '5': 9, '7': 'Bitcoin', '10': 'coinName'},
+    {'1': 'script_type', '3': 4, '4': 1, '5': 14, '6': '.hw.trezor.messages.bitcoin.InputScriptType', '7': 'SPENDADDRESS', '10': 'scriptType'},
+    {'1': 'no_script_type', '3': 5, '4': 1, '5': 8, '10': 'noScriptType'},
+    {'1': 'chunkify', '3': 6, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `SignMessage`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List signMessageDescriptor = $convert.base64Decode(
+    'CgtTaWduTWVzc2FnZRIbCglhZGRyZXNzX24YASADKA1SCGFkZHJlc3NOEhgKB21lc3NhZ2UYAi'
+    'ACKAxSB21lc3NhZ2USJAoJY29pbl9uYW1lGAMgASgJOgdCaXRjb2luUghjb2luTmFtZRJaCgtz'
+    'Y3JpcHRfdHlwZRgEIAEoDjIrLmh3LnRyZXpvci5tZXNzYWdlcy5iaXRjb2luLklucHV0U2NyaX'
+    'B0VHlwZToMU1BFTkRBRERSRVNTUgpzY3JpcHRUeXBlEiQKDm5vX3NjcmlwdF90eXBlGAUgASgI'
+    'Ugxub1NjcmlwdFR5cGUSGgoIY2h1bmtpZnkYBiABKAhSCGNodW5raWZ5');
+
+@$core.Deprecated('Use messageSignatureDescriptor instead')
+const MessageSignature$json = {
+  '1': 'MessageSignature',
+  '2': [
+    {'1': 'address', '3': 1, '4': 2, '5': 9, '10': 'address'},
+    {'1': 'signature', '3': 2, '4': 2, '5': 12, '10': 'signature'},
+  ],
+};
+
+/// Descriptor for `MessageSignature`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List messageSignatureDescriptor = $convert.base64Decode(
+    'ChBNZXNzYWdlU2lnbmF0dXJlEhgKB2FkZHJlc3MYASACKAlSB2FkZHJlc3MSHAoJc2lnbmF0dX'
+    'JlGAIgAigMUglzaWduYXR1cmU=');
+
+@$core.Deprecated('Use verifyMessageDescriptor instead')
+const VerifyMessage$json = {
+  '1': 'VerifyMessage',
+  '2': [
+    {'1': 'address', '3': 1, '4': 2, '5': 9, '10': 'address'},
+    {'1': 'signature', '3': 2, '4': 2, '5': 12, '10': 'signature'},
+    {'1': 'message', '3': 3, '4': 2, '5': 12, '10': 'message'},
+    {'1': 'coin_name', '3': 4, '4': 1, '5': 9, '7': 'Bitcoin', '10': 'coinName'},
+    {'1': 'chunkify', '3': 5, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `VerifyMessage`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List verifyMessageDescriptor = $convert.base64Decode(
+    'Cg1WZXJpZnlNZXNzYWdlEhgKB2FkZHJlc3MYASACKAlSB2FkZHJlc3MSHAoJc2lnbmF0dXJlGA'
+    'IgAigMUglzaWduYXR1cmUSGAoHbWVzc2FnZRgDIAIoDFIHbWVzc2FnZRIkCgljb2luX25hbWUY'
+    'BCABKAk6B0JpdGNvaW5SCGNvaW5OYW1lEhoKCGNodW5raWZ5GAUgASgIUghjaHVua2lmeQ==');
+
+@$core.Deprecated('Use signTxDescriptor instead')
+const SignTx$json = {
+  '1': 'SignTx',
+  '2': [
+    {'1': 'outputs_count', '3': 1, '4': 2, '5': 13, '10': 'outputsCount'},
+    {'1': 'inputs_count', '3': 2, '4': 2, '5': 13, '10': 'inputsCount'},
+    {'1': 'coin_name', '3': 3, '4': 1, '5': 9, '7': 'Bitcoin', '10': 'coinName'},
+    {'1': 'version', '3': 4, '4': 1, '5': 13, '7': '1', '10': 'version'},
+    {'1': 'lock_time', '3': 5, '4': 1, '5': 13, '7': '0', '10': 'lockTime'},
+    {'1': 'expiry', '3': 6, '4': 1, '5': 13, '10': 'expiry'},
+    {
+      '1': 'overwintered',
+      '3': 7,
+      '4': 1,
+      '5': 8,
+      '8': {'3': true},
+      '10': 'overwintered',
+    },
+    {'1': 'version_group_id', '3': 8, '4': 1, '5': 13, '10': 'versionGroupId'},
+    {'1': 'timestamp', '3': 9, '4': 1, '5': 13, '10': 'timestamp'},
+    {'1': 'branch_id', '3': 10, '4': 1, '5': 13, '10': 'branchId'},
+    {'1': 'amount_unit', '3': 11, '4': 1, '5': 14, '6': '.hw.trezor.messages.bitcoin.AmountUnit', '7': 'BITCOIN', '10': 'amountUnit'},
+    {'1': 'decred_staking_ticket', '3': 12, '4': 1, '5': 8, '7': 'false', '10': 'decredStakingTicket'},
+    {'1': 'serialize', '3': 13, '4': 1, '5': 8, '7': 'true', '10': 'serialize'},
+    {'1': 'coinjoin_request', '3': 14, '4': 1, '5': 11, '6': '.hw.trezor.messages.bitcoin.SignTx.CoinJoinRequest', '10': 'coinjoinRequest'},
+    {'1': 'chunkify', '3': 15, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+  '3': [SignTx_CoinJoinRequest$json],
+};
+
+@$core.Deprecated('Use signTxDescriptor instead')
+const SignTx_CoinJoinRequest$json = {
+  '1': 'CoinJoinRequest',
+  '2': [
+    {'1': 'fee_rate', '3': 1, '4': 2, '5': 13, '10': 'feeRate'},
+    {'1': 'no_fee_threshold', '3': 2, '4': 2, '5': 4, '10': 'noFeeThreshold'},
+    {'1': 'min_registrable_amount', '3': 3, '4': 2, '5': 4, '10': 'minRegistrableAmount'},
+    {'1': 'mask_public_key', '3': 4, '4': 2, '5': 12, '10': 'maskPublicKey'},
+    {'1': 'signature', '3': 5, '4': 2, '5': 12, '10': 'signature'},
+  ],
+};
+
+/// Descriptor for `SignTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List signTxDescriptor = $convert.base64Decode(
+    'CgZTaWduVHgSIwoNb3V0cHV0c19jb3VudBgBIAIoDVIMb3V0cHV0c0NvdW50EiEKDGlucHV0c1'
+    '9jb3VudBgCIAIoDVILaW5wdXRzQ291bnQSJAoJY29pbl9uYW1lGAMgASgJOgdCaXRjb2luUghj'
+    'b2luTmFtZRIbCgd2ZXJzaW9uGAQgASgNOgExUgd2ZXJzaW9uEh4KCWxvY2tfdGltZRgFIAEoDT'
+    'oBMFIIbG9ja1RpbWUSFgoGZXhwaXJ5GAYgASgNUgZleHBpcnkSJgoMb3ZlcndpbnRlcmVkGAcg'
+    'ASgIQgIYAVIMb3ZlcndpbnRlcmVkEigKEHZlcnNpb25fZ3JvdXBfaWQYCCABKA1SDnZlcnNpb2'
+    '5Hcm91cElkEhwKCXRpbWVzdGFtcBgJIAEoDVIJdGltZXN0YW1wEhsKCWJyYW5jaF9pZBgKIAEo'
+    'DVIIYnJhbmNoSWQSUAoLYW1vdW50X3VuaXQYCyABKA4yJi5ody50cmV6b3IubWVzc2FnZXMuYm'
+    'l0Y29pbi5BbW91bnRVbml0OgdCSVRDT0lOUgphbW91bnRVbml0EjkKFWRlY3JlZF9zdGFraW5n'
+    'X3RpY2tldBgMIAEoCDoFZmFsc2VSE2RlY3JlZFN0YWtpbmdUaWNrZXQSIgoJc2VyaWFsaXplGA'
+    '0gASgIOgR0cnVlUglzZXJpYWxpemUSXQoQY29pbmpvaW5fcmVxdWVzdBgOIAEoCzIyLmh3LnRy'
+    'ZXpvci5tZXNzYWdlcy5iaXRjb2luLlNpZ25UeC5Db2luSm9pblJlcXVlc3RSD2NvaW5qb2luUm'
+    'VxdWVzdBIaCghjaHVua2lmeRgPIAEoCFIIY2h1bmtpZnka0gEKD0NvaW5Kb2luUmVxdWVzdBIZ'
+    'CghmZWVfcmF0ZRgBIAIoDVIHZmVlUmF0ZRIoChBub19mZWVfdGhyZXNob2xkGAIgAigEUg5ub0'
+    'ZlZVRocmVzaG9sZBI0ChZtaW5fcmVnaXN0cmFibGVfYW1vdW50GAMgAigEUhRtaW5SZWdpc3Ry'
+    'YWJsZUFtb3VudBImCg9tYXNrX3B1YmxpY19rZXkYBCACKAxSDW1hc2tQdWJsaWNLZXkSHAoJc2'
+    'lnbmF0dXJlGAUgAigMUglzaWduYXR1cmU=');
+
+@$core.Deprecated('Use txRequestDescriptor instead')
+const TxRequest$json = {
+  '1': 'TxRequest',
+  '2': [
+    {'1': 'request_type', '3': 1, '4': 1, '5': 14, '6': '.hw.trezor.messages.bitcoin.TxRequest.RequestType', '10': 'requestType'},
+    {'1': 'details', '3': 2, '4': 1, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxRequest.TxRequestDetailsType', '10': 'details'},
+    {'1': 'serialized', '3': 3, '4': 1, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxRequest.TxRequestSerializedType', '10': 'serialized'},
+  ],
+  '3': [TxRequest_TxRequestDetailsType$json, TxRequest_TxRequestSerializedType$json],
+  '4': [TxRequest_RequestType$json],
+};
+
+@$core.Deprecated('Use txRequestDescriptor instead')
+const TxRequest_TxRequestDetailsType$json = {
+  '1': 'TxRequestDetailsType',
+  '2': [
+    {'1': 'request_index', '3': 1, '4': 1, '5': 13, '10': 'requestIndex'},
+    {'1': 'tx_hash', '3': 2, '4': 1, '5': 12, '10': 'txHash'},
+    {'1': 'extra_data_len', '3': 3, '4': 1, '5': 13, '10': 'extraDataLen'},
+    {'1': 'extra_data_offset', '3': 4, '4': 1, '5': 13, '10': 'extraDataOffset'},
+  ],
+};
+
+@$core.Deprecated('Use txRequestDescriptor instead')
+const TxRequest_TxRequestSerializedType$json = {
+  '1': 'TxRequestSerializedType',
+  '2': [
+    {'1': 'signature_index', '3': 1, '4': 1, '5': 13, '10': 'signatureIndex'},
+    {'1': 'signature', '3': 2, '4': 1, '5': 12, '10': 'signature'},
+    {'1': 'serialized_tx', '3': 3, '4': 1, '5': 12, '10': 'serializedTx'},
+  ],
+};
+
+@$core.Deprecated('Use txRequestDescriptor instead')
+const TxRequest_RequestType$json = {
+  '1': 'RequestType',
+  '2': [
+    {'1': 'TXINPUT', '2': 0},
+    {'1': 'TXOUTPUT', '2': 1},
+    {'1': 'TXMETA', '2': 2},
+    {'1': 'TXFINISHED', '2': 3},
+    {'1': 'TXEXTRADATA', '2': 4},
+    {'1': 'TXORIGINPUT', '2': 5},
+    {'1': 'TXORIGOUTPUT', '2': 6},
+    {'1': 'TXPAYMENTREQ', '2': 7},
+  ],
+};
+
+/// Descriptor for `TxRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List txRequestDescriptor = $convert.base64Decode(
+    'CglUeFJlcXVlc3QSVAoMcmVxdWVzdF90eXBlGAEgASgOMjEuaHcudHJlem9yLm1lc3NhZ2VzLm'
+    'JpdGNvaW4uVHhSZXF1ZXN0LlJlcXVlc3RUeXBlUgtyZXF1ZXN0VHlwZRJUCgdkZXRhaWxzGAIg'
+    'ASgLMjouaHcudHJlem9yLm1lc3NhZ2VzLmJpdGNvaW4uVHhSZXF1ZXN0LlR4UmVxdWVzdERldG'
+    'FpbHNUeXBlUgdkZXRhaWxzEl0KCnNlcmlhbGl6ZWQYAyABKAsyPS5ody50cmV6b3IubWVzc2Fn'
+    'ZXMuYml0Y29pbi5UeFJlcXVlc3QuVHhSZXF1ZXN0U2VyaWFsaXplZFR5cGVSCnNlcmlhbGl6ZW'
+    'QapgEKFFR4UmVxdWVzdERldGFpbHNUeXBlEiMKDXJlcXVlc3RfaW5kZXgYASABKA1SDHJlcXVl'
+    'c3RJbmRleBIXCgd0eF9oYXNoGAIgASgMUgZ0eEhhc2gSJAoOZXh0cmFfZGF0YV9sZW4YAyABKA'
+    '1SDGV4dHJhRGF0YUxlbhIqChFleHRyYV9kYXRhX29mZnNldBgEIAEoDVIPZXh0cmFEYXRhT2Zm'
+    'c2V0GoUBChdUeFJlcXVlc3RTZXJpYWxpemVkVHlwZRInCg9zaWduYXR1cmVfaW5kZXgYASABKA'
+    '1SDnNpZ25hdHVyZUluZGV4EhwKCXNpZ25hdHVyZRgCIAEoDFIJc2lnbmF0dXJlEiMKDXNlcmlh'
+    'bGl6ZWRfdHgYAyABKAxSDHNlcmlhbGl6ZWRUeCKKAQoLUmVxdWVzdFR5cGUSCwoHVFhJTlBVVB'
+    'AAEgwKCFRYT1VUUFVUEAESCgoGVFhNRVRBEAISDgoKVFhGSU5JU0hFRBADEg8KC1RYRVhUUkFE'
+    'QVRBEAQSDwoLVFhPUklHSU5QVVQQBRIQCgxUWE9SSUdPVVRQVVQQBhIQCgxUWFBBWU1FTlRSRV'
+    'EQBw==');
+
+@$core.Deprecated('Use txAckDescriptor instead')
+const TxAck$json = {
+  '1': 'TxAck',
+  '2': [
+    {'1': 'tx', '3': 1, '4': 1, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxAck.TransactionType', '10': 'tx'},
+  ],
+  '3': [TxAck_TransactionType$json],
+  '7': {'3': true},
+};
+
+@$core.Deprecated('Use txAckDescriptor instead')
+const TxAck_TransactionType$json = {
+  '1': 'TransactionType',
+  '2': [
+    {'1': 'version', '3': 1, '4': 1, '5': 13, '10': 'version'},
+    {'1': 'inputs', '3': 2, '4': 3, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxAck.TransactionType.TxInputType', '10': 'inputs'},
+    {'1': 'bin_outputs', '3': 3, '4': 3, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxAck.TransactionType.TxOutputBinType', '10': 'binOutputs'},
+    {'1': 'lock_time', '3': 4, '4': 1, '5': 13, '10': 'lockTime'},
+    {'1': 'outputs', '3': 5, '4': 3, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxAck.TransactionType.TxOutputType', '10': 'outputs'},
+    {'1': 'inputs_cnt', '3': 6, '4': 1, '5': 13, '10': 'inputsCnt'},
+    {'1': 'outputs_cnt', '3': 7, '4': 1, '5': 13, '10': 'outputsCnt'},
+    {'1': 'extra_data', '3': 8, '4': 1, '5': 12, '10': 'extraData'},
+    {'1': 'extra_data_len', '3': 9, '4': 1, '5': 13, '10': 'extraDataLen'},
+    {'1': 'expiry', '3': 10, '4': 1, '5': 13, '10': 'expiry'},
+    {
+      '1': 'overwintered',
+      '3': 11,
+      '4': 1,
+      '5': 8,
+      '8': {'3': true},
+      '10': 'overwintered',
+    },
+    {'1': 'version_group_id', '3': 12, '4': 1, '5': 13, '10': 'versionGroupId'},
+    {'1': 'timestamp', '3': 13, '4': 1, '5': 13, '10': 'timestamp'},
+    {'1': 'branch_id', '3': 14, '4': 1, '5': 13, '10': 'branchId'},
+  ],
+  '3': [TxAck_TransactionType_TxInputType$json, TxAck_TransactionType_TxOutputBinType$json, TxAck_TransactionType_TxOutputType$json],
+};
+
+@$core.Deprecated('Use txAckDescriptor instead')
+const TxAck_TransactionType_TxInputType$json = {
+  '1': 'TxInputType',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'prev_hash', '3': 2, '4': 2, '5': 12, '10': 'prevHash'},
+    {'1': 'prev_index', '3': 3, '4': 2, '5': 13, '10': 'prevIndex'},
+    {'1': 'script_sig', '3': 4, '4': 1, '5': 12, '10': 'scriptSig'},
+    {'1': 'sequence', '3': 5, '4': 1, '5': 13, '7': '4294967295', '10': 'sequence'},
+    {'1': 'script_type', '3': 6, '4': 1, '5': 14, '6': '.hw.trezor.messages.bitcoin.InputScriptType', '7': 'SPENDADDRESS', '10': 'scriptType'},
+    {'1': 'multisig', '3': 7, '4': 1, '5': 11, '6': '.hw.trezor.messages.bitcoin.MultisigRedeemScriptType', '10': 'multisig'},
+    {'1': 'amount', '3': 8, '4': 1, '5': 4, '10': 'amount'},
+    {'1': 'decred_tree', '3': 9, '4': 1, '5': 13, '10': 'decredTree'},
+    {'1': 'witness', '3': 13, '4': 1, '5': 12, '10': 'witness'},
+    {'1': 'ownership_proof', '3': 14, '4': 1, '5': 12, '10': 'ownershipProof'},
+    {'1': 'commitment_data', '3': 15, '4': 1, '5': 12, '10': 'commitmentData'},
+    {'1': 'orig_hash', '3': 16, '4': 1, '5': 12, '10': 'origHash'},
+    {'1': 'orig_index', '3': 17, '4': 1, '5': 13, '10': 'origIndex'},
+    {'1': 'decred_staking_spend', '3': 18, '4': 1, '5': 14, '6': '.hw.trezor.messages.bitcoin.DecredStakingSpendType', '10': 'decredStakingSpend'},
+    {'1': 'script_pubkey', '3': 19, '4': 1, '5': 12, '10': 'scriptPubkey'},
+    {'1': 'coinjoin_flags', '3': 20, '4': 1, '5': 13, '7': '0', '10': 'coinjoinFlags'},
+  ],
+};
+
+@$core.Deprecated('Use txAckDescriptor instead')
+const TxAck_TransactionType_TxOutputBinType$json = {
+  '1': 'TxOutputBinType',
+  '2': [
+    {'1': 'amount', '3': 1, '4': 2, '5': 4, '10': 'amount'},
+    {'1': 'script_pubkey', '3': 2, '4': 2, '5': 12, '10': 'scriptPubkey'},
+    {'1': 'decred_script_version', '3': 3, '4': 1, '5': 13, '10': 'decredScriptVersion'},
+  ],
+};
+
+@$core.Deprecated('Use txAckDescriptor instead')
+const TxAck_TransactionType_TxOutputType$json = {
+  '1': 'TxOutputType',
+  '2': [
+    {'1': 'address', '3': 1, '4': 1, '5': 9, '10': 'address'},
+    {'1': 'address_n', '3': 2, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'amount', '3': 3, '4': 2, '5': 4, '10': 'amount'},
+    {'1': 'script_type', '3': 4, '4': 1, '5': 14, '6': '.hw.trezor.messages.bitcoin.OutputScriptType', '7': 'PAYTOADDRESS', '10': 'scriptType'},
+    {'1': 'multisig', '3': 5, '4': 1, '5': 11, '6': '.hw.trezor.messages.bitcoin.MultisigRedeemScriptType', '10': 'multisig'},
+    {'1': 'op_return_data', '3': 6, '4': 1, '5': 12, '10': 'opReturnData'},
+    {'1': 'orig_hash', '3': 10, '4': 1, '5': 12, '10': 'origHash'},
+    {'1': 'orig_index', '3': 11, '4': 1, '5': 13, '10': 'origIndex'},
+    {'1': 'payment_req_index', '3': 12, '4': 1, '5': 13, '8': {}, '10': 'paymentReqIndex'},
+  ],
+};
+
+/// Descriptor for `TxAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List txAckDescriptor = $convert.base64Decode(
+    'CgVUeEFjaxJBCgJ0eBgBIAEoCzIxLmh3LnRyZXpvci5tZXNzYWdlcy5iaXRjb2luLlR4QWNrLl'
+    'RyYW5zYWN0aW9uVHlwZVICdHgaow8KD1RyYW5zYWN0aW9uVHlwZRIYCgd2ZXJzaW9uGAEgASgN'
+    'Ugd2ZXJzaW9uElUKBmlucHV0cxgCIAMoCzI9Lmh3LnRyZXpvci5tZXNzYWdlcy5iaXRjb2luLl'
+    'R4QWNrLlRyYW5zYWN0aW9uVHlwZS5UeElucHV0VHlwZVIGaW5wdXRzEmIKC2Jpbl9vdXRwdXRz'
+    'GAMgAygLMkEuaHcudHJlem9yLm1lc3NhZ2VzLmJpdGNvaW4uVHhBY2suVHJhbnNhY3Rpb25UeX'
+    'BlLlR4T3V0cHV0QmluVHlwZVIKYmluT3V0cHV0cxIbCglsb2NrX3RpbWUYBCABKA1SCGxvY2tU'
+    'aW1lElgKB291dHB1dHMYBSADKAsyPi5ody50cmV6b3IubWVzc2FnZXMuYml0Y29pbi5UeEFjay'
+    '5UcmFuc2FjdGlvblR5cGUuVHhPdXRwdXRUeXBlUgdvdXRwdXRzEh0KCmlucHV0c19jbnQYBiAB'
+    'KA1SCWlucHV0c0NudBIfCgtvdXRwdXRzX2NudBgHIAEoDVIKb3V0cHV0c0NudBIdCgpleHRyYV'
+    '9kYXRhGAggASgMUglleHRyYURhdGESJAoOZXh0cmFfZGF0YV9sZW4YCSABKA1SDGV4dHJhRGF0'
+    'YUxlbhIWCgZleHBpcnkYCiABKA1SBmV4cGlyeRImCgxvdmVyd2ludGVyZWQYCyABKAhCAhgBUg'
+    'xvdmVyd2ludGVyZWQSKAoQdmVyc2lvbl9ncm91cF9pZBgMIAEoDVIOdmVyc2lvbkdyb3VwSWQS'
+    'HAoJdGltZXN0YW1wGA0gASgNUgl0aW1lc3RhbXASGwoJYnJhbmNoX2lkGA4gASgNUghicmFuY2'
+    'hJZBrxBQoLVHhJbnB1dFR5cGUSGwoJYWRkcmVzc19uGAEgAygNUghhZGRyZXNzThIbCglwcmV2'
+    'X2hhc2gYAiACKAxSCHByZXZIYXNoEh0KCnByZXZfaW5kZXgYAyACKA1SCXByZXZJbmRleBIdCg'
+    'pzY3JpcHRfc2lnGAQgASgMUglzY3JpcHRTaWcSJgoIc2VxdWVuY2UYBSABKA06CjQyOTQ5Njcy'
+    'OTVSCHNlcXVlbmNlEloKC3NjcmlwdF90eXBlGAYgASgOMisuaHcudHJlem9yLm1lc3NhZ2VzLm'
+    'JpdGNvaW4uSW5wdXRTY3JpcHRUeXBlOgxTUEVOREFERFJFU1NSCnNjcmlwdFR5cGUSUAoIbXVs'
+    'dGlzaWcYByABKAsyNC5ody50cmV6b3IubWVzc2FnZXMuYml0Y29pbi5NdWx0aXNpZ1JlZGVlbV'
+    'NjcmlwdFR5cGVSCG11bHRpc2lnEhYKBmFtb3VudBgIIAEoBFIGYW1vdW50Eh8KC2RlY3JlZF90'
+    'cmVlGAkgASgNUgpkZWNyZWRUcmVlEhgKB3dpdG5lc3MYDSABKAxSB3dpdG5lc3MSJwoPb3duZX'
+    'JzaGlwX3Byb29mGA4gASgMUg5vd25lcnNoaXBQcm9vZhInCg9jb21taXRtZW50X2RhdGEYDyAB'
+    'KAxSDmNvbW1pdG1lbnREYXRhEhsKCW9yaWdfaGFzaBgQIAEoDFIIb3JpZ0hhc2gSHQoKb3JpZ1'
+    '9pbmRleBgRIAEoDVIJb3JpZ0luZGV4EmQKFGRlY3JlZF9zdGFraW5nX3NwZW5kGBIgASgOMjIu'
+    'aHcudHJlem9yLm1lc3NhZ2VzLmJpdGNvaW4uRGVjcmVkU3Rha2luZ1NwZW5kVHlwZVISZGVjcm'
+    'VkU3Rha2luZ1NwZW5kEiMKDXNjcmlwdF9wdWJrZXkYEyABKAxSDHNjcmlwdFB1YmtleRIoCg5j'
+    'b2luam9pbl9mbGFncxgUIAEoDToBMFINY29pbmpvaW5GbGFncxqCAQoPVHhPdXRwdXRCaW5UeX'
+    'BlEhYKBmFtb3VudBgBIAIoBFIGYW1vdW50EiMKDXNjcmlwdF9wdWJrZXkYAiACKAxSDHNjcmlw'
+    'dFB1YmtleRIyChVkZWNyZWRfc2NyaXB0X3ZlcnNpb24YAyABKA1SE2RlY3JlZFNjcmlwdFZlcn'
+    'Npb24aoAMKDFR4T3V0cHV0VHlwZRIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEhsKCWFkZHJl'
+    'c3NfbhgCIAMoDVIIYWRkcmVzc04SFgoGYW1vdW50GAMgAigEUgZhbW91bnQSWwoLc2NyaXB0X3'
+    'R5cGUYBCABKA4yLC5ody50cmV6b3IubWVzc2FnZXMuYml0Y29pbi5PdXRwdXRTY3JpcHRUeXBl'
+    'OgxQQVlUT0FERFJFU1NSCnNjcmlwdFR5cGUSUAoIbXVsdGlzaWcYBSABKAsyNC5ody50cmV6b3'
+    'IubWVzc2FnZXMuYml0Y29pbi5NdWx0aXNpZ1JlZGVlbVNjcmlwdFR5cGVSCG11bHRpc2lnEiQK'
+    'Dm9wX3JldHVybl9kYXRhGAYgASgMUgxvcFJldHVybkRhdGESGwoJb3JpZ19oYXNoGAogASgMUg'
+    'hvcmlnSGFzaBIdCgpvcmlnX2luZGV4GAsgASgNUglvcmlnSW5kZXgSMAoRcGF5bWVudF9yZXFf'
+    'aW5kZXgYDCABKA1CBMjwGQFSD3BheW1lbnRSZXFJbmRleDoCGAE=');
+
+@$core.Deprecated('Use txInputDescriptor instead')
+const TxInput$json = {
+  '1': 'TxInput',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'prev_hash', '3': 2, '4': 2, '5': 12, '10': 'prevHash'},
+    {'1': 'prev_index', '3': 3, '4': 2, '5': 13, '10': 'prevIndex'},
+    {'1': 'script_sig', '3': 4, '4': 1, '5': 12, '10': 'scriptSig'},
+    {'1': 'sequence', '3': 5, '4': 1, '5': 13, '7': '4294967295', '10': 'sequence'},
+    {'1': 'script_type', '3': 6, '4': 1, '5': 14, '6': '.hw.trezor.messages.bitcoin.InputScriptType', '7': 'SPENDADDRESS', '10': 'scriptType'},
+    {'1': 'multisig', '3': 7, '4': 1, '5': 11, '6': '.hw.trezor.messages.bitcoin.MultisigRedeemScriptType', '10': 'multisig'},
+    {'1': 'amount', '3': 8, '4': 2, '5': 4, '10': 'amount'},
+    {'1': 'decred_tree', '3': 9, '4': 1, '5': 13, '10': 'decredTree'},
+    {'1': 'witness', '3': 13, '4': 1, '5': 12, '10': 'witness'},
+    {'1': 'ownership_proof', '3': 14, '4': 1, '5': 12, '10': 'ownershipProof'},
+    {'1': 'commitment_data', '3': 15, '4': 1, '5': 12, '10': 'commitmentData'},
+    {'1': 'orig_hash', '3': 16, '4': 1, '5': 12, '10': 'origHash'},
+    {'1': 'orig_index', '3': 17, '4': 1, '5': 13, '10': 'origIndex'},
+    {'1': 'decred_staking_spend', '3': 18, '4': 1, '5': 14, '6': '.hw.trezor.messages.bitcoin.DecredStakingSpendType', '10': 'decredStakingSpend'},
+    {'1': 'script_pubkey', '3': 19, '4': 1, '5': 12, '10': 'scriptPubkey'},
+    {'1': 'coinjoin_flags', '3': 20, '4': 1, '5': 13, '7': '0', '10': 'coinjoinFlags'},
+  ],
+  '9': [
+    {'1': 10, '2': 11},
+    {'1': 11, '2': 12},
+    {'1': 12, '2': 13},
+  ],
+};
+
+/// Descriptor for `TxInput`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List txInputDescriptor = $convert.base64Decode(
+    'CgdUeElucHV0EhsKCWFkZHJlc3NfbhgBIAMoDVIIYWRkcmVzc04SGwoJcHJldl9oYXNoGAIgAi'
+    'gMUghwcmV2SGFzaBIdCgpwcmV2X2luZGV4GAMgAigNUglwcmV2SW5kZXgSHQoKc2NyaXB0X3Np'
+    'ZxgEIAEoDFIJc2NyaXB0U2lnEiYKCHNlcXVlbmNlGAUgASgNOgo0Mjk0OTY3Mjk1UghzZXF1ZW'
+    '5jZRJaCgtzY3JpcHRfdHlwZRgGIAEoDjIrLmh3LnRyZXpvci5tZXNzYWdlcy5iaXRjb2luLklu'
+    'cHV0U2NyaXB0VHlwZToMU1BFTkRBRERSRVNTUgpzY3JpcHRUeXBlElAKCG11bHRpc2lnGAcgAS'
+    'gLMjQuaHcudHJlem9yLm1lc3NhZ2VzLmJpdGNvaW4uTXVsdGlzaWdSZWRlZW1TY3JpcHRUeXBl'
+    'UghtdWx0aXNpZxIWCgZhbW91bnQYCCACKARSBmFtb3VudBIfCgtkZWNyZWRfdHJlZRgJIAEoDV'
+    'IKZGVjcmVkVHJlZRIYCgd3aXRuZXNzGA0gASgMUgd3aXRuZXNzEicKD293bmVyc2hpcF9wcm9v'
+    'ZhgOIAEoDFIOb3duZXJzaGlwUHJvb2YSJwoPY29tbWl0bWVudF9kYXRhGA8gASgMUg5jb21taX'
+    'RtZW50RGF0YRIbCglvcmlnX2hhc2gYECABKAxSCG9yaWdIYXNoEh0KCm9yaWdfaW5kZXgYESAB'
+    'KA1SCW9yaWdJbmRleBJkChRkZWNyZWRfc3Rha2luZ19zcGVuZBgSIAEoDjIyLmh3LnRyZXpvci'
+    '5tZXNzYWdlcy5iaXRjb2luLkRlY3JlZFN0YWtpbmdTcGVuZFR5cGVSEmRlY3JlZFN0YWtpbmdT'
+    'cGVuZBIjCg1zY3JpcHRfcHVia2V5GBMgASgMUgxzY3JpcHRQdWJrZXkSKAoOY29pbmpvaW5fZm'
+    'xhZ3MYFCABKA06ATBSDWNvaW5qb2luRmxhZ3NKBAgKEAtKBAgLEAxKBAgMEA0=');
+
+@$core.Deprecated('Use txOutputDescriptor instead')
+const TxOutput$json = {
+  '1': 'TxOutput',
+  '2': [
+    {'1': 'address', '3': 1, '4': 1, '5': 9, '10': 'address'},
+    {'1': 'address_n', '3': 2, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'amount', '3': 3, '4': 2, '5': 4, '10': 'amount'},
+    {'1': 'script_type', '3': 4, '4': 1, '5': 14, '6': '.hw.trezor.messages.bitcoin.OutputScriptType', '7': 'PAYTOADDRESS', '10': 'scriptType'},
+    {'1': 'multisig', '3': 5, '4': 1, '5': 11, '6': '.hw.trezor.messages.bitcoin.MultisigRedeemScriptType', '10': 'multisig'},
+    {'1': 'op_return_data', '3': 6, '4': 1, '5': 12, '10': 'opReturnData'},
+    {'1': 'orig_hash', '3': 10, '4': 1, '5': 12, '10': 'origHash'},
+    {'1': 'orig_index', '3': 11, '4': 1, '5': 13, '10': 'origIndex'},
+    {'1': 'payment_req_index', '3': 12, '4': 1, '5': 13, '8': {}, '10': 'paymentReqIndex'},
+  ],
+  '9': [
+    {'1': 7, '2': 8},
+    {'1': 8, '2': 9},
+    {'1': 9, '2': 10},
+  ],
+};
+
+/// Descriptor for `TxOutput`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List txOutputDescriptor = $convert.base64Decode(
+    'CghUeE91dHB1dBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEhsKCWFkZHJlc3NfbhgCIAMoDV'
+    'IIYWRkcmVzc04SFgoGYW1vdW50GAMgAigEUgZhbW91bnQSWwoLc2NyaXB0X3R5cGUYBCABKA4y'
+    'LC5ody50cmV6b3IubWVzc2FnZXMuYml0Y29pbi5PdXRwdXRTY3JpcHRUeXBlOgxQQVlUT0FERF'
+    'JFU1NSCnNjcmlwdFR5cGUSUAoIbXVsdGlzaWcYBSABKAsyNC5ody50cmV6b3IubWVzc2FnZXMu'
+    'Yml0Y29pbi5NdWx0aXNpZ1JlZGVlbVNjcmlwdFR5cGVSCG11bHRpc2lnEiQKDm9wX3JldHVybl'
+    '9kYXRhGAYgASgMUgxvcFJldHVybkRhdGESGwoJb3JpZ19oYXNoGAogASgMUghvcmlnSGFzaBId'
+    'CgpvcmlnX2luZGV4GAsgASgNUglvcmlnSW5kZXgSMAoRcGF5bWVudF9yZXFfaW5kZXgYDCABKA'
+    '1CBMjwGQFSD3BheW1lbnRSZXFJbmRleEoECAcQCEoECAgQCUoECAkQCg==');
+
+@$core.Deprecated('Use prevTxDescriptor instead')
+const PrevTx$json = {
+  '1': 'PrevTx',
+  '2': [
+    {'1': 'version', '3': 1, '4': 2, '5': 13, '10': 'version'},
+    {'1': 'lock_time', '3': 4, '4': 2, '5': 13, '10': 'lockTime'},
+    {'1': 'inputs_count', '3': 6, '4': 2, '5': 13, '10': 'inputsCount'},
+    {'1': 'outputs_count', '3': 7, '4': 2, '5': 13, '10': 'outputsCount'},
+    {'1': 'extra_data_len', '3': 9, '4': 1, '5': 13, '7': '0', '10': 'extraDataLen'},
+    {'1': 'expiry', '3': 10, '4': 1, '5': 13, '10': 'expiry'},
+    {'1': 'version_group_id', '3': 12, '4': 1, '5': 13, '10': 'versionGroupId'},
+    {'1': 'timestamp', '3': 13, '4': 1, '5': 13, '10': 'timestamp'},
+    {'1': 'branch_id', '3': 14, '4': 1, '5': 13, '10': 'branchId'},
+  ],
+  '9': [
+    {'1': 2, '2': 3},
+    {'1': 3, '2': 4},
+    {'1': 5, '2': 6},
+    {'1': 8, '2': 9},
+    {'1': 11, '2': 12},
+  ],
+};
+
+/// Descriptor for `PrevTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List prevTxDescriptor = $convert.base64Decode(
+    'CgZQcmV2VHgSGAoHdmVyc2lvbhgBIAIoDVIHdmVyc2lvbhIbCglsb2NrX3RpbWUYBCACKA1SCG'
+    'xvY2tUaW1lEiEKDGlucHV0c19jb3VudBgGIAIoDVILaW5wdXRzQ291bnQSIwoNb3V0cHV0c19j'
+    'b3VudBgHIAIoDVIMb3V0cHV0c0NvdW50EicKDmV4dHJhX2RhdGFfbGVuGAkgASgNOgEwUgxleH'
+    'RyYURhdGFMZW4SFgoGZXhwaXJ5GAogASgNUgZleHBpcnkSKAoQdmVyc2lvbl9ncm91cF9pZBgM'
+    'IAEoDVIOdmVyc2lvbkdyb3VwSWQSHAoJdGltZXN0YW1wGA0gASgNUgl0aW1lc3RhbXASGwoJYn'
+    'JhbmNoX2lkGA4gASgNUghicmFuY2hJZEoECAIQA0oECAMQBEoECAUQBkoECAgQCUoECAsQDA==');
+
+@$core.Deprecated('Use prevInputDescriptor instead')
+const PrevInput$json = {
+  '1': 'PrevInput',
+  '2': [
+    {'1': 'prev_hash', '3': 2, '4': 2, '5': 12, '10': 'prevHash'},
+    {'1': 'prev_index', '3': 3, '4': 2, '5': 13, '10': 'prevIndex'},
+    {'1': 'script_sig', '3': 4, '4': 2, '5': 12, '10': 'scriptSig'},
+    {'1': 'sequence', '3': 5, '4': 2, '5': 13, '10': 'sequence'},
+    {'1': 'decred_tree', '3': 9, '4': 1, '5': 13, '10': 'decredTree'},
+  ],
+  '9': [
+    {'1': 1, '2': 2},
+    {'1': 6, '2': 7},
+    {'1': 7, '2': 8},
+    {'1': 8, '2': 9},
+    {'1': 10, '2': 11},
+    {'1': 11, '2': 12},
+    {'1': 12, '2': 13},
+    {'1': 13, '2': 14},
+    {'1': 14, '2': 15},
+    {'1': 15, '2': 16},
+    {'1': 16, '2': 17},
+    {'1': 17, '2': 18},
+    {'1': 18, '2': 19},
+    {'1': 19, '2': 20},
+  ],
+};
+
+/// Descriptor for `PrevInput`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List prevInputDescriptor = $convert.base64Decode(
+    'CglQcmV2SW5wdXQSGwoJcHJldl9oYXNoGAIgAigMUghwcmV2SGFzaBIdCgpwcmV2X2luZGV4GA'
+    'MgAigNUglwcmV2SW5kZXgSHQoKc2NyaXB0X3NpZxgEIAIoDFIJc2NyaXB0U2lnEhoKCHNlcXVl'
+    'bmNlGAUgAigNUghzZXF1ZW5jZRIfCgtkZWNyZWRfdHJlZRgJIAEoDVIKZGVjcmVkVHJlZUoECA'
+    'EQAkoECAYQB0oECAcQCEoECAgQCUoECAoQC0oECAsQDEoECAwQDUoECA0QDkoECA4QD0oECA8Q'
+    'EEoECBAQEUoECBEQEkoECBIQE0oECBMQFA==');
+
+@$core.Deprecated('Use prevOutputDescriptor instead')
+const PrevOutput$json = {
+  '1': 'PrevOutput',
+  '2': [
+    {'1': 'amount', '3': 1, '4': 2, '5': 4, '10': 'amount'},
+    {'1': 'script_pubkey', '3': 2, '4': 2, '5': 12, '10': 'scriptPubkey'},
+    {'1': 'decred_script_version', '3': 3, '4': 1, '5': 13, '10': 'decredScriptVersion'},
+  ],
+};
+
+/// Descriptor for `PrevOutput`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List prevOutputDescriptor = $convert.base64Decode(
+    'CgpQcmV2T3V0cHV0EhYKBmFtb3VudBgBIAIoBFIGYW1vdW50EiMKDXNjcmlwdF9wdWJrZXkYAi'
+    'ACKAxSDHNjcmlwdFB1YmtleRIyChVkZWNyZWRfc2NyaXB0X3ZlcnNpb24YAyABKA1SE2RlY3Jl'
+    'ZFNjcmlwdFZlcnNpb24=');
+
+@$core.Deprecated('Use txAckPaymentRequestDescriptor instead')
+const TxAckPaymentRequest$json = {
+  '1': 'TxAckPaymentRequest',
+  '2': [
+    {'1': 'nonce', '3': 1, '4': 1, '5': 12, '10': 'nonce'},
+    {'1': 'recipient_name', '3': 2, '4': 2, '5': 9, '10': 'recipientName'},
+    {'1': 'memos', '3': 3, '4': 3, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxAckPaymentRequest.PaymentRequestMemo', '10': 'memos'},
+    {'1': 'amount', '3': 4, '4': 1, '5': 4, '10': 'amount'},
+    {'1': 'signature', '3': 5, '4': 2, '5': 12, '10': 'signature'},
+  ],
+  '3': [TxAckPaymentRequest_PaymentRequestMemo$json, TxAckPaymentRequest_TextMemo$json, TxAckPaymentRequest_RefundMemo$json, TxAckPaymentRequest_CoinPurchaseMemo$json],
+  '7': {},
+};
+
+@$core.Deprecated('Use txAckPaymentRequestDescriptor instead')
+const TxAckPaymentRequest_PaymentRequestMemo$json = {
+  '1': 'PaymentRequestMemo',
+  '2': [
+    {'1': 'text_memo', '3': 1, '4': 1, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxAckPaymentRequest.TextMemo', '10': 'textMemo'},
+    {'1': 'refund_memo', '3': 2, '4': 1, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxAckPaymentRequest.RefundMemo', '10': 'refundMemo'},
+    {'1': 'coin_purchase_memo', '3': 3, '4': 1, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxAckPaymentRequest.CoinPurchaseMemo', '10': 'coinPurchaseMemo'},
+  ],
+};
+
+@$core.Deprecated('Use txAckPaymentRequestDescriptor instead')
+const TxAckPaymentRequest_TextMemo$json = {
+  '1': 'TextMemo',
+  '2': [
+    {'1': 'text', '3': 1, '4': 2, '5': 9, '10': 'text'},
+  ],
+};
+
+@$core.Deprecated('Use txAckPaymentRequestDescriptor instead')
+const TxAckPaymentRequest_RefundMemo$json = {
+  '1': 'RefundMemo',
+  '2': [
+    {'1': 'address', '3': 1, '4': 2, '5': 9, '10': 'address'},
+    {'1': 'mac', '3': 2, '4': 2, '5': 12, '10': 'mac'},
+  ],
+};
+
+@$core.Deprecated('Use txAckPaymentRequestDescriptor instead')
+const TxAckPaymentRequest_CoinPurchaseMemo$json = {
+  '1': 'CoinPurchaseMemo',
+  '2': [
+    {'1': 'coin_type', '3': 1, '4': 2, '5': 13, '10': 'coinType'},
+    {'1': 'amount', '3': 2, '4': 2, '5': 9, '10': 'amount'},
+    {'1': 'address', '3': 3, '4': 2, '5': 9, '10': 'address'},
+    {'1': 'mac', '3': 4, '4': 2, '5': 12, '10': 'mac'},
+  ],
+};
+
+/// Descriptor for `TxAckPaymentRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List txAckPaymentRequestDescriptor = $convert.base64Decode(
+    'ChNUeEFja1BheW1lbnRSZXF1ZXN0EhQKBW5vbmNlGAEgASgMUgVub25jZRIlCg5yZWNpcGllbn'
+    'RfbmFtZRgCIAIoCVINcmVjaXBpZW50TmFtZRJYCgVtZW1vcxgDIAMoCzJCLmh3LnRyZXpvci5t'
+    'ZXNzYWdlcy5iaXRjb2luLlR4QWNrUGF5bWVudFJlcXVlc3QuUGF5bWVudFJlcXVlc3RNZW1vUg'
+    'VtZW1vcxIWCgZhbW91bnQYBCABKARSBmFtb3VudBIcCglzaWduYXR1cmUYBSACKAxSCXNpZ25h'
+    'dHVyZRq4AgoSUGF5bWVudFJlcXVlc3RNZW1vElUKCXRleHRfbWVtbxgBIAEoCzI4Lmh3LnRyZX'
+    'pvci5tZXNzYWdlcy5iaXRjb2luLlR4QWNrUGF5bWVudFJlcXVlc3QuVGV4dE1lbW9SCHRleHRN'
+    'ZW1vElsKC3JlZnVuZF9tZW1vGAIgASgLMjouaHcudHJlem9yLm1lc3NhZ2VzLmJpdGNvaW4uVH'
+    'hBY2tQYXltZW50UmVxdWVzdC5SZWZ1bmRNZW1vUgpyZWZ1bmRNZW1vEm4KEmNvaW5fcHVyY2hh'
+    'c2VfbWVtbxgDIAEoCzJALmh3LnRyZXpvci5tZXNzYWdlcy5iaXRjb2luLlR4QWNrUGF5bWVudF'
+    'JlcXVlc3QuQ29pblB1cmNoYXNlTWVtb1IQY29pblB1cmNoYXNlTWVtbxoeCghUZXh0TWVtbxIS'
+    'CgR0ZXh0GAEgAigJUgR0ZXh0GjgKClJlZnVuZE1lbW8SGAoHYWRkcmVzcxgBIAIoCVIHYWRkcm'
+    'VzcxIQCgNtYWMYAiACKAxSA21hYxpzChBDb2luUHVyY2hhc2VNZW1vEhsKCWNvaW5fdHlwZRgB'
+    'IAIoDVIIY29pblR5cGUSFgoGYW1vdW50GAIgAigJUgZhbW91bnQSGAoHYWRkcmVzcxgDIAIoCV'
+    'IHYWRkcmVzcxIQCgNtYWMYBCACKAxSA21hYzoEiLIZAQ==');
+
+@$core.Deprecated('Use txAckInputDescriptor instead')
+const TxAckInput$json = {
+  '1': 'TxAckInput',
+  '2': [
+    {'1': 'tx', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxAckInput.TxAckInputWrapper', '10': 'tx'},
+  ],
+  '3': [TxAckInput_TxAckInputWrapper$json],
+  '7': {},
+};
+
+@$core.Deprecated('Use txAckInputDescriptor instead')
+const TxAckInput_TxAckInputWrapper$json = {
+  '1': 'TxAckInputWrapper',
+  '2': [
+    {'1': 'input', '3': 2, '4': 2, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxInput', '10': 'input'},
+  ],
+};
+
+/// Descriptor for `TxAckInput`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List txAckInputDescriptor = $convert.base64Decode(
+    'CgpUeEFja0lucHV0EkgKAnR4GAEgAigLMjguaHcudHJlem9yLm1lc3NhZ2VzLmJpdGNvaW4uVH'
+    'hBY2tJbnB1dC5UeEFja0lucHV0V3JhcHBlclICdHgaTgoRVHhBY2tJbnB1dFdyYXBwZXISOQoF'
+    'aW5wdXQYAiACKAsyIy5ody50cmV6b3IubWVzc2FnZXMuYml0Y29pbi5UeElucHV0UgVpbnB1dD'
+    'oEkLIZFg==');
+
+@$core.Deprecated('Use txAckOutputDescriptor instead')
+const TxAckOutput$json = {
+  '1': 'TxAckOutput',
+  '2': [
+    {'1': 'tx', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxAckOutput.TxAckOutputWrapper', '10': 'tx'},
+  ],
+  '3': [TxAckOutput_TxAckOutputWrapper$json],
+  '7': {},
+};
+
+@$core.Deprecated('Use txAckOutputDescriptor instead')
+const TxAckOutput_TxAckOutputWrapper$json = {
+  '1': 'TxAckOutputWrapper',
+  '2': [
+    {'1': 'output', '3': 5, '4': 2, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxOutput', '10': 'output'},
+  ],
+};
+
+/// Descriptor for `TxAckOutput`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List txAckOutputDescriptor = $convert.base64Decode(
+    'CgtUeEFja091dHB1dBJKCgJ0eBgBIAIoCzI6Lmh3LnRyZXpvci5tZXNzYWdlcy5iaXRjb2luLl'
+    'R4QWNrT3V0cHV0LlR4QWNrT3V0cHV0V3JhcHBlclICdHgaUgoSVHhBY2tPdXRwdXRXcmFwcGVy'
+    'EjwKBm91dHB1dBgFIAIoCzIkLmh3LnRyZXpvci5tZXNzYWdlcy5iaXRjb2luLlR4T3V0cHV0Ug'
+    'ZvdXRwdXQ6BJCyGRY=');
+
+@$core.Deprecated('Use txAckPrevMetaDescriptor instead')
+const TxAckPrevMeta$json = {
+  '1': 'TxAckPrevMeta',
+  '2': [
+    {'1': 'tx', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.bitcoin.PrevTx', '10': 'tx'},
+  ],
+  '7': {},
+};
+
+/// Descriptor for `TxAckPrevMeta`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List txAckPrevMetaDescriptor = $convert.base64Decode(
+    'Cg1UeEFja1ByZXZNZXRhEjIKAnR4GAEgAigLMiIuaHcudHJlem9yLm1lc3NhZ2VzLmJpdGNvaW'
+    '4uUHJldlR4UgJ0eDoEkLIZFg==');
+
+@$core.Deprecated('Use txAckPrevInputDescriptor instead')
+const TxAckPrevInput$json = {
+  '1': 'TxAckPrevInput',
+  '2': [
+    {'1': 'tx', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxAckPrevInput.TxAckPrevInputWrapper', '10': 'tx'},
+  ],
+  '3': [TxAckPrevInput_TxAckPrevInputWrapper$json],
+  '7': {},
+};
+
+@$core.Deprecated('Use txAckPrevInputDescriptor instead')
+const TxAckPrevInput_TxAckPrevInputWrapper$json = {
+  '1': 'TxAckPrevInputWrapper',
+  '2': [
+    {'1': 'input', '3': 2, '4': 2, '5': 11, '6': '.hw.trezor.messages.bitcoin.PrevInput', '10': 'input'},
+  ],
+};
+
+/// Descriptor for `TxAckPrevInput`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List txAckPrevInputDescriptor = $convert.base64Decode(
+    'Cg5UeEFja1ByZXZJbnB1dBJQCgJ0eBgBIAIoCzJALmh3LnRyZXpvci5tZXNzYWdlcy5iaXRjb2'
+    'luLlR4QWNrUHJldklucHV0LlR4QWNrUHJldklucHV0V3JhcHBlclICdHgaVAoVVHhBY2tQcmV2'
+    'SW5wdXRXcmFwcGVyEjsKBWlucHV0GAIgAigLMiUuaHcudHJlem9yLm1lc3NhZ2VzLmJpdGNvaW'
+    '4uUHJldklucHV0UgVpbnB1dDoEkLIZFg==');
+
+@$core.Deprecated('Use txAckPrevOutputDescriptor instead')
+const TxAckPrevOutput$json = {
+  '1': 'TxAckPrevOutput',
+  '2': [
+    {'1': 'tx', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxAckPrevOutput.TxAckPrevOutputWrapper', '10': 'tx'},
+  ],
+  '3': [TxAckPrevOutput_TxAckPrevOutputWrapper$json],
+  '7': {},
+};
+
+@$core.Deprecated('Use txAckPrevOutputDescriptor instead')
+const TxAckPrevOutput_TxAckPrevOutputWrapper$json = {
+  '1': 'TxAckPrevOutputWrapper',
+  '2': [
+    {'1': 'output', '3': 3, '4': 2, '5': 11, '6': '.hw.trezor.messages.bitcoin.PrevOutput', '10': 'output'},
+  ],
+};
+
+/// Descriptor for `TxAckPrevOutput`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List txAckPrevOutputDescriptor = $convert.base64Decode(
+    'Cg9UeEFja1ByZXZPdXRwdXQSUgoCdHgYASACKAsyQi5ody50cmV6b3IubWVzc2FnZXMuYml0Y2'
+    '9pbi5UeEFja1ByZXZPdXRwdXQuVHhBY2tQcmV2T3V0cHV0V3JhcHBlclICdHgaWAoWVHhBY2tQ'
+    'cmV2T3V0cHV0V3JhcHBlchI+CgZvdXRwdXQYAyACKAsyJi5ody50cmV6b3IubWVzc2FnZXMuYm'
+    'l0Y29pbi5QcmV2T3V0cHV0UgZvdXRwdXQ6BJCyGRY=');
+
+@$core.Deprecated('Use txAckPrevExtraDataDescriptor instead')
+const TxAckPrevExtraData$json = {
+  '1': 'TxAckPrevExtraData',
+  '2': [
+    {'1': 'tx', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.bitcoin.TxAckPrevExtraData.TxAckPrevExtraDataWrapper', '10': 'tx'},
+  ],
+  '3': [TxAckPrevExtraData_TxAckPrevExtraDataWrapper$json],
+  '7': {},
+};
+
+@$core.Deprecated('Use txAckPrevExtraDataDescriptor instead')
+const TxAckPrevExtraData_TxAckPrevExtraDataWrapper$json = {
+  '1': 'TxAckPrevExtraDataWrapper',
+  '2': [
+    {'1': 'extra_data_chunk', '3': 8, '4': 2, '5': 12, '10': 'extraDataChunk'},
+  ],
+};
+
+/// Descriptor for `TxAckPrevExtraData`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List txAckPrevExtraDataDescriptor = $convert.base64Decode(
+    'ChJUeEFja1ByZXZFeHRyYURhdGESWAoCdHgYASACKAsySC5ody50cmV6b3IubWVzc2FnZXMuYm'
+    'l0Y29pbi5UeEFja1ByZXZFeHRyYURhdGEuVHhBY2tQcmV2RXh0cmFEYXRhV3JhcHBlclICdHga'
+    'RQoZVHhBY2tQcmV2RXh0cmFEYXRhV3JhcHBlchIoChBleHRyYV9kYXRhX2NodW5rGAggAigMUg'
+    '5leHRyYURhdGFDaHVuazoEkLIZFg==');
+
+@$core.Deprecated('Use getOwnershipProofDescriptor instead')
+const GetOwnershipProof$json = {
+  '1': 'GetOwnershipProof',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'coin_name', '3': 2, '4': 1, '5': 9, '7': 'Bitcoin', '10': 'coinName'},
+    {'1': 'script_type', '3': 3, '4': 1, '5': 14, '6': '.hw.trezor.messages.bitcoin.InputScriptType', '7': 'SPENDWITNESS', '10': 'scriptType'},
+    {'1': 'multisig', '3': 4, '4': 1, '5': 11, '6': '.hw.trezor.messages.bitcoin.MultisigRedeemScriptType', '10': 'multisig'},
+    {'1': 'user_confirmation', '3': 5, '4': 1, '5': 8, '7': 'false', '10': 'userConfirmation'},
+    {'1': 'ownership_ids', '3': 6, '4': 3, '5': 12, '10': 'ownershipIds'},
+    {'1': 'commitment_data', '3': 7, '4': 1, '5': 12, '7': '', '10': 'commitmentData'},
+  ],
+};
+
+/// Descriptor for `GetOwnershipProof`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getOwnershipProofDescriptor = $convert.base64Decode(
+    'ChFHZXRPd25lcnNoaXBQcm9vZhIbCglhZGRyZXNzX24YASADKA1SCGFkZHJlc3NOEiQKCWNvaW'
+    '5fbmFtZRgCIAEoCToHQml0Y29pblIIY29pbk5hbWUSWgoLc2NyaXB0X3R5cGUYAyABKA4yKy5o'
+    'dy50cmV6b3IubWVzc2FnZXMuYml0Y29pbi5JbnB1dFNjcmlwdFR5cGU6DFNQRU5EV0lUTkVTU1'
+    'IKc2NyaXB0VHlwZRJQCghtdWx0aXNpZxgEIAEoCzI0Lmh3LnRyZXpvci5tZXNzYWdlcy5iaXRj'
+    'b2luLk11bHRpc2lnUmVkZWVtU2NyaXB0VHlwZVIIbXVsdGlzaWcSMgoRdXNlcl9jb25maXJtYX'
+    'Rpb24YBSABKAg6BWZhbHNlUhB1c2VyQ29uZmlybWF0aW9uEiMKDW93bmVyc2hpcF9pZHMYBiAD'
+    'KAxSDG93bmVyc2hpcElkcxIpCg9jb21taXRtZW50X2RhdGEYByABKAw6AFIOY29tbWl0bWVudE'
+    'RhdGE=');
+
+@$core.Deprecated('Use ownershipProofDescriptor instead')
+const OwnershipProof$json = {
+  '1': 'OwnershipProof',
+  '2': [
+    {'1': 'ownership_proof', '3': 1, '4': 2, '5': 12, '10': 'ownershipProof'},
+    {'1': 'signature', '3': 2, '4': 2, '5': 12, '10': 'signature'},
+  ],
+};
+
+/// Descriptor for `OwnershipProof`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ownershipProofDescriptor = $convert.base64Decode(
+    'Cg5Pd25lcnNoaXBQcm9vZhInCg9vd25lcnNoaXBfcHJvb2YYASACKAxSDm93bmVyc2hpcFByb2'
+    '9mEhwKCXNpZ25hdHVyZRgCIAIoDFIJc2lnbmF0dXJl');
+
+@$core.Deprecated('Use authorizeCoinJoinDescriptor instead')
+const AuthorizeCoinJoin$json = {
+  '1': 'AuthorizeCoinJoin',
+  '2': [
+    {'1': 'coordinator', '3': 1, '4': 2, '5': 9, '10': 'coordinator'},
+    {'1': 'max_rounds', '3': 2, '4': 2, '5': 4, '10': 'maxRounds'},
+    {'1': 'max_coordinator_fee_rate', '3': 3, '4': 2, '5': 13, '10': 'maxCoordinatorFeeRate'},
+    {'1': 'max_fee_per_kvbyte', '3': 4, '4': 2, '5': 13, '10': 'maxFeePerKvbyte'},
+    {'1': 'address_n', '3': 5, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'coin_name', '3': 6, '4': 1, '5': 9, '7': 'Bitcoin', '10': 'coinName'},
+    {'1': 'script_type', '3': 7, '4': 1, '5': 14, '6': '.hw.trezor.messages.bitcoin.InputScriptType', '7': 'SPENDADDRESS', '10': 'scriptType'},
+    {'1': 'amount_unit', '3': 8, '4': 1, '5': 14, '6': '.hw.trezor.messages.bitcoin.AmountUnit', '7': 'BITCOIN', '10': 'amountUnit'},
+  ],
+};
+
+/// Descriptor for `AuthorizeCoinJoin`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List authorizeCoinJoinDescriptor = $convert.base64Decode(
+    'ChFBdXRob3JpemVDb2luSm9pbhIgCgtjb29yZGluYXRvchgBIAIoCVILY29vcmRpbmF0b3ISHQ'
+    'oKbWF4X3JvdW5kcxgCIAIoBFIJbWF4Um91bmRzEjcKGG1heF9jb29yZGluYXRvcl9mZWVfcmF0'
+    'ZRgDIAIoDVIVbWF4Q29vcmRpbmF0b3JGZWVSYXRlEisKEm1heF9mZWVfcGVyX2t2Ynl0ZRgEIA'
+    'IoDVIPbWF4RmVlUGVyS3ZieXRlEhsKCWFkZHJlc3NfbhgFIAMoDVIIYWRkcmVzc04SJAoJY29p'
+    'bl9uYW1lGAYgASgJOgdCaXRjb2luUghjb2luTmFtZRJaCgtzY3JpcHRfdHlwZRgHIAEoDjIrLm'
+    'h3LnRyZXpvci5tZXNzYWdlcy5iaXRjb2luLklucHV0U2NyaXB0VHlwZToMU1BFTkRBRERSRVNT'
+    'UgpzY3JpcHRUeXBlElAKC2Ftb3VudF91bml0GAggASgOMiYuaHcudHJlem9yLm1lc3NhZ2VzLm'
+    'JpdGNvaW4uQW1vdW50VW5pdDoHQklUQ09JTlIKYW1vdW50VW5pdA==');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bitcoin.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bitcoin.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-bitcoin.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-bitcoin.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bootloader.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bootloader.pb.dart
@@ -1,0 +1,260 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-bootloader.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+/// *
+///  Request: Ask device to erase its firmware (so it can be replaced via FirmwareUpload)
+///  @start
+///  @next FirmwareRequest
+class FirmwareErase extends $pb.GeneratedMessage {
+  factory FirmwareErase({
+    $core.int? length,
+  }) {
+    final $result = create();
+    if (length != null) {
+      $result.length = length;
+    }
+    return $result;
+  }
+  FirmwareErase._() : super();
+  factory FirmwareErase.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory FirmwareErase.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'FirmwareErase', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bootloader'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'length', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  FirmwareErase clone() => FirmwareErase()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  FirmwareErase copyWith(void Function(FirmwareErase) updates) => super.copyWith((message) => updates(message as FirmwareErase)) as FirmwareErase;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static FirmwareErase create() => FirmwareErase._();
+  FirmwareErase createEmptyInstance() => create();
+  static $pb.PbList<FirmwareErase> createRepeated() => $pb.PbList<FirmwareErase>();
+  @$core.pragma('dart2js:noInline')
+  static FirmwareErase getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FirmwareErase>(create);
+  static FirmwareErase? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get length => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set length($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasLength() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearLength() => clearField(1);
+}
+
+/// *
+///  Response: Ask for firmware chunk
+///  @next FirmwareUpload
+class FirmwareRequest extends $pb.GeneratedMessage {
+  factory FirmwareRequest({
+    $core.int? offset,
+    $core.int? length,
+  }) {
+    final $result = create();
+    if (offset != null) {
+      $result.offset = offset;
+    }
+    if (length != null) {
+      $result.length = length;
+    }
+    return $result;
+  }
+  FirmwareRequest._() : super();
+  factory FirmwareRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory FirmwareRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'FirmwareRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bootloader'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'offset', $pb.PbFieldType.QU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'length', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  FirmwareRequest clone() => FirmwareRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  FirmwareRequest copyWith(void Function(FirmwareRequest) updates) => super.copyWith((message) => updates(message as FirmwareRequest)) as FirmwareRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static FirmwareRequest create() => FirmwareRequest._();
+  FirmwareRequest createEmptyInstance() => create();
+  static $pb.PbList<FirmwareRequest> createRepeated() => $pb.PbList<FirmwareRequest>();
+  @$core.pragma('dart2js:noInline')
+  static FirmwareRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FirmwareRequest>(create);
+  static FirmwareRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get offset => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set offset($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasOffset() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearOffset() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get length => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set length($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasLength() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearLength() => clearField(2);
+}
+
+/// *
+///  Request: Send firmware in binary form to the device
+///  @next FirmwareRequest
+///  @next Success
+///  @next Failure
+class FirmwareUpload extends $pb.GeneratedMessage {
+  factory FirmwareUpload({
+    $core.List<$core.int>? payload,
+    $core.List<$core.int>? hash,
+  }) {
+    final $result = create();
+    if (payload != null) {
+      $result.payload = payload;
+    }
+    if (hash != null) {
+      $result.hash = hash;
+    }
+    return $result;
+  }
+  FirmwareUpload._() : super();
+  factory FirmwareUpload.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory FirmwareUpload.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'FirmwareUpload', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bootloader'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'payload', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'hash', $pb.PbFieldType.OY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  FirmwareUpload clone() => FirmwareUpload()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  FirmwareUpload copyWith(void Function(FirmwareUpload) updates) => super.copyWith((message) => updates(message as FirmwareUpload)) as FirmwareUpload;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static FirmwareUpload create() => FirmwareUpload._();
+  FirmwareUpload createEmptyInstance() => create();
+  static $pb.PbList<FirmwareUpload> createRepeated() => $pb.PbList<FirmwareUpload>();
+  @$core.pragma('dart2js:noInline')
+  static FirmwareUpload getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FirmwareUpload>(create);
+  static FirmwareUpload? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get payload => $_getN(0);
+  @$pb.TagNumber(1)
+  set payload($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPayload() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPayload() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get hash => $_getN(1);
+  @$pb.TagNumber(2)
+  set hash($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearHash() => clearField(2);
+}
+
+/// *
+///  Request: Perform a prodtest on T1
+///  @next Success
+///  @next Failure
+class ProdTestT1 extends $pb.GeneratedMessage {
+  factory ProdTestT1({
+    $core.List<$core.int>? payload,
+  }) {
+    final $result = create();
+    if (payload != null) {
+      $result.payload = payload;
+    }
+    return $result;
+  }
+  ProdTestT1._() : super();
+  factory ProdTestT1.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ProdTestT1.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ProdTestT1', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.bootloader'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'payload', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ProdTestT1 clone() => ProdTestT1()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ProdTestT1 copyWith(void Function(ProdTestT1) updates) => super.copyWith((message) => updates(message as ProdTestT1)) as ProdTestT1;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ProdTestT1 create() => ProdTestT1._();
+  ProdTestT1 createEmptyInstance() => create();
+  static $pb.PbList<ProdTestT1> createRepeated() => $pb.PbList<ProdTestT1>();
+  @$core.pragma('dart2js:noInline')
+  static ProdTestT1 getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ProdTestT1>(create);
+  static ProdTestT1? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get payload => $_getN(0);
+  @$pb.TagNumber(1)
+  set payload($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPayload() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPayload() => clearField(1);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bootloader.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bootloader.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-bootloader.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bootloader.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bootloader.pbjson.dart
@@ -1,0 +1,67 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-bootloader.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use firmwareEraseDescriptor instead')
+const FirmwareErase$json = {
+  '1': 'FirmwareErase',
+  '2': [
+    {'1': 'length', '3': 1, '4': 1, '5': 13, '10': 'length'},
+  ],
+};
+
+/// Descriptor for `FirmwareErase`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List firmwareEraseDescriptor = $convert.base64Decode(
+    'Cg1GaXJtd2FyZUVyYXNlEhYKBmxlbmd0aBgBIAEoDVIGbGVuZ3Ro');
+
+@$core.Deprecated('Use firmwareRequestDescriptor instead')
+const FirmwareRequest$json = {
+  '1': 'FirmwareRequest',
+  '2': [
+    {'1': 'offset', '3': 1, '4': 2, '5': 13, '10': 'offset'},
+    {'1': 'length', '3': 2, '4': 2, '5': 13, '10': 'length'},
+  ],
+};
+
+/// Descriptor for `FirmwareRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List firmwareRequestDescriptor = $convert.base64Decode(
+    'Cg9GaXJtd2FyZVJlcXVlc3QSFgoGb2Zmc2V0GAEgAigNUgZvZmZzZXQSFgoGbGVuZ3RoGAIgAi'
+    'gNUgZsZW5ndGg=');
+
+@$core.Deprecated('Use firmwareUploadDescriptor instead')
+const FirmwareUpload$json = {
+  '1': 'FirmwareUpload',
+  '2': [
+    {'1': 'payload', '3': 1, '4': 2, '5': 12, '10': 'payload'},
+    {'1': 'hash', '3': 2, '4': 1, '5': 12, '10': 'hash'},
+  ],
+};
+
+/// Descriptor for `FirmwareUpload`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List firmwareUploadDescriptor = $convert.base64Decode(
+    'Cg5GaXJtd2FyZVVwbG9hZBIYCgdwYXlsb2FkGAEgAigMUgdwYXlsb2FkEhIKBGhhc2gYAiABKA'
+    'xSBGhhc2g=');
+
+@$core.Deprecated('Use prodTestT1Descriptor instead')
+const ProdTestT1$json = {
+  '1': 'ProdTestT1',
+  '2': [
+    {'1': 'payload', '3': 1, '4': 1, '5': 12, '10': 'payload'},
+  ],
+};
+
+/// Descriptor for `ProdTestT1`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List prodTestT1Descriptor = $convert.base64Decode(
+    'CgpQcm9kVGVzdFQxEhgKB3BheWxvYWQYASABKAxSB3BheWxvYWQ=');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bootloader.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-bootloader.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-bootloader.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-bootloader.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-cardano.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-cardano.pb.dart
@@ -1,0 +1,3171 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-cardano.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'messages-cardano.pbenum.dart';
+import 'messages-common.pb.dart' as $0;
+
+export 'messages-cardano.pbenum.dart';
+
+/// *
+///  Structure representing cardano PointerAddress pointer,
+///  which points to a staking key registration certificate.
+///  @embed
+class CardanoBlockchainPointerType extends $pb.GeneratedMessage {
+  factory CardanoBlockchainPointerType({
+    $core.int? blockIndex,
+    $core.int? txIndex,
+    $core.int? certificateIndex,
+  }) {
+    final $result = create();
+    if (blockIndex != null) {
+      $result.blockIndex = blockIndex;
+    }
+    if (txIndex != null) {
+      $result.txIndex = txIndex;
+    }
+    if (certificateIndex != null) {
+      $result.certificateIndex = certificateIndex;
+    }
+    return $result;
+  }
+  CardanoBlockchainPointerType._() : super();
+  factory CardanoBlockchainPointerType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoBlockchainPointerType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoBlockchainPointerType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'blockIndex', $pb.PbFieldType.QU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'txIndex', $pb.PbFieldType.QU3)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'certificateIndex', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoBlockchainPointerType clone() => CardanoBlockchainPointerType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoBlockchainPointerType copyWith(void Function(CardanoBlockchainPointerType) updates) => super.copyWith((message) => updates(message as CardanoBlockchainPointerType)) as CardanoBlockchainPointerType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoBlockchainPointerType create() => CardanoBlockchainPointerType._();
+  CardanoBlockchainPointerType createEmptyInstance() => create();
+  static $pb.PbList<CardanoBlockchainPointerType> createRepeated() => $pb.PbList<CardanoBlockchainPointerType>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoBlockchainPointerType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoBlockchainPointerType>(create);
+  static CardanoBlockchainPointerType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get blockIndex => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set blockIndex($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasBlockIndex() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearBlockIndex() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get txIndex => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set txIndex($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTxIndex() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTxIndex() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get certificateIndex => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set certificateIndex($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasCertificateIndex() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearCertificateIndex() => clearField(3);
+}
+
+///
+///  @embed
+class CardanoNativeScript extends $pb.GeneratedMessage {
+  factory CardanoNativeScript({
+    CardanoNativeScriptType? type,
+    $core.Iterable<CardanoNativeScript>? scripts,
+    $core.List<$core.int>? keyHash,
+    $core.Iterable<$core.int>? keyPath,
+    $core.int? requiredSignaturesCount,
+    $fixnum.Int64? invalidBefore,
+    $fixnum.Int64? invalidHereafter,
+  }) {
+    final $result = create();
+    if (type != null) {
+      $result.type = type;
+    }
+    if (scripts != null) {
+      $result.scripts.addAll(scripts);
+    }
+    if (keyHash != null) {
+      $result.keyHash = keyHash;
+    }
+    if (keyPath != null) {
+      $result.keyPath.addAll(keyPath);
+    }
+    if (requiredSignaturesCount != null) {
+      $result.requiredSignaturesCount = requiredSignaturesCount;
+    }
+    if (invalidBefore != null) {
+      $result.invalidBefore = invalidBefore;
+    }
+    if (invalidHereafter != null) {
+      $result.invalidHereafter = invalidHereafter;
+    }
+    return $result;
+  }
+  CardanoNativeScript._() : super();
+  factory CardanoNativeScript.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoNativeScript.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoNativeScript', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..e<CardanoNativeScriptType>(1, _omitFieldNames ? '' : 'type', $pb.PbFieldType.QE, defaultOrMaker: CardanoNativeScriptType.PUB_KEY, valueOf: CardanoNativeScriptType.valueOf, enumValues: CardanoNativeScriptType.values)
+    ..pc<CardanoNativeScript>(2, _omitFieldNames ? '' : 'scripts', $pb.PbFieldType.PM, subBuilder: CardanoNativeScript.create)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'keyHash', $pb.PbFieldType.OY)
+    ..p<$core.int>(4, _omitFieldNames ? '' : 'keyPath', $pb.PbFieldType.PU3)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'requiredSignaturesCount', $pb.PbFieldType.OU3)
+    ..a<$fixnum.Int64>(6, _omitFieldNames ? '' : 'invalidBefore', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(7, _omitFieldNames ? '' : 'invalidHereafter', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoNativeScript clone() => CardanoNativeScript()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoNativeScript copyWith(void Function(CardanoNativeScript) updates) => super.copyWith((message) => updates(message as CardanoNativeScript)) as CardanoNativeScript;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoNativeScript create() => CardanoNativeScript._();
+  CardanoNativeScript createEmptyInstance() => create();
+  static $pb.PbList<CardanoNativeScript> createRepeated() => $pb.PbList<CardanoNativeScript>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoNativeScript getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoNativeScript>(create);
+  static CardanoNativeScript? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  CardanoNativeScriptType get type => $_getN(0);
+  @$pb.TagNumber(1)
+  set type(CardanoNativeScriptType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearType() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<CardanoNativeScript> get scripts => $_getList(1);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get keyHash => $_getN(2);
+  @$pb.TagNumber(3)
+  set keyHash($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasKeyHash() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearKeyHash() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get keyPath => $_getList(3);
+
+  @$pb.TagNumber(5)
+  $core.int get requiredSignaturesCount => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set requiredSignaturesCount($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasRequiredSignaturesCount() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearRequiredSignaturesCount() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $fixnum.Int64 get invalidBefore => $_getI64(5);
+  @$pb.TagNumber(6)
+  set invalidBefore($fixnum.Int64 v) { $_setInt64(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasInvalidBefore() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearInvalidBefore() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $fixnum.Int64 get invalidHereafter => $_getI64(6);
+  @$pb.TagNumber(7)
+  set invalidHereafter($fixnum.Int64 v) { $_setInt64(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasInvalidHereafter() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearInvalidHereafter() => clearField(7);
+}
+
+/// *
+///  Request: Ask device for Cardano native script hash
+///  @start
+///  @next CardanoNativeScriptHash
+///  @next Failure
+class CardanoGetNativeScriptHash extends $pb.GeneratedMessage {
+  factory CardanoGetNativeScriptHash({
+    CardanoNativeScript? script,
+    CardanoNativeScriptHashDisplayFormat? displayFormat,
+    CardanoDerivationType? derivationType,
+  }) {
+    final $result = create();
+    if (script != null) {
+      $result.script = script;
+    }
+    if (displayFormat != null) {
+      $result.displayFormat = displayFormat;
+    }
+    if (derivationType != null) {
+      $result.derivationType = derivationType;
+    }
+    return $result;
+  }
+  CardanoGetNativeScriptHash._() : super();
+  factory CardanoGetNativeScriptHash.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoGetNativeScriptHash.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoGetNativeScriptHash', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..aQM<CardanoNativeScript>(1, _omitFieldNames ? '' : 'script', subBuilder: CardanoNativeScript.create)
+    ..e<CardanoNativeScriptHashDisplayFormat>(2, _omitFieldNames ? '' : 'displayFormat', $pb.PbFieldType.QE, defaultOrMaker: CardanoNativeScriptHashDisplayFormat.HIDE, valueOf: CardanoNativeScriptHashDisplayFormat.valueOf, enumValues: CardanoNativeScriptHashDisplayFormat.values)
+    ..e<CardanoDerivationType>(3, _omitFieldNames ? '' : 'derivationType', $pb.PbFieldType.QE, defaultOrMaker: CardanoDerivationType.LEDGER, valueOf: CardanoDerivationType.valueOf, enumValues: CardanoDerivationType.values)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoGetNativeScriptHash clone() => CardanoGetNativeScriptHash()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoGetNativeScriptHash copyWith(void Function(CardanoGetNativeScriptHash) updates) => super.copyWith((message) => updates(message as CardanoGetNativeScriptHash)) as CardanoGetNativeScriptHash;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoGetNativeScriptHash create() => CardanoGetNativeScriptHash._();
+  CardanoGetNativeScriptHash createEmptyInstance() => create();
+  static $pb.PbList<CardanoGetNativeScriptHash> createRepeated() => $pb.PbList<CardanoGetNativeScriptHash>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoGetNativeScriptHash getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoGetNativeScriptHash>(create);
+  static CardanoGetNativeScriptHash? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  CardanoNativeScript get script => $_getN(0);
+  @$pb.TagNumber(1)
+  set script(CardanoNativeScript v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasScript() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearScript() => clearField(1);
+  @$pb.TagNumber(1)
+  CardanoNativeScript ensureScript() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  CardanoNativeScriptHashDisplayFormat get displayFormat => $_getN(1);
+  @$pb.TagNumber(2)
+  set displayFormat(CardanoNativeScriptHashDisplayFormat v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasDisplayFormat() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearDisplayFormat() => clearField(2);
+
+  @$pb.TagNumber(3)
+  CardanoDerivationType get derivationType => $_getN(2);
+  @$pb.TagNumber(3)
+  set derivationType(CardanoDerivationType v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasDerivationType() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearDerivationType() => clearField(3);
+}
+
+/// *
+///  Request: Ask device for Cardano native script hash
+///  @end
+class CardanoNativeScriptHash extends $pb.GeneratedMessage {
+  factory CardanoNativeScriptHash({
+    $core.List<$core.int>? scriptHash,
+  }) {
+    final $result = create();
+    if (scriptHash != null) {
+      $result.scriptHash = scriptHash;
+    }
+    return $result;
+  }
+  CardanoNativeScriptHash._() : super();
+  factory CardanoNativeScriptHash.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoNativeScriptHash.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoNativeScriptHash', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'scriptHash', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoNativeScriptHash clone() => CardanoNativeScriptHash()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoNativeScriptHash copyWith(void Function(CardanoNativeScriptHash) updates) => super.copyWith((message) => updates(message as CardanoNativeScriptHash)) as CardanoNativeScriptHash;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoNativeScriptHash create() => CardanoNativeScriptHash._();
+  CardanoNativeScriptHash createEmptyInstance() => create();
+  static $pb.PbList<CardanoNativeScriptHash> createRepeated() => $pb.PbList<CardanoNativeScriptHash>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoNativeScriptHash getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoNativeScriptHash>(create);
+  static CardanoNativeScriptHash? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get scriptHash => $_getN(0);
+  @$pb.TagNumber(1)
+  set scriptHash($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasScriptHash() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearScriptHash() => clearField(1);
+}
+
+/// *
+///  Structure to represent address parameters so they can be
+///  reused in CardanoGetAddress and CardanoTxOutputType.
+///  NetworkId isn't a part of the parameters, because in a transaction
+///  this will be included separately in the transaction itself, so it
+///  shouldn't be duplicated here.
+///  @embed
+class CardanoAddressParametersType extends $pb.GeneratedMessage {
+  factory CardanoAddressParametersType({
+    CardanoAddressType? addressType,
+    $core.Iterable<$core.int>? addressN,
+    $core.Iterable<$core.int>? addressNStaking,
+    $core.List<$core.int>? stakingKeyHash,
+    CardanoBlockchainPointerType? certificatePointer,
+    $core.List<$core.int>? scriptPaymentHash,
+    $core.List<$core.int>? scriptStakingHash,
+  }) {
+    final $result = create();
+    if (addressType != null) {
+      $result.addressType = addressType;
+    }
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (addressNStaking != null) {
+      $result.addressNStaking.addAll(addressNStaking);
+    }
+    if (stakingKeyHash != null) {
+      $result.stakingKeyHash = stakingKeyHash;
+    }
+    if (certificatePointer != null) {
+      $result.certificatePointer = certificatePointer;
+    }
+    if (scriptPaymentHash != null) {
+      $result.scriptPaymentHash = scriptPaymentHash;
+    }
+    if (scriptStakingHash != null) {
+      $result.scriptStakingHash = scriptStakingHash;
+    }
+    return $result;
+  }
+  CardanoAddressParametersType._() : super();
+  factory CardanoAddressParametersType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoAddressParametersType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoAddressParametersType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..e<CardanoAddressType>(1, _omitFieldNames ? '' : 'addressType', $pb.PbFieldType.QE, defaultOrMaker: CardanoAddressType.BASE, valueOf: CardanoAddressType.valueOf, enumValues: CardanoAddressType.values)
+    ..p<$core.int>(2, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..p<$core.int>(3, _omitFieldNames ? '' : 'addressNStaking', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'stakingKeyHash', $pb.PbFieldType.OY)
+    ..aOM<CardanoBlockchainPointerType>(5, _omitFieldNames ? '' : 'certificatePointer', subBuilder: CardanoBlockchainPointerType.create)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'scriptPaymentHash', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(7, _omitFieldNames ? '' : 'scriptStakingHash', $pb.PbFieldType.OY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoAddressParametersType clone() => CardanoAddressParametersType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoAddressParametersType copyWith(void Function(CardanoAddressParametersType) updates) => super.copyWith((message) => updates(message as CardanoAddressParametersType)) as CardanoAddressParametersType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoAddressParametersType create() => CardanoAddressParametersType._();
+  CardanoAddressParametersType createEmptyInstance() => create();
+  static $pb.PbList<CardanoAddressParametersType> createRepeated() => $pb.PbList<CardanoAddressParametersType>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoAddressParametersType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoAddressParametersType>(create);
+  static CardanoAddressParametersType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  CardanoAddressType get addressType => $_getN(0);
+  @$pb.TagNumber(1)
+  set addressType(CardanoAddressType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddressType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddressType() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get addressN => $_getList(1);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get addressNStaking => $_getList(2);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get stakingKeyHash => $_getN(3);
+  @$pb.TagNumber(4)
+  set stakingKeyHash($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasStakingKeyHash() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearStakingKeyHash() => clearField(4);
+
+  /// can be sent directly e.g. if it doesn't belong to
+  /// the same account as address_n
+  @$pb.TagNumber(5)
+  CardanoBlockchainPointerType get certificatePointer => $_getN(4);
+  @$pb.TagNumber(5)
+  set certificatePointer(CardanoBlockchainPointerType v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasCertificatePointer() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearCertificatePointer() => clearField(5);
+  @$pb.TagNumber(5)
+  CardanoBlockchainPointerType ensureCertificatePointer() => $_ensure(4);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get scriptPaymentHash => $_getN(5);
+  @$pb.TagNumber(6)
+  set scriptPaymentHash($core.List<$core.int> v) { $_setBytes(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasScriptPaymentHash() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearScriptPaymentHash() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.List<$core.int> get scriptStakingHash => $_getN(6);
+  @$pb.TagNumber(7)
+  set scriptStakingHash($core.List<$core.int> v) { $_setBytes(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasScriptStakingHash() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearScriptStakingHash() => clearField(7);
+}
+
+/// *
+///  Request: Ask device for Cardano address
+///  @start
+///  @next CardanoAddress
+///  @next Failure
+class CardanoGetAddress extends $pb.GeneratedMessage {
+  factory CardanoGetAddress({
+    $core.bool? showDisplay,
+    $core.int? protocolMagic,
+    $core.int? networkId,
+    CardanoAddressParametersType? addressParameters,
+    CardanoDerivationType? derivationType,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    if (protocolMagic != null) {
+      $result.protocolMagic = protocolMagic;
+    }
+    if (networkId != null) {
+      $result.networkId = networkId;
+    }
+    if (addressParameters != null) {
+      $result.addressParameters = addressParameters;
+    }
+    if (derivationType != null) {
+      $result.derivationType = derivationType;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  CardanoGetAddress._() : super();
+  factory CardanoGetAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoGetAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoGetAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..aOB(2, _omitFieldNames ? '' : 'showDisplay')
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'protocolMagic', $pb.PbFieldType.QU3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'networkId', $pb.PbFieldType.QU3)
+    ..aQM<CardanoAddressParametersType>(5, _omitFieldNames ? '' : 'addressParameters', subBuilder: CardanoAddressParametersType.create)
+    ..e<CardanoDerivationType>(6, _omitFieldNames ? '' : 'derivationType', $pb.PbFieldType.QE, defaultOrMaker: CardanoDerivationType.LEDGER, valueOf: CardanoDerivationType.valueOf, enumValues: CardanoDerivationType.values)
+    ..aOB(7, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoGetAddress clone() => CardanoGetAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoGetAddress copyWith(void Function(CardanoGetAddress) updates) => super.copyWith((message) => updates(message as CardanoGetAddress)) as CardanoGetAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoGetAddress create() => CardanoGetAddress._();
+  CardanoGetAddress createEmptyInstance() => create();
+  static $pb.PbList<CardanoGetAddress> createRepeated() => $pb.PbList<CardanoGetAddress>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoGetAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoGetAddress>(create);
+  static CardanoGetAddress? _defaultInstance;
+
+  /// repeated uint32 address_n = 1;                               // moved to address_parameters
+  @$pb.TagNumber(2)
+  $core.bool get showDisplay => $_getBF(0);
+  @$pb.TagNumber(2)
+  set showDisplay($core.bool v) { $_setBool(0, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasShowDisplay() => $_has(0);
+  @$pb.TagNumber(2)
+  void clearShowDisplay() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get protocolMagic => $_getIZ(1);
+  @$pb.TagNumber(3)
+  set protocolMagic($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasProtocolMagic() => $_has(1);
+  @$pb.TagNumber(3)
+  void clearProtocolMagic() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get networkId => $_getIZ(2);
+  @$pb.TagNumber(4)
+  set networkId($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasNetworkId() => $_has(2);
+  @$pb.TagNumber(4)
+  void clearNetworkId() => clearField(4);
+
+  @$pb.TagNumber(5)
+  CardanoAddressParametersType get addressParameters => $_getN(3);
+  @$pb.TagNumber(5)
+  set addressParameters(CardanoAddressParametersType v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasAddressParameters() => $_has(3);
+  @$pb.TagNumber(5)
+  void clearAddressParameters() => clearField(5);
+  @$pb.TagNumber(5)
+  CardanoAddressParametersType ensureAddressParameters() => $_ensure(3);
+
+  @$pb.TagNumber(6)
+  CardanoDerivationType get derivationType => $_getN(4);
+  @$pb.TagNumber(6)
+  set derivationType(CardanoDerivationType v) { setField(6, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasDerivationType() => $_has(4);
+  @$pb.TagNumber(6)
+  void clearDerivationType() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.bool get chunkify => $_getBF(5);
+  @$pb.TagNumber(7)
+  set chunkify($core.bool v) { $_setBool(5, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasChunkify() => $_has(5);
+  @$pb.TagNumber(7)
+  void clearChunkify() => clearField(7);
+}
+
+/// *
+///  Request: Ask device for Cardano address
+///  @end
+class CardanoAddress extends $pb.GeneratedMessage {
+  factory CardanoAddress({
+    $core.String? address,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    return $result;
+  }
+  CardanoAddress._() : super();
+  factory CardanoAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'address')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoAddress clone() => CardanoAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoAddress copyWith(void Function(CardanoAddress) updates) => super.copyWith((message) => updates(message as CardanoAddress)) as CardanoAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoAddress create() => CardanoAddress._();
+  CardanoAddress createEmptyInstance() => create();
+  static $pb.PbList<CardanoAddress> createRepeated() => $pb.PbList<CardanoAddress>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoAddress>(create);
+  static CardanoAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+}
+
+/// *
+///  Request: Ask device for public key corresponding to address_n path
+///  @start
+///  @next CardanoPublicKey
+///  @next Failure
+class CardanoGetPublicKey extends $pb.GeneratedMessage {
+  factory CardanoGetPublicKey({
+    $core.Iterable<$core.int>? addressN,
+    $core.bool? showDisplay,
+    CardanoDerivationType? derivationType,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    if (derivationType != null) {
+      $result.derivationType = derivationType;
+    }
+    return $result;
+  }
+  CardanoGetPublicKey._() : super();
+  factory CardanoGetPublicKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoGetPublicKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoGetPublicKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aOB(2, _omitFieldNames ? '' : 'showDisplay')
+    ..e<CardanoDerivationType>(3, _omitFieldNames ? '' : 'derivationType', $pb.PbFieldType.QE, defaultOrMaker: CardanoDerivationType.LEDGER, valueOf: CardanoDerivationType.valueOf, enumValues: CardanoDerivationType.values)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoGetPublicKey clone() => CardanoGetPublicKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoGetPublicKey copyWith(void Function(CardanoGetPublicKey) updates) => super.copyWith((message) => updates(message as CardanoGetPublicKey)) as CardanoGetPublicKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoGetPublicKey create() => CardanoGetPublicKey._();
+  CardanoGetPublicKey createEmptyInstance() => create();
+  static $pb.PbList<CardanoGetPublicKey> createRepeated() => $pb.PbList<CardanoGetPublicKey>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoGetPublicKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoGetPublicKey>(create);
+  static CardanoGetPublicKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.bool get showDisplay => $_getBF(1);
+  @$pb.TagNumber(2)
+  set showDisplay($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasShowDisplay() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearShowDisplay() => clearField(2);
+
+  @$pb.TagNumber(3)
+  CardanoDerivationType get derivationType => $_getN(2);
+  @$pb.TagNumber(3)
+  set derivationType(CardanoDerivationType v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasDerivationType() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearDerivationType() => clearField(3);
+}
+
+/// *
+///  Response: Contains public key derived from device private seed
+///  @end
+class CardanoPublicKey extends $pb.GeneratedMessage {
+  factory CardanoPublicKey({
+    $core.String? xpub,
+    $0.HDNodeType? node,
+  }) {
+    final $result = create();
+    if (xpub != null) {
+      $result.xpub = xpub;
+    }
+    if (node != null) {
+      $result.node = node;
+    }
+    return $result;
+  }
+  CardanoPublicKey._() : super();
+  factory CardanoPublicKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoPublicKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoPublicKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'xpub')
+    ..aQM<$0.HDNodeType>(2, _omitFieldNames ? '' : 'node', subBuilder: $0.HDNodeType.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoPublicKey clone() => CardanoPublicKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoPublicKey copyWith(void Function(CardanoPublicKey) updates) => super.copyWith((message) => updates(message as CardanoPublicKey)) as CardanoPublicKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoPublicKey create() => CardanoPublicKey._();
+  CardanoPublicKey createEmptyInstance() => create();
+  static $pb.PbList<CardanoPublicKey> createRepeated() => $pb.PbList<CardanoPublicKey>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoPublicKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoPublicKey>(create);
+  static CardanoPublicKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get xpub => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set xpub($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasXpub() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearXpub() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $0.HDNodeType get node => $_getN(1);
+  @$pb.TagNumber(2)
+  set node($0.HDNodeType v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasNode() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNode() => clearField(2);
+  @$pb.TagNumber(2)
+  $0.HDNodeType ensureNode() => $_ensure(1);
+}
+
+/// *
+///  Request: Initiate the Cardano transaction signing process on the device
+///  @start
+///  @next CardanoTxItemAck
+///  @next Failure
+class CardanoSignTxInit extends $pb.GeneratedMessage {
+  factory CardanoSignTxInit({
+    CardanoTxSigningMode? signingMode,
+    $core.int? protocolMagic,
+    $core.int? networkId,
+    $core.int? inputsCount,
+    $core.int? outputsCount,
+    $fixnum.Int64? fee,
+    $fixnum.Int64? ttl,
+    $core.int? certificatesCount,
+    $core.int? withdrawalsCount,
+    $core.bool? hasAuxiliaryData,
+    $fixnum.Int64? validityIntervalStart,
+    $core.int? witnessRequestsCount,
+    $core.int? mintingAssetGroupsCount,
+    CardanoDerivationType? derivationType,
+    $core.bool? includeNetworkId,
+    $core.List<$core.int>? scriptDataHash,
+    $core.int? collateralInputsCount,
+    $core.int? requiredSignersCount,
+    $core.bool? hasCollateralReturn,
+    $fixnum.Int64? totalCollateral,
+    $core.int? referenceInputsCount,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (signingMode != null) {
+      $result.signingMode = signingMode;
+    }
+    if (protocolMagic != null) {
+      $result.protocolMagic = protocolMagic;
+    }
+    if (networkId != null) {
+      $result.networkId = networkId;
+    }
+    if (inputsCount != null) {
+      $result.inputsCount = inputsCount;
+    }
+    if (outputsCount != null) {
+      $result.outputsCount = outputsCount;
+    }
+    if (fee != null) {
+      $result.fee = fee;
+    }
+    if (ttl != null) {
+      $result.ttl = ttl;
+    }
+    if (certificatesCount != null) {
+      $result.certificatesCount = certificatesCount;
+    }
+    if (withdrawalsCount != null) {
+      $result.withdrawalsCount = withdrawalsCount;
+    }
+    if (hasAuxiliaryData != null) {
+      $result.hasAuxiliaryData = hasAuxiliaryData;
+    }
+    if (validityIntervalStart != null) {
+      $result.validityIntervalStart = validityIntervalStart;
+    }
+    if (witnessRequestsCount != null) {
+      $result.witnessRequestsCount = witnessRequestsCount;
+    }
+    if (mintingAssetGroupsCount != null) {
+      $result.mintingAssetGroupsCount = mintingAssetGroupsCount;
+    }
+    if (derivationType != null) {
+      $result.derivationType = derivationType;
+    }
+    if (includeNetworkId != null) {
+      $result.includeNetworkId = includeNetworkId;
+    }
+    if (scriptDataHash != null) {
+      $result.scriptDataHash = scriptDataHash;
+    }
+    if (collateralInputsCount != null) {
+      $result.collateralInputsCount = collateralInputsCount;
+    }
+    if (requiredSignersCount != null) {
+      $result.requiredSignersCount = requiredSignersCount;
+    }
+    if (hasCollateralReturn != null) {
+      $result.hasCollateralReturn = hasCollateralReturn;
+    }
+    if (totalCollateral != null) {
+      $result.totalCollateral = totalCollateral;
+    }
+    if (referenceInputsCount != null) {
+      $result.referenceInputsCount = referenceInputsCount;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  CardanoSignTxInit._() : super();
+  factory CardanoSignTxInit.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoSignTxInit.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoSignTxInit', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..e<CardanoTxSigningMode>(1, _omitFieldNames ? '' : 'signingMode', $pb.PbFieldType.QE, defaultOrMaker: CardanoTxSigningMode.ORDINARY_TRANSACTION, valueOf: CardanoTxSigningMode.valueOf, enumValues: CardanoTxSigningMode.values)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'protocolMagic', $pb.PbFieldType.QU3)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'networkId', $pb.PbFieldType.QU3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'inputsCount', $pb.PbFieldType.QU3)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'outputsCount', $pb.PbFieldType.QU3)
+    ..a<$fixnum.Int64>(6, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(7, _omitFieldNames ? '' : 'ttl', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(8, _omitFieldNames ? '' : 'certificatesCount', $pb.PbFieldType.QU3)
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'withdrawalsCount', $pb.PbFieldType.QU3)
+    ..a<$core.bool>(10, _omitFieldNames ? '' : 'hasAuxiliaryData', $pb.PbFieldType.QB)
+    ..a<$fixnum.Int64>(11, _omitFieldNames ? '' : 'validityIntervalStart', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(12, _omitFieldNames ? '' : 'witnessRequestsCount', $pb.PbFieldType.QU3)
+    ..a<$core.int>(13, _omitFieldNames ? '' : 'mintingAssetGroupsCount', $pb.PbFieldType.QU3)
+    ..e<CardanoDerivationType>(14, _omitFieldNames ? '' : 'derivationType', $pb.PbFieldType.QE, defaultOrMaker: CardanoDerivationType.LEDGER, valueOf: CardanoDerivationType.valueOf, enumValues: CardanoDerivationType.values)
+    ..aOB(15, _omitFieldNames ? '' : 'includeNetworkId')
+    ..a<$core.List<$core.int>>(16, _omitFieldNames ? '' : 'scriptDataHash', $pb.PbFieldType.OY)
+    ..a<$core.int>(17, _omitFieldNames ? '' : 'collateralInputsCount', $pb.PbFieldType.QU3)
+    ..a<$core.int>(18, _omitFieldNames ? '' : 'requiredSignersCount', $pb.PbFieldType.QU3)
+    ..aOB(19, _omitFieldNames ? '' : 'hasCollateralReturn')
+    ..a<$fixnum.Int64>(20, _omitFieldNames ? '' : 'totalCollateral', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(21, _omitFieldNames ? '' : 'referenceInputsCount', $pb.PbFieldType.OU3)
+    ..aOB(22, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoSignTxInit clone() => CardanoSignTxInit()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoSignTxInit copyWith(void Function(CardanoSignTxInit) updates) => super.copyWith((message) => updates(message as CardanoSignTxInit)) as CardanoSignTxInit;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoSignTxInit create() => CardanoSignTxInit._();
+  CardanoSignTxInit createEmptyInstance() => create();
+  static $pb.PbList<CardanoSignTxInit> createRepeated() => $pb.PbList<CardanoSignTxInit>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoSignTxInit getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoSignTxInit>(create);
+  static CardanoSignTxInit? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  CardanoTxSigningMode get signingMode => $_getN(0);
+  @$pb.TagNumber(1)
+  set signingMode(CardanoTxSigningMode v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSigningMode() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSigningMode() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get protocolMagic => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set protocolMagic($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasProtocolMagic() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearProtocolMagic() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get networkId => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set networkId($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasNetworkId() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearNetworkId() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get inputsCount => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set inputsCount($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasInputsCount() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearInputsCount() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get outputsCount => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set outputsCount($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasOutputsCount() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearOutputsCount() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $fixnum.Int64 get fee => $_getI64(5);
+  @$pb.TagNumber(6)
+  set fee($fixnum.Int64 v) { $_setInt64(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasFee() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearFee() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $fixnum.Int64 get ttl => $_getI64(6);
+  @$pb.TagNumber(7)
+  set ttl($fixnum.Int64 v) { $_setInt64(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasTtl() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearTtl() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.int get certificatesCount => $_getIZ(7);
+  @$pb.TagNumber(8)
+  set certificatesCount($core.int v) { $_setUnsignedInt32(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasCertificatesCount() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearCertificatesCount() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.int get withdrawalsCount => $_getIZ(8);
+  @$pb.TagNumber(9)
+  set withdrawalsCount($core.int v) { $_setUnsignedInt32(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasWithdrawalsCount() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearWithdrawalsCount() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.bool get hasAuxiliaryData => $_getBF(9);
+  @$pb.TagNumber(10)
+  set hasAuxiliaryData($core.bool v) { $_setBool(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasHasAuxiliaryData() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearHasAuxiliaryData() => clearField(10);
+
+  @$pb.TagNumber(11)
+  $fixnum.Int64 get validityIntervalStart => $_getI64(10);
+  @$pb.TagNumber(11)
+  set validityIntervalStart($fixnum.Int64 v) { $_setInt64(10, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasValidityIntervalStart() => $_has(10);
+  @$pb.TagNumber(11)
+  void clearValidityIntervalStart() => clearField(11);
+
+  @$pb.TagNumber(12)
+  $core.int get witnessRequestsCount => $_getIZ(11);
+  @$pb.TagNumber(12)
+  set witnessRequestsCount($core.int v) { $_setUnsignedInt32(11, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasWitnessRequestsCount() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearWitnessRequestsCount() => clearField(12);
+
+  @$pb.TagNumber(13)
+  $core.int get mintingAssetGroupsCount => $_getIZ(12);
+  @$pb.TagNumber(13)
+  set mintingAssetGroupsCount($core.int v) { $_setUnsignedInt32(12, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasMintingAssetGroupsCount() => $_has(12);
+  @$pb.TagNumber(13)
+  void clearMintingAssetGroupsCount() => clearField(13);
+
+  @$pb.TagNumber(14)
+  CardanoDerivationType get derivationType => $_getN(13);
+  @$pb.TagNumber(14)
+  set derivationType(CardanoDerivationType v) { setField(14, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasDerivationType() => $_has(13);
+  @$pb.TagNumber(14)
+  void clearDerivationType() => clearField(14);
+
+  @$pb.TagNumber(15)
+  $core.bool get includeNetworkId => $_getBF(14);
+  @$pb.TagNumber(15)
+  set includeNetworkId($core.bool v) { $_setBool(14, v); }
+  @$pb.TagNumber(15)
+  $core.bool hasIncludeNetworkId() => $_has(14);
+  @$pb.TagNumber(15)
+  void clearIncludeNetworkId() => clearField(15);
+
+  @$pb.TagNumber(16)
+  $core.List<$core.int> get scriptDataHash => $_getN(15);
+  @$pb.TagNumber(16)
+  set scriptDataHash($core.List<$core.int> v) { $_setBytes(15, v); }
+  @$pb.TagNumber(16)
+  $core.bool hasScriptDataHash() => $_has(15);
+  @$pb.TagNumber(16)
+  void clearScriptDataHash() => clearField(16);
+
+  @$pb.TagNumber(17)
+  $core.int get collateralInputsCount => $_getIZ(16);
+  @$pb.TagNumber(17)
+  set collateralInputsCount($core.int v) { $_setUnsignedInt32(16, v); }
+  @$pb.TagNumber(17)
+  $core.bool hasCollateralInputsCount() => $_has(16);
+  @$pb.TagNumber(17)
+  void clearCollateralInputsCount() => clearField(17);
+
+  @$pb.TagNumber(18)
+  $core.int get requiredSignersCount => $_getIZ(17);
+  @$pb.TagNumber(18)
+  set requiredSignersCount($core.int v) { $_setUnsignedInt32(17, v); }
+  @$pb.TagNumber(18)
+  $core.bool hasRequiredSignersCount() => $_has(17);
+  @$pb.TagNumber(18)
+  void clearRequiredSignersCount() => clearField(18);
+
+  @$pb.TagNumber(19)
+  $core.bool get hasCollateralReturn => $_getBF(18);
+  @$pb.TagNumber(19)
+  set hasCollateralReturn($core.bool v) { $_setBool(18, v); }
+  @$pb.TagNumber(19)
+  $core.bool hasHasCollateralReturn() => $_has(18);
+  @$pb.TagNumber(19)
+  void clearHasCollateralReturn() => clearField(19);
+
+  @$pb.TagNumber(20)
+  $fixnum.Int64 get totalCollateral => $_getI64(19);
+  @$pb.TagNumber(20)
+  set totalCollateral($fixnum.Int64 v) { $_setInt64(19, v); }
+  @$pb.TagNumber(20)
+  $core.bool hasTotalCollateral() => $_has(19);
+  @$pb.TagNumber(20)
+  void clearTotalCollateral() => clearField(20);
+
+  @$pb.TagNumber(21)
+  $core.int get referenceInputsCount => $_getIZ(20);
+  @$pb.TagNumber(21)
+  set referenceInputsCount($core.int v) { $_setUnsignedInt32(20, v); }
+  @$pb.TagNumber(21)
+  $core.bool hasReferenceInputsCount() => $_has(20);
+  @$pb.TagNumber(21)
+  void clearReferenceInputsCount() => clearField(21);
+
+  @$pb.TagNumber(22)
+  $core.bool get chunkify => $_getBF(21);
+  @$pb.TagNumber(22)
+  set chunkify($core.bool v) { $_setBool(21, v); }
+  @$pb.TagNumber(22)
+  $core.bool hasChunkify() => $_has(21);
+  @$pb.TagNumber(22)
+  void clearChunkify() => clearField(22);
+}
+
+/// *
+///  Request: Transaction input data
+///  @next CardanoTxItemAck
+class CardanoTxInput extends $pb.GeneratedMessage {
+  factory CardanoTxInput({
+    $core.List<$core.int>? prevHash,
+    $core.int? prevIndex,
+  }) {
+    final $result = create();
+    if (prevHash != null) {
+      $result.prevHash = prevHash;
+    }
+    if (prevIndex != null) {
+      $result.prevIndex = prevIndex;
+    }
+    return $result;
+  }
+  CardanoTxInput._() : super();
+  factory CardanoTxInput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxInput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxInput', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'prevHash', $pb.PbFieldType.QY)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'prevIndex', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxInput clone() => CardanoTxInput()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxInput copyWith(void Function(CardanoTxInput) updates) => super.copyWith((message) => updates(message as CardanoTxInput)) as CardanoTxInput;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxInput create() => CardanoTxInput._();
+  CardanoTxInput createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxInput> createRepeated() => $pb.PbList<CardanoTxInput>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxInput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxInput>(create);
+  static CardanoTxInput? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get prevHash => $_getN(0);
+  @$pb.TagNumber(1)
+  set prevHash($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPrevHash() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPrevHash() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get prevIndex => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set prevIndex($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPrevIndex() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPrevIndex() => clearField(2);
+}
+
+/// *
+///  Request: Transaction output data
+///  @next CardanoTxItemAck
+class CardanoTxOutput extends $pb.GeneratedMessage {
+  factory CardanoTxOutput({
+    $core.String? address,
+    CardanoAddressParametersType? addressParameters,
+    $fixnum.Int64? amount,
+    $core.int? assetGroupsCount,
+    $core.List<$core.int>? datumHash,
+    CardanoTxOutputSerializationFormat? format,
+    $core.int? inlineDatumSize,
+    $core.int? referenceScriptSize,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    if (addressParameters != null) {
+      $result.addressParameters = addressParameters;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (assetGroupsCount != null) {
+      $result.assetGroupsCount = assetGroupsCount;
+    }
+    if (datumHash != null) {
+      $result.datumHash = datumHash;
+    }
+    if (format != null) {
+      $result.format = format;
+    }
+    if (inlineDatumSize != null) {
+      $result.inlineDatumSize = inlineDatumSize;
+    }
+    if (referenceScriptSize != null) {
+      $result.referenceScriptSize = referenceScriptSize;
+    }
+    return $result;
+  }
+  CardanoTxOutput._() : super();
+  factory CardanoTxOutput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxOutput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxOutput', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'address')
+    ..aOM<CardanoAddressParametersType>(2, _omitFieldNames ? '' : 'addressParameters', subBuilder: CardanoAddressParametersType.create)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'assetGroupsCount', $pb.PbFieldType.QU3)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'datumHash', $pb.PbFieldType.OY)
+    ..e<CardanoTxOutputSerializationFormat>(6, _omitFieldNames ? '' : 'format', $pb.PbFieldType.OE, defaultOrMaker: CardanoTxOutputSerializationFormat.ARRAY_LEGACY, valueOf: CardanoTxOutputSerializationFormat.valueOf, enumValues: CardanoTxOutputSerializationFormat.values)
+    ..a<$core.int>(7, _omitFieldNames ? '' : 'inlineDatumSize', $pb.PbFieldType.OU3)
+    ..a<$core.int>(8, _omitFieldNames ? '' : 'referenceScriptSize', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxOutput clone() => CardanoTxOutput()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxOutput copyWith(void Function(CardanoTxOutput) updates) => super.copyWith((message) => updates(message as CardanoTxOutput)) as CardanoTxOutput;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxOutput create() => CardanoTxOutput._();
+  CardanoTxOutput createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxOutput> createRepeated() => $pb.PbList<CardanoTxOutput>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxOutput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxOutput>(create);
+  static CardanoTxOutput? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+
+  @$pb.TagNumber(2)
+  CardanoAddressParametersType get addressParameters => $_getN(1);
+  @$pb.TagNumber(2)
+  set addressParameters(CardanoAddressParametersType v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAddressParameters() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAddressParameters() => clearField(2);
+  @$pb.TagNumber(2)
+  CardanoAddressParametersType ensureAddressParameters() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get amount => $_getI64(2);
+  @$pb.TagNumber(3)
+  set amount($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasAmount() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearAmount() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get assetGroupsCount => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set assetGroupsCount($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasAssetGroupsCount() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearAssetGroupsCount() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get datumHash => $_getN(4);
+  @$pb.TagNumber(5)
+  set datumHash($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasDatumHash() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearDatumHash() => clearField(5);
+
+  @$pb.TagNumber(6)
+  CardanoTxOutputSerializationFormat get format => $_getN(5);
+  @$pb.TagNumber(6)
+  set format(CardanoTxOutputSerializationFormat v) { setField(6, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasFormat() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearFormat() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.int get inlineDatumSize => $_getIZ(6);
+  @$pb.TagNumber(7)
+  set inlineDatumSize($core.int v) { $_setUnsignedInt32(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasInlineDatumSize() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearInlineDatumSize() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.int get referenceScriptSize => $_getIZ(7);
+  @$pb.TagNumber(8)
+  set referenceScriptSize($core.int v) { $_setUnsignedInt32(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasReferenceScriptSize() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearReferenceScriptSize() => clearField(8);
+}
+
+/// *
+///  Request: Transaction output asset group data
+///  @next CardanoTxItemAck
+class CardanoAssetGroup extends $pb.GeneratedMessage {
+  factory CardanoAssetGroup({
+    $core.List<$core.int>? policyId,
+    $core.int? tokensCount,
+  }) {
+    final $result = create();
+    if (policyId != null) {
+      $result.policyId = policyId;
+    }
+    if (tokensCount != null) {
+      $result.tokensCount = tokensCount;
+    }
+    return $result;
+  }
+  CardanoAssetGroup._() : super();
+  factory CardanoAssetGroup.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoAssetGroup.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoAssetGroup', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'policyId', $pb.PbFieldType.QY)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'tokensCount', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoAssetGroup clone() => CardanoAssetGroup()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoAssetGroup copyWith(void Function(CardanoAssetGroup) updates) => super.copyWith((message) => updates(message as CardanoAssetGroup)) as CardanoAssetGroup;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoAssetGroup create() => CardanoAssetGroup._();
+  CardanoAssetGroup createEmptyInstance() => create();
+  static $pb.PbList<CardanoAssetGroup> createRepeated() => $pb.PbList<CardanoAssetGroup>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoAssetGroup getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoAssetGroup>(create);
+  static CardanoAssetGroup? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get policyId => $_getN(0);
+  @$pb.TagNumber(1)
+  set policyId($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPolicyId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPolicyId() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get tokensCount => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set tokensCount($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTokensCount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTokensCount() => clearField(2);
+}
+
+/// *
+///  Request: Transaction output asset group token data
+///  @next CardanoTxItemAck
+class CardanoToken extends $pb.GeneratedMessage {
+  factory CardanoToken({
+    $core.List<$core.int>? assetNameBytes,
+    $fixnum.Int64? amount,
+    $fixnum.Int64? mintAmount,
+  }) {
+    final $result = create();
+    if (assetNameBytes != null) {
+      $result.assetNameBytes = assetNameBytes;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (mintAmount != null) {
+      $result.mintAmount = mintAmount;
+    }
+    return $result;
+  }
+  CardanoToken._() : super();
+  factory CardanoToken.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoToken.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoToken', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'assetNameBytes', $pb.PbFieldType.QY)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'mintAmount', $pb.PbFieldType.OS6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoToken clone() => CardanoToken()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoToken copyWith(void Function(CardanoToken) updates) => super.copyWith((message) => updates(message as CardanoToken)) as CardanoToken;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoToken create() => CardanoToken._();
+  CardanoToken createEmptyInstance() => create();
+  static $pb.PbList<CardanoToken> createRepeated() => $pb.PbList<CardanoToken>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoToken getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoToken>(create);
+  static CardanoToken? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get assetNameBytes => $_getN(0);
+  @$pb.TagNumber(1)
+  set assetNameBytes($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAssetNameBytes() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAssetNameBytes() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get amount => $_getI64(1);
+  @$pb.TagNumber(2)
+  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAmount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAmount() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get mintAmount => $_getI64(2);
+  @$pb.TagNumber(3)
+  set mintAmount($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasMintAmount() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearMintAmount() => clearField(3);
+}
+
+/// *
+///  Request: Transaction output inline datum chunk
+///  @next CardanoTxItemAck
+class CardanoTxInlineDatumChunk extends $pb.GeneratedMessage {
+  factory CardanoTxInlineDatumChunk({
+    $core.List<$core.int>? data,
+  }) {
+    final $result = create();
+    if (data != null) {
+      $result.data = data;
+    }
+    return $result;
+  }
+  CardanoTxInlineDatumChunk._() : super();
+  factory CardanoTxInlineDatumChunk.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxInlineDatumChunk.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxInlineDatumChunk', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'data', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxInlineDatumChunk clone() => CardanoTxInlineDatumChunk()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxInlineDatumChunk copyWith(void Function(CardanoTxInlineDatumChunk) updates) => super.copyWith((message) => updates(message as CardanoTxInlineDatumChunk)) as CardanoTxInlineDatumChunk;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxInlineDatumChunk create() => CardanoTxInlineDatumChunk._();
+  CardanoTxInlineDatumChunk createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxInlineDatumChunk> createRepeated() => $pb.PbList<CardanoTxInlineDatumChunk>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxInlineDatumChunk getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxInlineDatumChunk>(create);
+  static CardanoTxInlineDatumChunk? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get data => $_getN(0);
+  @$pb.TagNumber(1)
+  set data($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasData() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearData() => clearField(1);
+}
+
+/// *
+///  Request: Transaction output reference script chunk
+///  @next CardanoTxItemAck
+class CardanoTxReferenceScriptChunk extends $pb.GeneratedMessage {
+  factory CardanoTxReferenceScriptChunk({
+    $core.List<$core.int>? data,
+  }) {
+    final $result = create();
+    if (data != null) {
+      $result.data = data;
+    }
+    return $result;
+  }
+  CardanoTxReferenceScriptChunk._() : super();
+  factory CardanoTxReferenceScriptChunk.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxReferenceScriptChunk.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxReferenceScriptChunk', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'data', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxReferenceScriptChunk clone() => CardanoTxReferenceScriptChunk()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxReferenceScriptChunk copyWith(void Function(CardanoTxReferenceScriptChunk) updates) => super.copyWith((message) => updates(message as CardanoTxReferenceScriptChunk)) as CardanoTxReferenceScriptChunk;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxReferenceScriptChunk create() => CardanoTxReferenceScriptChunk._();
+  CardanoTxReferenceScriptChunk createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxReferenceScriptChunk> createRepeated() => $pb.PbList<CardanoTxReferenceScriptChunk>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxReferenceScriptChunk getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxReferenceScriptChunk>(create);
+  static CardanoTxReferenceScriptChunk? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get data => $_getN(0);
+  @$pb.TagNumber(1)
+  set data($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasData() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearData() => clearField(1);
+}
+
+/// *
+///  Request: Stake pool owner parameters
+///  @next CardanoTxItemAck
+class CardanoPoolOwner extends $pb.GeneratedMessage {
+  factory CardanoPoolOwner({
+    $core.Iterable<$core.int>? stakingKeyPath,
+    $core.List<$core.int>? stakingKeyHash,
+  }) {
+    final $result = create();
+    if (stakingKeyPath != null) {
+      $result.stakingKeyPath.addAll(stakingKeyPath);
+    }
+    if (stakingKeyHash != null) {
+      $result.stakingKeyHash = stakingKeyHash;
+    }
+    return $result;
+  }
+  CardanoPoolOwner._() : super();
+  factory CardanoPoolOwner.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoPoolOwner.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoPoolOwner', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'stakingKeyPath', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'stakingKeyHash', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoPoolOwner clone() => CardanoPoolOwner()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoPoolOwner copyWith(void Function(CardanoPoolOwner) updates) => super.copyWith((message) => updates(message as CardanoPoolOwner)) as CardanoPoolOwner;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoPoolOwner create() => CardanoPoolOwner._();
+  CardanoPoolOwner createEmptyInstance() => create();
+  static $pb.PbList<CardanoPoolOwner> createRepeated() => $pb.PbList<CardanoPoolOwner>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoPoolOwner getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoPoolOwner>(create);
+  static CardanoPoolOwner? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get stakingKeyPath => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get stakingKeyHash => $_getN(1);
+  @$pb.TagNumber(2)
+  set stakingKeyHash($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasStakingKeyHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearStakingKeyHash() => clearField(2);
+}
+
+/// *
+///  Request: Stake pool relay parameters
+///  @next CardanoTxItemAck
+class CardanoPoolRelayParameters extends $pb.GeneratedMessage {
+  factory CardanoPoolRelayParameters({
+    CardanoPoolRelayType? type,
+    $core.List<$core.int>? ipv4Address,
+    $core.List<$core.int>? ipv6Address,
+    $core.String? hostName,
+    $core.int? port,
+  }) {
+    final $result = create();
+    if (type != null) {
+      $result.type = type;
+    }
+    if (ipv4Address != null) {
+      $result.ipv4Address = ipv4Address;
+    }
+    if (ipv6Address != null) {
+      $result.ipv6Address = ipv6Address;
+    }
+    if (hostName != null) {
+      $result.hostName = hostName;
+    }
+    if (port != null) {
+      $result.port = port;
+    }
+    return $result;
+  }
+  CardanoPoolRelayParameters._() : super();
+  factory CardanoPoolRelayParameters.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoPoolRelayParameters.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoPoolRelayParameters', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..e<CardanoPoolRelayType>(1, _omitFieldNames ? '' : 'type', $pb.PbFieldType.QE, defaultOrMaker: CardanoPoolRelayType.SINGLE_HOST_IP, valueOf: CardanoPoolRelayType.valueOf, enumValues: CardanoPoolRelayType.values)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'ipv4Address', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'ipv6Address', $pb.PbFieldType.OY)
+    ..aOS(4, _omitFieldNames ? '' : 'hostName')
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'port', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoPoolRelayParameters clone() => CardanoPoolRelayParameters()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoPoolRelayParameters copyWith(void Function(CardanoPoolRelayParameters) updates) => super.copyWith((message) => updates(message as CardanoPoolRelayParameters)) as CardanoPoolRelayParameters;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoPoolRelayParameters create() => CardanoPoolRelayParameters._();
+  CardanoPoolRelayParameters createEmptyInstance() => create();
+  static $pb.PbList<CardanoPoolRelayParameters> createRepeated() => $pb.PbList<CardanoPoolRelayParameters>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoPoolRelayParameters getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoPoolRelayParameters>(create);
+  static CardanoPoolRelayParameters? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  CardanoPoolRelayType get type => $_getN(0);
+  @$pb.TagNumber(1)
+  set type(CardanoPoolRelayType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearType() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get ipv4Address => $_getN(1);
+  @$pb.TagNumber(2)
+  set ipv4Address($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasIpv4Address() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearIpv4Address() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get ipv6Address => $_getN(2);
+  @$pb.TagNumber(3)
+  set ipv6Address($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasIpv6Address() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearIpv6Address() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get hostName => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set hostName($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasHostName() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearHostName() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get port => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set port($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasPort() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearPort() => clearField(5);
+}
+
+/// *
+///  Stake pool metadata parameters
+///  @embed
+class CardanoPoolMetadataType extends $pb.GeneratedMessage {
+  factory CardanoPoolMetadataType({
+    $core.String? url,
+    $core.List<$core.int>? hash,
+  }) {
+    final $result = create();
+    if (url != null) {
+      $result.url = url;
+    }
+    if (hash != null) {
+      $result.hash = hash;
+    }
+    return $result;
+  }
+  CardanoPoolMetadataType._() : super();
+  factory CardanoPoolMetadataType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoPoolMetadataType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoPoolMetadataType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'url')
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'hash', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoPoolMetadataType clone() => CardanoPoolMetadataType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoPoolMetadataType copyWith(void Function(CardanoPoolMetadataType) updates) => super.copyWith((message) => updates(message as CardanoPoolMetadataType)) as CardanoPoolMetadataType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoPoolMetadataType create() => CardanoPoolMetadataType._();
+  CardanoPoolMetadataType createEmptyInstance() => create();
+  static $pb.PbList<CardanoPoolMetadataType> createRepeated() => $pb.PbList<CardanoPoolMetadataType>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoPoolMetadataType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoPoolMetadataType>(create);
+  static CardanoPoolMetadataType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get url => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set url($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasUrl() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearUrl() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get hash => $_getN(1);
+  @$pb.TagNumber(2)
+  set hash($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearHash() => clearField(2);
+}
+
+/// *
+///  Stake pool parameters
+///  @embed
+class CardanoPoolParametersType extends $pb.GeneratedMessage {
+  factory CardanoPoolParametersType({
+    $core.List<$core.int>? poolId,
+    $core.List<$core.int>? vrfKeyHash,
+    $fixnum.Int64? pledge,
+    $fixnum.Int64? cost,
+    $fixnum.Int64? marginNumerator,
+    $fixnum.Int64? marginDenominator,
+    $core.String? rewardAccount,
+    CardanoPoolMetadataType? metadata,
+    $core.int? ownersCount,
+    $core.int? relaysCount,
+  }) {
+    final $result = create();
+    if (poolId != null) {
+      $result.poolId = poolId;
+    }
+    if (vrfKeyHash != null) {
+      $result.vrfKeyHash = vrfKeyHash;
+    }
+    if (pledge != null) {
+      $result.pledge = pledge;
+    }
+    if (cost != null) {
+      $result.cost = cost;
+    }
+    if (marginNumerator != null) {
+      $result.marginNumerator = marginNumerator;
+    }
+    if (marginDenominator != null) {
+      $result.marginDenominator = marginDenominator;
+    }
+    if (rewardAccount != null) {
+      $result.rewardAccount = rewardAccount;
+    }
+    if (metadata != null) {
+      $result.metadata = metadata;
+    }
+    if (ownersCount != null) {
+      $result.ownersCount = ownersCount;
+    }
+    if (relaysCount != null) {
+      $result.relaysCount = relaysCount;
+    }
+    return $result;
+  }
+  CardanoPoolParametersType._() : super();
+  factory CardanoPoolParametersType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoPoolParametersType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoPoolParametersType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'poolId', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'vrfKeyHash', $pb.PbFieldType.QY)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'pledge', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'cost', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(5, _omitFieldNames ? '' : 'marginNumerator', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(6, _omitFieldNames ? '' : 'marginDenominator', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aQS(7, _omitFieldNames ? '' : 'rewardAccount')
+    ..aOM<CardanoPoolMetadataType>(10, _omitFieldNames ? '' : 'metadata', subBuilder: CardanoPoolMetadataType.create)
+    ..a<$core.int>(11, _omitFieldNames ? '' : 'ownersCount', $pb.PbFieldType.QU3)
+    ..a<$core.int>(12, _omitFieldNames ? '' : 'relaysCount', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoPoolParametersType clone() => CardanoPoolParametersType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoPoolParametersType copyWith(void Function(CardanoPoolParametersType) updates) => super.copyWith((message) => updates(message as CardanoPoolParametersType)) as CardanoPoolParametersType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoPoolParametersType create() => CardanoPoolParametersType._();
+  CardanoPoolParametersType createEmptyInstance() => create();
+  static $pb.PbList<CardanoPoolParametersType> createRepeated() => $pb.PbList<CardanoPoolParametersType>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoPoolParametersType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoPoolParametersType>(create);
+  static CardanoPoolParametersType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get poolId => $_getN(0);
+  @$pb.TagNumber(1)
+  set poolId($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPoolId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPoolId() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get vrfKeyHash => $_getN(1);
+  @$pb.TagNumber(2)
+  set vrfKeyHash($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasVrfKeyHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearVrfKeyHash() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get pledge => $_getI64(2);
+  @$pb.TagNumber(3)
+  set pledge($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasPledge() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearPledge() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get cost => $_getI64(3);
+  @$pb.TagNumber(4)
+  set cost($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasCost() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearCost() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $fixnum.Int64 get marginNumerator => $_getI64(4);
+  @$pb.TagNumber(5)
+  set marginNumerator($fixnum.Int64 v) { $_setInt64(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasMarginNumerator() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearMarginNumerator() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $fixnum.Int64 get marginDenominator => $_getI64(5);
+  @$pb.TagNumber(6)
+  set marginDenominator($fixnum.Int64 v) { $_setInt64(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasMarginDenominator() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearMarginDenominator() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.String get rewardAccount => $_getSZ(6);
+  @$pb.TagNumber(7)
+  set rewardAccount($core.String v) { $_setString(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasRewardAccount() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearRewardAccount() => clearField(7);
+
+  /// repeated CardanoPoolOwner owners = 8;            // legacy pool owners list - support for pre-tx-streaming firmwares dropped
+  /// repeated CardanoPoolRelayParameters relays = 9;  // legacy pool relays list - support for pre-tx-streaming firmwares dropped
+  @$pb.TagNumber(10)
+  CardanoPoolMetadataType get metadata => $_getN(7);
+  @$pb.TagNumber(10)
+  set metadata(CardanoPoolMetadataType v) { setField(10, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasMetadata() => $_has(7);
+  @$pb.TagNumber(10)
+  void clearMetadata() => clearField(10);
+  @$pb.TagNumber(10)
+  CardanoPoolMetadataType ensureMetadata() => $_ensure(7);
+
+  @$pb.TagNumber(11)
+  $core.int get ownersCount => $_getIZ(8);
+  @$pb.TagNumber(11)
+  set ownersCount($core.int v) { $_setUnsignedInt32(8, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasOwnersCount() => $_has(8);
+  @$pb.TagNumber(11)
+  void clearOwnersCount() => clearField(11);
+
+  @$pb.TagNumber(12)
+  $core.int get relaysCount => $_getIZ(9);
+  @$pb.TagNumber(12)
+  set relaysCount($core.int v) { $_setUnsignedInt32(9, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasRelaysCount() => $_has(9);
+  @$pb.TagNumber(12)
+  void clearRelaysCount() => clearField(12);
+}
+
+/// *
+///  Request: Transaction certificate data
+///  @next CardanoTxItemAck
+class CardanoTxCertificate extends $pb.GeneratedMessage {
+  factory CardanoTxCertificate({
+    CardanoCertificateType? type,
+    $core.Iterable<$core.int>? path,
+    $core.List<$core.int>? pool,
+    CardanoPoolParametersType? poolParameters,
+    $core.List<$core.int>? scriptHash,
+    $core.List<$core.int>? keyHash,
+  }) {
+    final $result = create();
+    if (type != null) {
+      $result.type = type;
+    }
+    if (path != null) {
+      $result.path.addAll(path);
+    }
+    if (pool != null) {
+      $result.pool = pool;
+    }
+    if (poolParameters != null) {
+      $result.poolParameters = poolParameters;
+    }
+    if (scriptHash != null) {
+      $result.scriptHash = scriptHash;
+    }
+    if (keyHash != null) {
+      $result.keyHash = keyHash;
+    }
+    return $result;
+  }
+  CardanoTxCertificate._() : super();
+  factory CardanoTxCertificate.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxCertificate.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxCertificate', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..e<CardanoCertificateType>(1, _omitFieldNames ? '' : 'type', $pb.PbFieldType.QE, defaultOrMaker: CardanoCertificateType.STAKE_REGISTRATION, valueOf: CardanoCertificateType.valueOf, enumValues: CardanoCertificateType.values)
+    ..p<$core.int>(2, _omitFieldNames ? '' : 'path', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'pool', $pb.PbFieldType.OY)
+    ..aOM<CardanoPoolParametersType>(4, _omitFieldNames ? '' : 'poolParameters', subBuilder: CardanoPoolParametersType.create)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'scriptHash', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'keyHash', $pb.PbFieldType.OY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxCertificate clone() => CardanoTxCertificate()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxCertificate copyWith(void Function(CardanoTxCertificate) updates) => super.copyWith((message) => updates(message as CardanoTxCertificate)) as CardanoTxCertificate;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxCertificate create() => CardanoTxCertificate._();
+  CardanoTxCertificate createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxCertificate> createRepeated() => $pb.PbList<CardanoTxCertificate>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxCertificate getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxCertificate>(create);
+  static CardanoTxCertificate? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  CardanoCertificateType get type => $_getN(0);
+  @$pb.TagNumber(1)
+  set type(CardanoCertificateType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearType() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get path => $_getList(1);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get pool => $_getN(2);
+  @$pb.TagNumber(3)
+  set pool($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasPool() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearPool() => clearField(3);
+
+  @$pb.TagNumber(4)
+  CardanoPoolParametersType get poolParameters => $_getN(3);
+  @$pb.TagNumber(4)
+  set poolParameters(CardanoPoolParametersType v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasPoolParameters() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearPoolParameters() => clearField(4);
+  @$pb.TagNumber(4)
+  CardanoPoolParametersType ensurePoolParameters() => $_ensure(3);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get scriptHash => $_getN(4);
+  @$pb.TagNumber(5)
+  set scriptHash($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasScriptHash() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearScriptHash() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get keyHash => $_getN(5);
+  @$pb.TagNumber(6)
+  set keyHash($core.List<$core.int> v) { $_setBytes(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasKeyHash() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearKeyHash() => clearField(6);
+}
+
+/// *
+///  Request: Transaction withdrawal data
+///  @next CardanoTxItemAck
+class CardanoTxWithdrawal extends $pb.GeneratedMessage {
+  factory CardanoTxWithdrawal({
+    $core.Iterable<$core.int>? path,
+    $fixnum.Int64? amount,
+    $core.List<$core.int>? scriptHash,
+    $core.List<$core.int>? keyHash,
+  }) {
+    final $result = create();
+    if (path != null) {
+      $result.path.addAll(path);
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (scriptHash != null) {
+      $result.scriptHash = scriptHash;
+    }
+    if (keyHash != null) {
+      $result.keyHash = keyHash;
+    }
+    return $result;
+  }
+  CardanoTxWithdrawal._() : super();
+  factory CardanoTxWithdrawal.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxWithdrawal.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxWithdrawal', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'path', $pb.PbFieldType.PU3)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'scriptHash', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'keyHash', $pb.PbFieldType.OY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxWithdrawal clone() => CardanoTxWithdrawal()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxWithdrawal copyWith(void Function(CardanoTxWithdrawal) updates) => super.copyWith((message) => updates(message as CardanoTxWithdrawal)) as CardanoTxWithdrawal;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxWithdrawal create() => CardanoTxWithdrawal._();
+  CardanoTxWithdrawal createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxWithdrawal> createRepeated() => $pb.PbList<CardanoTxWithdrawal>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxWithdrawal getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxWithdrawal>(create);
+  static CardanoTxWithdrawal? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get path => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get amount => $_getI64(1);
+  @$pb.TagNumber(2)
+  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAmount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAmount() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get scriptHash => $_getN(2);
+  @$pb.TagNumber(3)
+  set scriptHash($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasScriptHash() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearScriptHash() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get keyHash => $_getN(3);
+  @$pb.TagNumber(4)
+  set keyHash($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasKeyHash() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearKeyHash() => clearField(4);
+}
+
+/// *
+///  @embed
+class CardanoCVoteRegistrationDelegation extends $pb.GeneratedMessage {
+  factory CardanoCVoteRegistrationDelegation({
+    $core.List<$core.int>? votePublicKey,
+    $core.int? weight,
+  }) {
+    final $result = create();
+    if (votePublicKey != null) {
+      $result.votePublicKey = votePublicKey;
+    }
+    if (weight != null) {
+      $result.weight = weight;
+    }
+    return $result;
+  }
+  CardanoCVoteRegistrationDelegation._() : super();
+  factory CardanoCVoteRegistrationDelegation.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoCVoteRegistrationDelegation.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoCVoteRegistrationDelegation', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'votePublicKey', $pb.PbFieldType.QY)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'weight', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoCVoteRegistrationDelegation clone() => CardanoCVoteRegistrationDelegation()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoCVoteRegistrationDelegation copyWith(void Function(CardanoCVoteRegistrationDelegation) updates) => super.copyWith((message) => updates(message as CardanoCVoteRegistrationDelegation)) as CardanoCVoteRegistrationDelegation;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoCVoteRegistrationDelegation create() => CardanoCVoteRegistrationDelegation._();
+  CardanoCVoteRegistrationDelegation createEmptyInstance() => create();
+  static $pb.PbList<CardanoCVoteRegistrationDelegation> createRepeated() => $pb.PbList<CardanoCVoteRegistrationDelegation>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoCVoteRegistrationDelegation getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoCVoteRegistrationDelegation>(create);
+  static CardanoCVoteRegistrationDelegation? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get votePublicKey => $_getN(0);
+  @$pb.TagNumber(1)
+  set votePublicKey($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasVotePublicKey() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearVotePublicKey() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get weight => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set weight($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasWeight() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearWeight() => clearField(2);
+}
+
+/// *
+///  @embed
+class CardanoCVoteRegistrationParametersType extends $pb.GeneratedMessage {
+  factory CardanoCVoteRegistrationParametersType({
+    $core.List<$core.int>? votePublicKey,
+    $core.Iterable<$core.int>? stakingPath,
+    CardanoAddressParametersType? paymentAddressParameters,
+    $fixnum.Int64? nonce,
+    CardanoCVoteRegistrationFormat? format,
+    $core.Iterable<CardanoCVoteRegistrationDelegation>? delegations,
+    $fixnum.Int64? votingPurpose,
+    $core.String? paymentAddress,
+  }) {
+    final $result = create();
+    if (votePublicKey != null) {
+      $result.votePublicKey = votePublicKey;
+    }
+    if (stakingPath != null) {
+      $result.stakingPath.addAll(stakingPath);
+    }
+    if (paymentAddressParameters != null) {
+      $result.paymentAddressParameters = paymentAddressParameters;
+    }
+    if (nonce != null) {
+      $result.nonce = nonce;
+    }
+    if (format != null) {
+      $result.format = format;
+    }
+    if (delegations != null) {
+      $result.delegations.addAll(delegations);
+    }
+    if (votingPurpose != null) {
+      $result.votingPurpose = votingPurpose;
+    }
+    if (paymentAddress != null) {
+      $result.paymentAddress = paymentAddress;
+    }
+    return $result;
+  }
+  CardanoCVoteRegistrationParametersType._() : super();
+  factory CardanoCVoteRegistrationParametersType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoCVoteRegistrationParametersType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoCVoteRegistrationParametersType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'votePublicKey', $pb.PbFieldType.OY)
+    ..p<$core.int>(2, _omitFieldNames ? '' : 'stakingPath', $pb.PbFieldType.PU3)
+    ..aOM<CardanoAddressParametersType>(3, _omitFieldNames ? '' : 'paymentAddressParameters', subBuilder: CardanoAddressParametersType.create)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'nonce', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..e<CardanoCVoteRegistrationFormat>(5, _omitFieldNames ? '' : 'format', $pb.PbFieldType.OE, defaultOrMaker: CardanoCVoteRegistrationFormat.CIP15, valueOf: CardanoCVoteRegistrationFormat.valueOf, enumValues: CardanoCVoteRegistrationFormat.values)
+    ..pc<CardanoCVoteRegistrationDelegation>(6, _omitFieldNames ? '' : 'delegations', $pb.PbFieldType.PM, subBuilder: CardanoCVoteRegistrationDelegation.create)
+    ..a<$fixnum.Int64>(7, _omitFieldNames ? '' : 'votingPurpose', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aOS(8, _omitFieldNames ? '' : 'paymentAddress')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoCVoteRegistrationParametersType clone() => CardanoCVoteRegistrationParametersType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoCVoteRegistrationParametersType copyWith(void Function(CardanoCVoteRegistrationParametersType) updates) => super.copyWith((message) => updates(message as CardanoCVoteRegistrationParametersType)) as CardanoCVoteRegistrationParametersType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoCVoteRegistrationParametersType create() => CardanoCVoteRegistrationParametersType._();
+  CardanoCVoteRegistrationParametersType createEmptyInstance() => create();
+  static $pb.PbList<CardanoCVoteRegistrationParametersType> createRepeated() => $pb.PbList<CardanoCVoteRegistrationParametersType>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoCVoteRegistrationParametersType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoCVoteRegistrationParametersType>(create);
+  static CardanoCVoteRegistrationParametersType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get votePublicKey => $_getN(0);
+  @$pb.TagNumber(1)
+  set votePublicKey($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasVotePublicKey() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearVotePublicKey() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get stakingPath => $_getList(1);
+
+  @$pb.TagNumber(3)
+  CardanoAddressParametersType get paymentAddressParameters => $_getN(2);
+  @$pb.TagNumber(3)
+  set paymentAddressParameters(CardanoAddressParametersType v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasPaymentAddressParameters() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearPaymentAddressParameters() => clearField(3);
+  @$pb.TagNumber(3)
+  CardanoAddressParametersType ensurePaymentAddressParameters() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get nonce => $_getI64(3);
+  @$pb.TagNumber(4)
+  set nonce($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasNonce() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearNonce() => clearField(4);
+
+  @$pb.TagNumber(5)
+  CardanoCVoteRegistrationFormat get format => $_getN(4);
+  @$pb.TagNumber(5)
+  set format(CardanoCVoteRegistrationFormat v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasFormat() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearFormat() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<CardanoCVoteRegistrationDelegation> get delegations => $_getList(5);
+
+  @$pb.TagNumber(7)
+  $fixnum.Int64 get votingPurpose => $_getI64(6);
+  @$pb.TagNumber(7)
+  set votingPurpose($fixnum.Int64 v) { $_setInt64(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasVotingPurpose() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearVotingPurpose() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.String get paymentAddress => $_getSZ(7);
+  @$pb.TagNumber(8)
+  set paymentAddress($core.String v) { $_setString(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasPaymentAddress() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearPaymentAddress() => clearField(8);
+}
+
+/// *
+///  Request: Transaction auxiliary data
+///  @next CardanoTxItemAck
+///  @next CardanoTxAuxiliaryDataSupplement
+class CardanoTxAuxiliaryData extends $pb.GeneratedMessage {
+  factory CardanoTxAuxiliaryData({
+    CardanoCVoteRegistrationParametersType? cvoteRegistrationParameters,
+    $core.List<$core.int>? hash,
+  }) {
+    final $result = create();
+    if (cvoteRegistrationParameters != null) {
+      $result.cvoteRegistrationParameters = cvoteRegistrationParameters;
+    }
+    if (hash != null) {
+      $result.hash = hash;
+    }
+    return $result;
+  }
+  CardanoTxAuxiliaryData._() : super();
+  factory CardanoTxAuxiliaryData.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxAuxiliaryData.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxAuxiliaryData', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..aOM<CardanoCVoteRegistrationParametersType>(1, _omitFieldNames ? '' : 'cvoteRegistrationParameters', subBuilder: CardanoCVoteRegistrationParametersType.create)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'hash', $pb.PbFieldType.OY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxAuxiliaryData clone() => CardanoTxAuxiliaryData()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxAuxiliaryData copyWith(void Function(CardanoTxAuxiliaryData) updates) => super.copyWith((message) => updates(message as CardanoTxAuxiliaryData)) as CardanoTxAuxiliaryData;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxAuxiliaryData create() => CardanoTxAuxiliaryData._();
+  CardanoTxAuxiliaryData createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxAuxiliaryData> createRepeated() => $pb.PbList<CardanoTxAuxiliaryData>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxAuxiliaryData getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxAuxiliaryData>(create);
+  static CardanoTxAuxiliaryData? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  CardanoCVoteRegistrationParametersType get cvoteRegistrationParameters => $_getN(0);
+  @$pb.TagNumber(1)
+  set cvoteRegistrationParameters(CardanoCVoteRegistrationParametersType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasCvoteRegistrationParameters() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCvoteRegistrationParameters() => clearField(1);
+  @$pb.TagNumber(1)
+  CardanoCVoteRegistrationParametersType ensureCvoteRegistrationParameters() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get hash => $_getN(1);
+  @$pb.TagNumber(2)
+  set hash($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearHash() => clearField(2);
+}
+
+/// *
+///  Request: Transaction mint
+///  @next CardanoTxItemAck
+class CardanoTxMint extends $pb.GeneratedMessage {
+  factory CardanoTxMint({
+    $core.int? assetGroupsCount,
+  }) {
+    final $result = create();
+    if (assetGroupsCount != null) {
+      $result.assetGroupsCount = assetGroupsCount;
+    }
+    return $result;
+  }
+  CardanoTxMint._() : super();
+  factory CardanoTxMint.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxMint.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxMint', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'assetGroupsCount', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxMint clone() => CardanoTxMint()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxMint copyWith(void Function(CardanoTxMint) updates) => super.copyWith((message) => updates(message as CardanoTxMint)) as CardanoTxMint;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxMint create() => CardanoTxMint._();
+  CardanoTxMint createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxMint> createRepeated() => $pb.PbList<CardanoTxMint>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxMint getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxMint>(create);
+  static CardanoTxMint? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get assetGroupsCount => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set assetGroupsCount($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAssetGroupsCount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAssetGroupsCount() => clearField(1);
+}
+
+/// *
+///  Request: Transaction collateral input data
+///  @next CardanoTxItemAck
+class CardanoTxCollateralInput extends $pb.GeneratedMessage {
+  factory CardanoTxCollateralInput({
+    $core.List<$core.int>? prevHash,
+    $core.int? prevIndex,
+  }) {
+    final $result = create();
+    if (prevHash != null) {
+      $result.prevHash = prevHash;
+    }
+    if (prevIndex != null) {
+      $result.prevIndex = prevIndex;
+    }
+    return $result;
+  }
+  CardanoTxCollateralInput._() : super();
+  factory CardanoTxCollateralInput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxCollateralInput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxCollateralInput', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'prevHash', $pb.PbFieldType.QY)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'prevIndex', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxCollateralInput clone() => CardanoTxCollateralInput()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxCollateralInput copyWith(void Function(CardanoTxCollateralInput) updates) => super.copyWith((message) => updates(message as CardanoTxCollateralInput)) as CardanoTxCollateralInput;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxCollateralInput create() => CardanoTxCollateralInput._();
+  CardanoTxCollateralInput createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxCollateralInput> createRepeated() => $pb.PbList<CardanoTxCollateralInput>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxCollateralInput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxCollateralInput>(create);
+  static CardanoTxCollateralInput? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get prevHash => $_getN(0);
+  @$pb.TagNumber(1)
+  set prevHash($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPrevHash() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPrevHash() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get prevIndex => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set prevIndex($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPrevIndex() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPrevIndex() => clearField(2);
+}
+
+/// *
+///  Request: Transaction required signer
+///  @next CardanoTxItemAck
+class CardanoTxRequiredSigner extends $pb.GeneratedMessage {
+  factory CardanoTxRequiredSigner({
+    $core.List<$core.int>? keyHash,
+    $core.Iterable<$core.int>? keyPath,
+  }) {
+    final $result = create();
+    if (keyHash != null) {
+      $result.keyHash = keyHash;
+    }
+    if (keyPath != null) {
+      $result.keyPath.addAll(keyPath);
+    }
+    return $result;
+  }
+  CardanoTxRequiredSigner._() : super();
+  factory CardanoTxRequiredSigner.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxRequiredSigner.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxRequiredSigner', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'keyHash', $pb.PbFieldType.OY)
+    ..p<$core.int>(2, _omitFieldNames ? '' : 'keyPath', $pb.PbFieldType.PU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxRequiredSigner clone() => CardanoTxRequiredSigner()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxRequiredSigner copyWith(void Function(CardanoTxRequiredSigner) updates) => super.copyWith((message) => updates(message as CardanoTxRequiredSigner)) as CardanoTxRequiredSigner;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxRequiredSigner create() => CardanoTxRequiredSigner._();
+  CardanoTxRequiredSigner createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxRequiredSigner> createRepeated() => $pb.PbList<CardanoTxRequiredSigner>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxRequiredSigner getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxRequiredSigner>(create);
+  static CardanoTxRequiredSigner? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get keyHash => $_getN(0);
+  @$pb.TagNumber(1)
+  set keyHash($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasKeyHash() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearKeyHash() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get keyPath => $_getList(1);
+}
+
+/// *
+///  Request: Transaction reference input data
+///  @next CardanoTxItemAck
+class CardanoTxReferenceInput extends $pb.GeneratedMessage {
+  factory CardanoTxReferenceInput({
+    $core.List<$core.int>? prevHash,
+    $core.int? prevIndex,
+  }) {
+    final $result = create();
+    if (prevHash != null) {
+      $result.prevHash = prevHash;
+    }
+    if (prevIndex != null) {
+      $result.prevIndex = prevIndex;
+    }
+    return $result;
+  }
+  CardanoTxReferenceInput._() : super();
+  factory CardanoTxReferenceInput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxReferenceInput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxReferenceInput', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'prevHash', $pb.PbFieldType.QY)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'prevIndex', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxReferenceInput clone() => CardanoTxReferenceInput()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxReferenceInput copyWith(void Function(CardanoTxReferenceInput) updates) => super.copyWith((message) => updates(message as CardanoTxReferenceInput)) as CardanoTxReferenceInput;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxReferenceInput create() => CardanoTxReferenceInput._();
+  CardanoTxReferenceInput createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxReferenceInput> createRepeated() => $pb.PbList<CardanoTxReferenceInput>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxReferenceInput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxReferenceInput>(create);
+  static CardanoTxReferenceInput? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get prevHash => $_getN(0);
+  @$pb.TagNumber(1)
+  set prevHash($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPrevHash() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPrevHash() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get prevIndex => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set prevIndex($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPrevIndex() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPrevIndex() => clearField(2);
+}
+
+/// *
+///  Response: Acknowledgement of the last transaction item received
+///  @next CardanoTxInput
+///  @next CardanoTxOutput
+///  @next CardanoAssetGroup
+///  @next CardanoToken
+///  @next CardanoTxInlineDatumChunk
+///  @next CardanoTxReferenceScriptChunk
+///  @next CardanoTxCertificate
+///  @next CardanoPoolOwner
+///  @next CardanoPoolRelayParameters
+///  @next CardanoTxWithdrawal
+///  @next CardanoTxAuxiliaryData
+///  @next CardanoTxWitnessRequest
+///  @next CardanoTxMint
+///  @next CardanoTxCollateralInput
+///  @next CardanoTxRequiredSigner
+///  @next CardanoTxReferenceInput
+class CardanoTxItemAck extends $pb.GeneratedMessage {
+  factory CardanoTxItemAck() => create();
+  CardanoTxItemAck._() : super();
+  factory CardanoTxItemAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxItemAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxItemAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxItemAck clone() => CardanoTxItemAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxItemAck copyWith(void Function(CardanoTxItemAck) updates) => super.copyWith((message) => updates(message as CardanoTxItemAck)) as CardanoTxItemAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxItemAck create() => CardanoTxItemAck._();
+  CardanoTxItemAck createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxItemAck> createRepeated() => $pb.PbList<CardanoTxItemAck>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxItemAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxItemAck>(create);
+  static CardanoTxItemAck? _defaultInstance;
+}
+
+/// *
+///  Response: Device-generated supplement for the auxiliary data
+///  @next CardanoTxWitnessRequest
+class CardanoTxAuxiliaryDataSupplement extends $pb.GeneratedMessage {
+  factory CardanoTxAuxiliaryDataSupplement({
+    CardanoTxAuxiliaryDataSupplementType? type,
+    $core.List<$core.int>? auxiliaryDataHash,
+    $core.List<$core.int>? cvoteRegistrationSignature,
+  }) {
+    final $result = create();
+    if (type != null) {
+      $result.type = type;
+    }
+    if (auxiliaryDataHash != null) {
+      $result.auxiliaryDataHash = auxiliaryDataHash;
+    }
+    if (cvoteRegistrationSignature != null) {
+      $result.cvoteRegistrationSignature = cvoteRegistrationSignature;
+    }
+    return $result;
+  }
+  CardanoTxAuxiliaryDataSupplement._() : super();
+  factory CardanoTxAuxiliaryDataSupplement.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxAuxiliaryDataSupplement.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxAuxiliaryDataSupplement', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..e<CardanoTxAuxiliaryDataSupplementType>(1, _omitFieldNames ? '' : 'type', $pb.PbFieldType.QE, defaultOrMaker: CardanoTxAuxiliaryDataSupplementType.NONE, valueOf: CardanoTxAuxiliaryDataSupplementType.valueOf, enumValues: CardanoTxAuxiliaryDataSupplementType.values)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'auxiliaryDataHash', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'cvoteRegistrationSignature', $pb.PbFieldType.OY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxAuxiliaryDataSupplement clone() => CardanoTxAuxiliaryDataSupplement()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxAuxiliaryDataSupplement copyWith(void Function(CardanoTxAuxiliaryDataSupplement) updates) => super.copyWith((message) => updates(message as CardanoTxAuxiliaryDataSupplement)) as CardanoTxAuxiliaryDataSupplement;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxAuxiliaryDataSupplement create() => CardanoTxAuxiliaryDataSupplement._();
+  CardanoTxAuxiliaryDataSupplement createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxAuxiliaryDataSupplement> createRepeated() => $pb.PbList<CardanoTxAuxiliaryDataSupplement>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxAuxiliaryDataSupplement getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxAuxiliaryDataSupplement>(create);
+  static CardanoTxAuxiliaryDataSupplement? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  CardanoTxAuxiliaryDataSupplementType get type => $_getN(0);
+  @$pb.TagNumber(1)
+  set type(CardanoTxAuxiliaryDataSupplementType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearType() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get auxiliaryDataHash => $_getN(1);
+  @$pb.TagNumber(2)
+  set auxiliaryDataHash($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAuxiliaryDataHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAuxiliaryDataHash() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get cvoteRegistrationSignature => $_getN(2);
+  @$pb.TagNumber(3)
+  set cvoteRegistrationSignature($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasCvoteRegistrationSignature() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearCvoteRegistrationSignature() => clearField(3);
+}
+
+/// *
+///  Request: Ask the device to sign a witness path
+///  @next CardanoTxWitnessResponse
+class CardanoTxWitnessRequest extends $pb.GeneratedMessage {
+  factory CardanoTxWitnessRequest({
+    $core.Iterable<$core.int>? path,
+  }) {
+    final $result = create();
+    if (path != null) {
+      $result.path.addAll(path);
+    }
+    return $result;
+  }
+  CardanoTxWitnessRequest._() : super();
+  factory CardanoTxWitnessRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxWitnessRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxWitnessRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'path', $pb.PbFieldType.PU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxWitnessRequest clone() => CardanoTxWitnessRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxWitnessRequest copyWith(void Function(CardanoTxWitnessRequest) updates) => super.copyWith((message) => updates(message as CardanoTxWitnessRequest)) as CardanoTxWitnessRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxWitnessRequest create() => CardanoTxWitnessRequest._();
+  CardanoTxWitnessRequest createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxWitnessRequest> createRepeated() => $pb.PbList<CardanoTxWitnessRequest>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxWitnessRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxWitnessRequest>(create);
+  static CardanoTxWitnessRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get path => $_getList(0);
+}
+
+/// *
+///  Response: Signature corresponding to the requested witness path
+///  @next CardanoTxWitnessRequest
+///  @next CardanoTxHostAck
+class CardanoTxWitnessResponse extends $pb.GeneratedMessage {
+  factory CardanoTxWitnessResponse({
+    CardanoTxWitnessType? type,
+    $core.List<$core.int>? pubKey,
+    $core.List<$core.int>? signature,
+    $core.List<$core.int>? chainCode,
+  }) {
+    final $result = create();
+    if (type != null) {
+      $result.type = type;
+    }
+    if (pubKey != null) {
+      $result.pubKey = pubKey;
+    }
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    if (chainCode != null) {
+      $result.chainCode = chainCode;
+    }
+    return $result;
+  }
+  CardanoTxWitnessResponse._() : super();
+  factory CardanoTxWitnessResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxWitnessResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxWitnessResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..e<CardanoTxWitnessType>(1, _omitFieldNames ? '' : 'type', $pb.PbFieldType.QE, defaultOrMaker: CardanoTxWitnessType.BYRON_WITNESS, valueOf: CardanoTxWitnessType.valueOf, enumValues: CardanoTxWitnessType.values)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'pubKey', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'chainCode', $pb.PbFieldType.OY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxWitnessResponse clone() => CardanoTxWitnessResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxWitnessResponse copyWith(void Function(CardanoTxWitnessResponse) updates) => super.copyWith((message) => updates(message as CardanoTxWitnessResponse)) as CardanoTxWitnessResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxWitnessResponse create() => CardanoTxWitnessResponse._();
+  CardanoTxWitnessResponse createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxWitnessResponse> createRepeated() => $pb.PbList<CardanoTxWitnessResponse>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxWitnessResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxWitnessResponse>(create);
+  static CardanoTxWitnessResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  CardanoTxWitnessType get type => $_getN(0);
+  @$pb.TagNumber(1)
+  set type(CardanoTxWitnessType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearType() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get pubKey => $_getN(1);
+  @$pb.TagNumber(2)
+  set pubKey($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPubKey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPubKey() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get signature => $_getN(2);
+  @$pb.TagNumber(3)
+  set signature($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSignature() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSignature() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get chainCode => $_getN(3);
+  @$pb.TagNumber(4)
+  set chainCode($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasChainCode() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearChainCode() => clearField(4);
+}
+
+/// *
+///  Request: Acknowledgement of the last response received
+///  @next CardanoTxBodyHash
+///  @next CardanoSignTxFinished
+class CardanoTxHostAck extends $pb.GeneratedMessage {
+  factory CardanoTxHostAck() => create();
+  CardanoTxHostAck._() : super();
+  factory CardanoTxHostAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxHostAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxHostAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxHostAck clone() => CardanoTxHostAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxHostAck copyWith(void Function(CardanoTxHostAck) updates) => super.copyWith((message) => updates(message as CardanoTxHostAck)) as CardanoTxHostAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxHostAck create() => CardanoTxHostAck._();
+  CardanoTxHostAck createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxHostAck> createRepeated() => $pb.PbList<CardanoTxHostAck>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxHostAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxHostAck>(create);
+  static CardanoTxHostAck? _defaultInstance;
+}
+
+/// *
+///  Response: Hash of the serialized transaction body
+///  @next CardanoTxHostAck
+class CardanoTxBodyHash extends $pb.GeneratedMessage {
+  factory CardanoTxBodyHash({
+    $core.List<$core.int>? txHash,
+  }) {
+    final $result = create();
+    if (txHash != null) {
+      $result.txHash = txHash;
+    }
+    return $result;
+  }
+  CardanoTxBodyHash._() : super();
+  factory CardanoTxBodyHash.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoTxBodyHash.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoTxBodyHash', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'txHash', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoTxBodyHash clone() => CardanoTxBodyHash()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoTxBodyHash copyWith(void Function(CardanoTxBodyHash) updates) => super.copyWith((message) => updates(message as CardanoTxBodyHash)) as CardanoTxBodyHash;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxBodyHash create() => CardanoTxBodyHash._();
+  CardanoTxBodyHash createEmptyInstance() => create();
+  static $pb.PbList<CardanoTxBodyHash> createRepeated() => $pb.PbList<CardanoTxBodyHash>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoTxBodyHash getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoTxBodyHash>(create);
+  static CardanoTxBodyHash? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get txHash => $_getN(0);
+  @$pb.TagNumber(1)
+  set txHash($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTxHash() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTxHash() => clearField(1);
+}
+
+/// *
+///  Response: Confirm the successful completion of the signing process
+///  @end
+class CardanoSignTxFinished extends $pb.GeneratedMessage {
+  factory CardanoSignTxFinished() => create();
+  CardanoSignTxFinished._() : super();
+  factory CardanoSignTxFinished.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CardanoSignTxFinished.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CardanoSignTxFinished', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.cardano'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CardanoSignTxFinished clone() => CardanoSignTxFinished()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CardanoSignTxFinished copyWith(void Function(CardanoSignTxFinished) updates) => super.copyWith((message) => updates(message as CardanoSignTxFinished)) as CardanoSignTxFinished;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CardanoSignTxFinished create() => CardanoSignTxFinished._();
+  CardanoSignTxFinished createEmptyInstance() => create();
+  static $pb.PbList<CardanoSignTxFinished> createRepeated() => $pb.PbList<CardanoSignTxFinished>();
+  @$core.pragma('dart2js:noInline')
+  static CardanoSignTxFinished getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CardanoSignTxFinished>(create);
+  static CardanoSignTxFinished? _defaultInstance;
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-cardano.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-cardano.pbenum.dart
@@ -1,0 +1,225 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-cardano.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+class CardanoDerivationType extends $pb.ProtobufEnum {
+  static const CardanoDerivationType LEDGER = CardanoDerivationType._(0, _omitEnumNames ? '' : 'LEDGER');
+  static const CardanoDerivationType ICARUS = CardanoDerivationType._(1, _omitEnumNames ? '' : 'ICARUS');
+  static const CardanoDerivationType ICARUS_TREZOR = CardanoDerivationType._(2, _omitEnumNames ? '' : 'ICARUS_TREZOR');
+
+  static const $core.List<CardanoDerivationType> values = <CardanoDerivationType> [
+    LEDGER,
+    ICARUS,
+    ICARUS_TREZOR,
+  ];
+
+  static final $core.Map<$core.int, CardanoDerivationType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static CardanoDerivationType? valueOf($core.int value) => _byValue[value];
+
+  const CardanoDerivationType._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Values correspond to address header values given by the spec.
+///  Script addresses are only supported in transaction outputs.
+class CardanoAddressType extends $pb.ProtobufEnum {
+  static const CardanoAddressType BASE = CardanoAddressType._(0, _omitEnumNames ? '' : 'BASE');
+  static const CardanoAddressType BASE_SCRIPT_KEY = CardanoAddressType._(1, _omitEnumNames ? '' : 'BASE_SCRIPT_KEY');
+  static const CardanoAddressType BASE_KEY_SCRIPT = CardanoAddressType._(2, _omitEnumNames ? '' : 'BASE_KEY_SCRIPT');
+  static const CardanoAddressType BASE_SCRIPT_SCRIPT = CardanoAddressType._(3, _omitEnumNames ? '' : 'BASE_SCRIPT_SCRIPT');
+  static const CardanoAddressType POINTER = CardanoAddressType._(4, _omitEnumNames ? '' : 'POINTER');
+  static const CardanoAddressType POINTER_SCRIPT = CardanoAddressType._(5, _omitEnumNames ? '' : 'POINTER_SCRIPT');
+  static const CardanoAddressType ENTERPRISE = CardanoAddressType._(6, _omitEnumNames ? '' : 'ENTERPRISE');
+  static const CardanoAddressType ENTERPRISE_SCRIPT = CardanoAddressType._(7, _omitEnumNames ? '' : 'ENTERPRISE_SCRIPT');
+  static const CardanoAddressType BYRON = CardanoAddressType._(8, _omitEnumNames ? '' : 'BYRON');
+  static const CardanoAddressType REWARD = CardanoAddressType._(14, _omitEnumNames ? '' : 'REWARD');
+  static const CardanoAddressType REWARD_SCRIPT = CardanoAddressType._(15, _omitEnumNames ? '' : 'REWARD_SCRIPT');
+
+  static const $core.List<CardanoAddressType> values = <CardanoAddressType> [
+    BASE,
+    BASE_SCRIPT_KEY,
+    BASE_KEY_SCRIPT,
+    BASE_SCRIPT_SCRIPT,
+    POINTER,
+    POINTER_SCRIPT,
+    ENTERPRISE,
+    ENTERPRISE_SCRIPT,
+    BYRON,
+    REWARD,
+    REWARD_SCRIPT,
+  ];
+
+  static final $core.Map<$core.int, CardanoAddressType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static CardanoAddressType? valueOf($core.int value) => _byValue[value];
+
+  const CardanoAddressType._($core.int v, $core.String n) : super(v, n);
+}
+
+class CardanoNativeScriptType extends $pb.ProtobufEnum {
+  static const CardanoNativeScriptType PUB_KEY = CardanoNativeScriptType._(0, _omitEnumNames ? '' : 'PUB_KEY');
+  static const CardanoNativeScriptType ALL = CardanoNativeScriptType._(1, _omitEnumNames ? '' : 'ALL');
+  static const CardanoNativeScriptType ANY = CardanoNativeScriptType._(2, _omitEnumNames ? '' : 'ANY');
+  static const CardanoNativeScriptType N_OF_K = CardanoNativeScriptType._(3, _omitEnumNames ? '' : 'N_OF_K');
+  static const CardanoNativeScriptType INVALID_BEFORE = CardanoNativeScriptType._(4, _omitEnumNames ? '' : 'INVALID_BEFORE');
+  static const CardanoNativeScriptType INVALID_HEREAFTER = CardanoNativeScriptType._(5, _omitEnumNames ? '' : 'INVALID_HEREAFTER');
+
+  static const $core.List<CardanoNativeScriptType> values = <CardanoNativeScriptType> [
+    PUB_KEY,
+    ALL,
+    ANY,
+    N_OF_K,
+    INVALID_BEFORE,
+    INVALID_HEREAFTER,
+  ];
+
+  static final $core.Map<$core.int, CardanoNativeScriptType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static CardanoNativeScriptType? valueOf($core.int value) => _byValue[value];
+
+  const CardanoNativeScriptType._($core.int v, $core.String n) : super(v, n);
+}
+
+class CardanoNativeScriptHashDisplayFormat extends $pb.ProtobufEnum {
+  static const CardanoNativeScriptHashDisplayFormat HIDE = CardanoNativeScriptHashDisplayFormat._(0, _omitEnumNames ? '' : 'HIDE');
+  static const CardanoNativeScriptHashDisplayFormat BECH32 = CardanoNativeScriptHashDisplayFormat._(1, _omitEnumNames ? '' : 'BECH32');
+  static const CardanoNativeScriptHashDisplayFormat POLICY_ID = CardanoNativeScriptHashDisplayFormat._(2, _omitEnumNames ? '' : 'POLICY_ID');
+
+  static const $core.List<CardanoNativeScriptHashDisplayFormat> values = <CardanoNativeScriptHashDisplayFormat> [
+    HIDE,
+    BECH32,
+    POLICY_ID,
+  ];
+
+  static final $core.Map<$core.int, CardanoNativeScriptHashDisplayFormat> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static CardanoNativeScriptHashDisplayFormat? valueOf($core.int value) => _byValue[value];
+
+  const CardanoNativeScriptHashDisplayFormat._($core.int v, $core.String n) : super(v, n);
+}
+
+class CardanoTxOutputSerializationFormat extends $pb.ProtobufEnum {
+  static const CardanoTxOutputSerializationFormat ARRAY_LEGACY = CardanoTxOutputSerializationFormat._(0, _omitEnumNames ? '' : 'ARRAY_LEGACY');
+  static const CardanoTxOutputSerializationFormat MAP_BABBAGE = CardanoTxOutputSerializationFormat._(1, _omitEnumNames ? '' : 'MAP_BABBAGE');
+
+  static const $core.List<CardanoTxOutputSerializationFormat> values = <CardanoTxOutputSerializationFormat> [
+    ARRAY_LEGACY,
+    MAP_BABBAGE,
+  ];
+
+  static final $core.Map<$core.int, CardanoTxOutputSerializationFormat> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static CardanoTxOutputSerializationFormat? valueOf($core.int value) => _byValue[value];
+
+  const CardanoTxOutputSerializationFormat._($core.int v, $core.String n) : super(v, n);
+}
+
+class CardanoCertificateType extends $pb.ProtobufEnum {
+  static const CardanoCertificateType STAKE_REGISTRATION = CardanoCertificateType._(0, _omitEnumNames ? '' : 'STAKE_REGISTRATION');
+  static const CardanoCertificateType STAKE_DEREGISTRATION = CardanoCertificateType._(1, _omitEnumNames ? '' : 'STAKE_DEREGISTRATION');
+  static const CardanoCertificateType STAKE_DELEGATION = CardanoCertificateType._(2, _omitEnumNames ? '' : 'STAKE_DELEGATION');
+  static const CardanoCertificateType STAKE_POOL_REGISTRATION = CardanoCertificateType._(3, _omitEnumNames ? '' : 'STAKE_POOL_REGISTRATION');
+
+  static const $core.List<CardanoCertificateType> values = <CardanoCertificateType> [
+    STAKE_REGISTRATION,
+    STAKE_DEREGISTRATION,
+    STAKE_DELEGATION,
+    STAKE_POOL_REGISTRATION,
+  ];
+
+  static final $core.Map<$core.int, CardanoCertificateType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static CardanoCertificateType? valueOf($core.int value) => _byValue[value];
+
+  const CardanoCertificateType._($core.int v, $core.String n) : super(v, n);
+}
+
+class CardanoPoolRelayType extends $pb.ProtobufEnum {
+  static const CardanoPoolRelayType SINGLE_HOST_IP = CardanoPoolRelayType._(0, _omitEnumNames ? '' : 'SINGLE_HOST_IP');
+  static const CardanoPoolRelayType SINGLE_HOST_NAME = CardanoPoolRelayType._(1, _omitEnumNames ? '' : 'SINGLE_HOST_NAME');
+  static const CardanoPoolRelayType MULTIPLE_HOST_NAME = CardanoPoolRelayType._(2, _omitEnumNames ? '' : 'MULTIPLE_HOST_NAME');
+
+  static const $core.List<CardanoPoolRelayType> values = <CardanoPoolRelayType> [
+    SINGLE_HOST_IP,
+    SINGLE_HOST_NAME,
+    MULTIPLE_HOST_NAME,
+  ];
+
+  static final $core.Map<$core.int, CardanoPoolRelayType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static CardanoPoolRelayType? valueOf($core.int value) => _byValue[value];
+
+  const CardanoPoolRelayType._($core.int v, $core.String n) : super(v, n);
+}
+
+class CardanoTxAuxiliaryDataSupplementType extends $pb.ProtobufEnum {
+  static const CardanoTxAuxiliaryDataSupplementType NONE = CardanoTxAuxiliaryDataSupplementType._(0, _omitEnumNames ? '' : 'NONE');
+  static const CardanoTxAuxiliaryDataSupplementType CVOTE_REGISTRATION_SIGNATURE = CardanoTxAuxiliaryDataSupplementType._(1, _omitEnumNames ? '' : 'CVOTE_REGISTRATION_SIGNATURE');
+
+  static const $core.List<CardanoTxAuxiliaryDataSupplementType> values = <CardanoTxAuxiliaryDataSupplementType> [
+    NONE,
+    CVOTE_REGISTRATION_SIGNATURE,
+  ];
+
+  static final $core.Map<$core.int, CardanoTxAuxiliaryDataSupplementType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static CardanoTxAuxiliaryDataSupplementType? valueOf($core.int value) => _byValue[value];
+
+  const CardanoTxAuxiliaryDataSupplementType._($core.int v, $core.String n) : super(v, n);
+}
+
+class CardanoCVoteRegistrationFormat extends $pb.ProtobufEnum {
+  static const CardanoCVoteRegistrationFormat CIP15 = CardanoCVoteRegistrationFormat._(0, _omitEnumNames ? '' : 'CIP15');
+  static const CardanoCVoteRegistrationFormat CIP36 = CardanoCVoteRegistrationFormat._(1, _omitEnumNames ? '' : 'CIP36');
+
+  static const $core.List<CardanoCVoteRegistrationFormat> values = <CardanoCVoteRegistrationFormat> [
+    CIP15,
+    CIP36,
+  ];
+
+  static final $core.Map<$core.int, CardanoCVoteRegistrationFormat> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static CardanoCVoteRegistrationFormat? valueOf($core.int value) => _byValue[value];
+
+  const CardanoCVoteRegistrationFormat._($core.int v, $core.String n) : super(v, n);
+}
+
+class CardanoTxSigningMode extends $pb.ProtobufEnum {
+  static const CardanoTxSigningMode ORDINARY_TRANSACTION = CardanoTxSigningMode._(0, _omitEnumNames ? '' : 'ORDINARY_TRANSACTION');
+  static const CardanoTxSigningMode POOL_REGISTRATION_AS_OWNER = CardanoTxSigningMode._(1, _omitEnumNames ? '' : 'POOL_REGISTRATION_AS_OWNER');
+  static const CardanoTxSigningMode MULTISIG_TRANSACTION = CardanoTxSigningMode._(2, _omitEnumNames ? '' : 'MULTISIG_TRANSACTION');
+  static const CardanoTxSigningMode PLUTUS_TRANSACTION = CardanoTxSigningMode._(3, _omitEnumNames ? '' : 'PLUTUS_TRANSACTION');
+
+  static const $core.List<CardanoTxSigningMode> values = <CardanoTxSigningMode> [
+    ORDINARY_TRANSACTION,
+    POOL_REGISTRATION_AS_OWNER,
+    MULTISIG_TRANSACTION,
+    PLUTUS_TRANSACTION,
+  ];
+
+  static final $core.Map<$core.int, CardanoTxSigningMode> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static CardanoTxSigningMode? valueOf($core.int value) => _byValue[value];
+
+  const CardanoTxSigningMode._($core.int v, $core.String n) : super(v, n);
+}
+
+class CardanoTxWitnessType extends $pb.ProtobufEnum {
+  static const CardanoTxWitnessType BYRON_WITNESS = CardanoTxWitnessType._(0, _omitEnumNames ? '' : 'BYRON_WITNESS');
+  static const CardanoTxWitnessType SHELLEY_WITNESS = CardanoTxWitnessType._(1, _omitEnumNames ? '' : 'SHELLEY_WITNESS');
+
+  static const $core.List<CardanoTxWitnessType> values = <CardanoTxWitnessType> [
+    BYRON_WITNESS,
+    SHELLEY_WITNESS,
+  ];
+
+  static final $core.Map<$core.int, CardanoTxWitnessType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static CardanoTxWitnessType? valueOf($core.int value) => _byValue[value];
+
+  const CardanoTxWitnessType._($core.int v, $core.String n) : super(v, n);
+}
+
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-cardano.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-cardano.pbjson.dart
@@ -1,0 +1,816 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-cardano.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use cardanoDerivationTypeDescriptor instead')
+const CardanoDerivationType$json = {
+  '1': 'CardanoDerivationType',
+  '2': [
+    {'1': 'LEDGER', '2': 0},
+    {'1': 'ICARUS', '2': 1},
+    {'1': 'ICARUS_TREZOR', '2': 2},
+  ],
+};
+
+/// Descriptor for `CardanoDerivationType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List cardanoDerivationTypeDescriptor = $convert.base64Decode(
+    'ChVDYXJkYW5vRGVyaXZhdGlvblR5cGUSCgoGTEVER0VSEAASCgoGSUNBUlVTEAESEQoNSUNBUl'
+    'VTX1RSRVpPUhAC');
+
+@$core.Deprecated('Use cardanoAddressTypeDescriptor instead')
+const CardanoAddressType$json = {
+  '1': 'CardanoAddressType',
+  '2': [
+    {'1': 'BASE', '2': 0},
+    {'1': 'BASE_SCRIPT_KEY', '2': 1},
+    {'1': 'BASE_KEY_SCRIPT', '2': 2},
+    {'1': 'BASE_SCRIPT_SCRIPT', '2': 3},
+    {'1': 'POINTER', '2': 4},
+    {'1': 'POINTER_SCRIPT', '2': 5},
+    {'1': 'ENTERPRISE', '2': 6},
+    {'1': 'ENTERPRISE_SCRIPT', '2': 7},
+    {'1': 'BYRON', '2': 8},
+    {'1': 'REWARD', '2': 14},
+    {'1': 'REWARD_SCRIPT', '2': 15},
+  ],
+};
+
+/// Descriptor for `CardanoAddressType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List cardanoAddressTypeDescriptor = $convert.base64Decode(
+    'ChJDYXJkYW5vQWRkcmVzc1R5cGUSCAoEQkFTRRAAEhMKD0JBU0VfU0NSSVBUX0tFWRABEhMKD0'
+    'JBU0VfS0VZX1NDUklQVBACEhYKEkJBU0VfU0NSSVBUX1NDUklQVBADEgsKB1BPSU5URVIQBBIS'
+    'Cg5QT0lOVEVSX1NDUklQVBAFEg4KCkVOVEVSUFJJU0UQBhIVChFFTlRFUlBSSVNFX1NDUklQVB'
+    'AHEgkKBUJZUk9OEAgSCgoGUkVXQVJEEA4SEQoNUkVXQVJEX1NDUklQVBAP');
+
+@$core.Deprecated('Use cardanoNativeScriptTypeDescriptor instead')
+const CardanoNativeScriptType$json = {
+  '1': 'CardanoNativeScriptType',
+  '2': [
+    {'1': 'PUB_KEY', '2': 0},
+    {'1': 'ALL', '2': 1},
+    {'1': 'ANY', '2': 2},
+    {'1': 'N_OF_K', '2': 3},
+    {'1': 'INVALID_BEFORE', '2': 4},
+    {'1': 'INVALID_HEREAFTER', '2': 5},
+  ],
+};
+
+/// Descriptor for `CardanoNativeScriptType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List cardanoNativeScriptTypeDescriptor = $convert.base64Decode(
+    'ChdDYXJkYW5vTmF0aXZlU2NyaXB0VHlwZRILCgdQVUJfS0VZEAASBwoDQUxMEAESBwoDQU5ZEA'
+    'ISCgoGTl9PRl9LEAMSEgoOSU5WQUxJRF9CRUZPUkUQBBIVChFJTlZBTElEX0hFUkVBRlRFUhAF');
+
+@$core.Deprecated('Use cardanoNativeScriptHashDisplayFormatDescriptor instead')
+const CardanoNativeScriptHashDisplayFormat$json = {
+  '1': 'CardanoNativeScriptHashDisplayFormat',
+  '2': [
+    {'1': 'HIDE', '2': 0},
+    {'1': 'BECH32', '2': 1},
+    {'1': 'POLICY_ID', '2': 2},
+  ],
+};
+
+/// Descriptor for `CardanoNativeScriptHashDisplayFormat`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List cardanoNativeScriptHashDisplayFormatDescriptor = $convert.base64Decode(
+    'CiRDYXJkYW5vTmF0aXZlU2NyaXB0SGFzaERpc3BsYXlGb3JtYXQSCAoESElERRAAEgoKBkJFQ0'
+    'gzMhABEg0KCVBPTElDWV9JRBAC');
+
+@$core.Deprecated('Use cardanoTxOutputSerializationFormatDescriptor instead')
+const CardanoTxOutputSerializationFormat$json = {
+  '1': 'CardanoTxOutputSerializationFormat',
+  '2': [
+    {'1': 'ARRAY_LEGACY', '2': 0},
+    {'1': 'MAP_BABBAGE', '2': 1},
+  ],
+};
+
+/// Descriptor for `CardanoTxOutputSerializationFormat`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List cardanoTxOutputSerializationFormatDescriptor = $convert.base64Decode(
+    'CiJDYXJkYW5vVHhPdXRwdXRTZXJpYWxpemF0aW9uRm9ybWF0EhAKDEFSUkFZX0xFR0FDWRAAEg'
+    '8KC01BUF9CQUJCQUdFEAE=');
+
+@$core.Deprecated('Use cardanoCertificateTypeDescriptor instead')
+const CardanoCertificateType$json = {
+  '1': 'CardanoCertificateType',
+  '2': [
+    {'1': 'STAKE_REGISTRATION', '2': 0},
+    {'1': 'STAKE_DEREGISTRATION', '2': 1},
+    {'1': 'STAKE_DELEGATION', '2': 2},
+    {'1': 'STAKE_POOL_REGISTRATION', '2': 3},
+  ],
+};
+
+/// Descriptor for `CardanoCertificateType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List cardanoCertificateTypeDescriptor = $convert.base64Decode(
+    'ChZDYXJkYW5vQ2VydGlmaWNhdGVUeXBlEhYKElNUQUtFX1JFR0lTVFJBVElPThAAEhgKFFNUQU'
+    'tFX0RFUkVHSVNUUkFUSU9OEAESFAoQU1RBS0VfREVMRUdBVElPThACEhsKF1NUQUtFX1BPT0xf'
+    'UkVHSVNUUkFUSU9OEAM=');
+
+@$core.Deprecated('Use cardanoPoolRelayTypeDescriptor instead')
+const CardanoPoolRelayType$json = {
+  '1': 'CardanoPoolRelayType',
+  '2': [
+    {'1': 'SINGLE_HOST_IP', '2': 0},
+    {'1': 'SINGLE_HOST_NAME', '2': 1},
+    {'1': 'MULTIPLE_HOST_NAME', '2': 2},
+  ],
+};
+
+/// Descriptor for `CardanoPoolRelayType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List cardanoPoolRelayTypeDescriptor = $convert.base64Decode(
+    'ChRDYXJkYW5vUG9vbFJlbGF5VHlwZRISCg5TSU5HTEVfSE9TVF9JUBAAEhQKEFNJTkdMRV9IT1'
+    'NUX05BTUUQARIWChJNVUxUSVBMRV9IT1NUX05BTUUQAg==');
+
+@$core.Deprecated('Use cardanoTxAuxiliaryDataSupplementTypeDescriptor instead')
+const CardanoTxAuxiliaryDataSupplementType$json = {
+  '1': 'CardanoTxAuxiliaryDataSupplementType',
+  '2': [
+    {'1': 'NONE', '2': 0},
+    {'1': 'CVOTE_REGISTRATION_SIGNATURE', '2': 1},
+  ],
+};
+
+/// Descriptor for `CardanoTxAuxiliaryDataSupplementType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List cardanoTxAuxiliaryDataSupplementTypeDescriptor = $convert.base64Decode(
+    'CiRDYXJkYW5vVHhBdXhpbGlhcnlEYXRhU3VwcGxlbWVudFR5cGUSCAoETk9ORRAAEiAKHENWT1'
+    'RFX1JFR0lTVFJBVElPTl9TSUdOQVRVUkUQAQ==');
+
+@$core.Deprecated('Use cardanoCVoteRegistrationFormatDescriptor instead')
+const CardanoCVoteRegistrationFormat$json = {
+  '1': 'CardanoCVoteRegistrationFormat',
+  '2': [
+    {'1': 'CIP15', '2': 0},
+    {'1': 'CIP36', '2': 1},
+  ],
+};
+
+/// Descriptor for `CardanoCVoteRegistrationFormat`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List cardanoCVoteRegistrationFormatDescriptor = $convert.base64Decode(
+    'Ch5DYXJkYW5vQ1ZvdGVSZWdpc3RyYXRpb25Gb3JtYXQSCQoFQ0lQMTUQABIJCgVDSVAzNhAB');
+
+@$core.Deprecated('Use cardanoTxSigningModeDescriptor instead')
+const CardanoTxSigningMode$json = {
+  '1': 'CardanoTxSigningMode',
+  '2': [
+    {'1': 'ORDINARY_TRANSACTION', '2': 0},
+    {'1': 'POOL_REGISTRATION_AS_OWNER', '2': 1},
+    {'1': 'MULTISIG_TRANSACTION', '2': 2},
+    {'1': 'PLUTUS_TRANSACTION', '2': 3},
+  ],
+};
+
+/// Descriptor for `CardanoTxSigningMode`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List cardanoTxSigningModeDescriptor = $convert.base64Decode(
+    'ChRDYXJkYW5vVHhTaWduaW5nTW9kZRIYChRPUkRJTkFSWV9UUkFOU0FDVElPThAAEh4KGlBPT0'
+    'xfUkVHSVNUUkFUSU9OX0FTX09XTkVSEAESGAoUTVVMVElTSUdfVFJBTlNBQ1RJT04QAhIWChJQ'
+    'TFVUVVNfVFJBTlNBQ1RJT04QAw==');
+
+@$core.Deprecated('Use cardanoTxWitnessTypeDescriptor instead')
+const CardanoTxWitnessType$json = {
+  '1': 'CardanoTxWitnessType',
+  '2': [
+    {'1': 'BYRON_WITNESS', '2': 0},
+    {'1': 'SHELLEY_WITNESS', '2': 1},
+  ],
+};
+
+/// Descriptor for `CardanoTxWitnessType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List cardanoTxWitnessTypeDescriptor = $convert.base64Decode(
+    'ChRDYXJkYW5vVHhXaXRuZXNzVHlwZRIRCg1CWVJPTl9XSVRORVNTEAASEwoPU0hFTExFWV9XSV'
+    'RORVNTEAE=');
+
+@$core.Deprecated('Use cardanoBlockchainPointerTypeDescriptor instead')
+const CardanoBlockchainPointerType$json = {
+  '1': 'CardanoBlockchainPointerType',
+  '2': [
+    {'1': 'block_index', '3': 1, '4': 2, '5': 13, '10': 'blockIndex'},
+    {'1': 'tx_index', '3': 2, '4': 2, '5': 13, '10': 'txIndex'},
+    {'1': 'certificate_index', '3': 3, '4': 2, '5': 13, '10': 'certificateIndex'},
+  ],
+};
+
+/// Descriptor for `CardanoBlockchainPointerType`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoBlockchainPointerTypeDescriptor = $convert.base64Decode(
+    'ChxDYXJkYW5vQmxvY2tjaGFpblBvaW50ZXJUeXBlEh8KC2Jsb2NrX2luZGV4GAEgAigNUgpibG'
+    '9ja0luZGV4EhkKCHR4X2luZGV4GAIgAigNUgd0eEluZGV4EisKEWNlcnRpZmljYXRlX2luZGV4'
+    'GAMgAigNUhBjZXJ0aWZpY2F0ZUluZGV4');
+
+@$core.Deprecated('Use cardanoNativeScriptDescriptor instead')
+const CardanoNativeScript$json = {
+  '1': 'CardanoNativeScript',
+  '2': [
+    {'1': 'type', '3': 1, '4': 2, '5': 14, '6': '.hw.trezor.messages.cardano.CardanoNativeScriptType', '10': 'type'},
+    {'1': 'scripts', '3': 2, '4': 3, '5': 11, '6': '.hw.trezor.messages.cardano.CardanoNativeScript', '10': 'scripts'},
+    {'1': 'key_hash', '3': 3, '4': 1, '5': 12, '10': 'keyHash'},
+    {'1': 'key_path', '3': 4, '4': 3, '5': 13, '10': 'keyPath'},
+    {'1': 'required_signatures_count', '3': 5, '4': 1, '5': 13, '10': 'requiredSignaturesCount'},
+    {'1': 'invalid_before', '3': 6, '4': 1, '5': 4, '10': 'invalidBefore'},
+    {'1': 'invalid_hereafter', '3': 7, '4': 1, '5': 4, '10': 'invalidHereafter'},
+  ],
+};
+
+/// Descriptor for `CardanoNativeScript`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoNativeScriptDescriptor = $convert.base64Decode(
+    'ChNDYXJkYW5vTmF0aXZlU2NyaXB0EkcKBHR5cGUYASACKA4yMy5ody50cmV6b3IubWVzc2FnZX'
+    'MuY2FyZGFuby5DYXJkYW5vTmF0aXZlU2NyaXB0VHlwZVIEdHlwZRJJCgdzY3JpcHRzGAIgAygL'
+    'Mi8uaHcudHJlem9yLm1lc3NhZ2VzLmNhcmRhbm8uQ2FyZGFub05hdGl2ZVNjcmlwdFIHc2NyaX'
+    'B0cxIZCghrZXlfaGFzaBgDIAEoDFIHa2V5SGFzaBIZCghrZXlfcGF0aBgEIAMoDVIHa2V5UGF0'
+    'aBI6ChlyZXF1aXJlZF9zaWduYXR1cmVzX2NvdW50GAUgASgNUhdyZXF1aXJlZFNpZ25hdHVyZX'
+    'NDb3VudBIlCg5pbnZhbGlkX2JlZm9yZRgGIAEoBFINaW52YWxpZEJlZm9yZRIrChFpbnZhbGlk'
+    'X2hlcmVhZnRlchgHIAEoBFIQaW52YWxpZEhlcmVhZnRlcg==');
+
+@$core.Deprecated('Use cardanoGetNativeScriptHashDescriptor instead')
+const CardanoGetNativeScriptHash$json = {
+  '1': 'CardanoGetNativeScriptHash',
+  '2': [
+    {'1': 'script', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.cardano.CardanoNativeScript', '10': 'script'},
+    {'1': 'display_format', '3': 2, '4': 2, '5': 14, '6': '.hw.trezor.messages.cardano.CardanoNativeScriptHashDisplayFormat', '10': 'displayFormat'},
+    {'1': 'derivation_type', '3': 3, '4': 2, '5': 14, '6': '.hw.trezor.messages.cardano.CardanoDerivationType', '10': 'derivationType'},
+  ],
+};
+
+/// Descriptor for `CardanoGetNativeScriptHash`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoGetNativeScriptHashDescriptor = $convert.base64Decode(
+    'ChpDYXJkYW5vR2V0TmF0aXZlU2NyaXB0SGFzaBJHCgZzY3JpcHQYASACKAsyLy5ody50cmV6b3'
+    'IubWVzc2FnZXMuY2FyZGFuby5DYXJkYW5vTmF0aXZlU2NyaXB0UgZzY3JpcHQSZwoOZGlzcGxh'
+    'eV9mb3JtYXQYAiACKA4yQC5ody50cmV6b3IubWVzc2FnZXMuY2FyZGFuby5DYXJkYW5vTmF0aX'
+    'ZlU2NyaXB0SGFzaERpc3BsYXlGb3JtYXRSDWRpc3BsYXlGb3JtYXQSWgoPZGVyaXZhdGlvbl90'
+    'eXBlGAMgAigOMjEuaHcudHJlem9yLm1lc3NhZ2VzLmNhcmRhbm8uQ2FyZGFub0Rlcml2YXRpb2'
+    '5UeXBlUg5kZXJpdmF0aW9uVHlwZQ==');
+
+@$core.Deprecated('Use cardanoNativeScriptHashDescriptor instead')
+const CardanoNativeScriptHash$json = {
+  '1': 'CardanoNativeScriptHash',
+  '2': [
+    {'1': 'script_hash', '3': 1, '4': 2, '5': 12, '10': 'scriptHash'},
+  ],
+};
+
+/// Descriptor for `CardanoNativeScriptHash`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoNativeScriptHashDescriptor = $convert.base64Decode(
+    'ChdDYXJkYW5vTmF0aXZlU2NyaXB0SGFzaBIfCgtzY3JpcHRfaGFzaBgBIAIoDFIKc2NyaXB0SG'
+    'FzaA==');
+
+@$core.Deprecated('Use cardanoAddressParametersTypeDescriptor instead')
+const CardanoAddressParametersType$json = {
+  '1': 'CardanoAddressParametersType',
+  '2': [
+    {'1': 'address_type', '3': 1, '4': 2, '5': 14, '6': '.hw.trezor.messages.cardano.CardanoAddressType', '10': 'addressType'},
+    {'1': 'address_n', '3': 2, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'address_n_staking', '3': 3, '4': 3, '5': 13, '10': 'addressNStaking'},
+    {'1': 'staking_key_hash', '3': 4, '4': 1, '5': 12, '10': 'stakingKeyHash'},
+    {'1': 'certificate_pointer', '3': 5, '4': 1, '5': 11, '6': '.hw.trezor.messages.cardano.CardanoBlockchainPointerType', '10': 'certificatePointer'},
+    {'1': 'script_payment_hash', '3': 6, '4': 1, '5': 12, '10': 'scriptPaymentHash'},
+    {'1': 'script_staking_hash', '3': 7, '4': 1, '5': 12, '10': 'scriptStakingHash'},
+  ],
+};
+
+/// Descriptor for `CardanoAddressParametersType`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoAddressParametersTypeDescriptor = $convert.base64Decode(
+    'ChxDYXJkYW5vQWRkcmVzc1BhcmFtZXRlcnNUeXBlElEKDGFkZHJlc3NfdHlwZRgBIAIoDjIuLm'
+    'h3LnRyZXpvci5tZXNzYWdlcy5jYXJkYW5vLkNhcmRhbm9BZGRyZXNzVHlwZVILYWRkcmVzc1R5'
+    'cGUSGwoJYWRkcmVzc19uGAIgAygNUghhZGRyZXNzThIqChFhZGRyZXNzX25fc3Rha2luZxgDIA'
+    'MoDVIPYWRkcmVzc05TdGFraW5nEigKEHN0YWtpbmdfa2V5X2hhc2gYBCABKAxSDnN0YWtpbmdL'
+    'ZXlIYXNoEmkKE2NlcnRpZmljYXRlX3BvaW50ZXIYBSABKAsyOC5ody50cmV6b3IubWVzc2FnZX'
+    'MuY2FyZGFuby5DYXJkYW5vQmxvY2tjaGFpblBvaW50ZXJUeXBlUhJjZXJ0aWZpY2F0ZVBvaW50'
+    'ZXISLgoTc2NyaXB0X3BheW1lbnRfaGFzaBgGIAEoDFIRc2NyaXB0UGF5bWVudEhhc2gSLgoTc2'
+    'NyaXB0X3N0YWtpbmdfaGFzaBgHIAEoDFIRc2NyaXB0U3Rha2luZ0hhc2g=');
+
+@$core.Deprecated('Use cardanoGetAddressDescriptor instead')
+const CardanoGetAddress$json = {
+  '1': 'CardanoGetAddress',
+  '2': [
+    {'1': 'show_display', '3': 2, '4': 1, '5': 8, '7': 'false', '10': 'showDisplay'},
+    {'1': 'protocol_magic', '3': 3, '4': 2, '5': 13, '10': 'protocolMagic'},
+    {'1': 'network_id', '3': 4, '4': 2, '5': 13, '10': 'networkId'},
+    {'1': 'address_parameters', '3': 5, '4': 2, '5': 11, '6': '.hw.trezor.messages.cardano.CardanoAddressParametersType', '10': 'addressParameters'},
+    {'1': 'derivation_type', '3': 6, '4': 2, '5': 14, '6': '.hw.trezor.messages.cardano.CardanoDerivationType', '10': 'derivationType'},
+    {'1': 'chunkify', '3': 7, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `CardanoGetAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoGetAddressDescriptor = $convert.base64Decode(
+    'ChFDYXJkYW5vR2V0QWRkcmVzcxIoCgxzaG93X2Rpc3BsYXkYAiABKAg6BWZhbHNlUgtzaG93RG'
+    'lzcGxheRIlCg5wcm90b2NvbF9tYWdpYxgDIAIoDVINcHJvdG9jb2xNYWdpYxIdCgpuZXR3b3Jr'
+    'X2lkGAQgAigNUgluZXR3b3JrSWQSZwoSYWRkcmVzc19wYXJhbWV0ZXJzGAUgAigLMjguaHcudH'
+    'Jlem9yLm1lc3NhZ2VzLmNhcmRhbm8uQ2FyZGFub0FkZHJlc3NQYXJhbWV0ZXJzVHlwZVIRYWRk'
+    'cmVzc1BhcmFtZXRlcnMSWgoPZGVyaXZhdGlvbl90eXBlGAYgAigOMjEuaHcudHJlem9yLm1lc3'
+    'NhZ2VzLmNhcmRhbm8uQ2FyZGFub0Rlcml2YXRpb25UeXBlUg5kZXJpdmF0aW9uVHlwZRIaCghj'
+    'aHVua2lmeRgHIAEoCFIIY2h1bmtpZnk=');
+
+@$core.Deprecated('Use cardanoAddressDescriptor instead')
+const CardanoAddress$json = {
+  '1': 'CardanoAddress',
+  '2': [
+    {'1': 'address', '3': 1, '4': 2, '5': 9, '10': 'address'},
+  ],
+};
+
+/// Descriptor for `CardanoAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoAddressDescriptor = $convert.base64Decode(
+    'Cg5DYXJkYW5vQWRkcmVzcxIYCgdhZGRyZXNzGAEgAigJUgdhZGRyZXNz');
+
+@$core.Deprecated('Use cardanoGetPublicKeyDescriptor instead')
+const CardanoGetPublicKey$json = {
+  '1': 'CardanoGetPublicKey',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'show_display', '3': 2, '4': 1, '5': 8, '10': 'showDisplay'},
+    {'1': 'derivation_type', '3': 3, '4': 2, '5': 14, '6': '.hw.trezor.messages.cardano.CardanoDerivationType', '10': 'derivationType'},
+  ],
+};
+
+/// Descriptor for `CardanoGetPublicKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoGetPublicKeyDescriptor = $convert.base64Decode(
+    'ChNDYXJkYW5vR2V0UHVibGljS2V5EhsKCWFkZHJlc3NfbhgBIAMoDVIIYWRkcmVzc04SIQoMc2'
+    'hvd19kaXNwbGF5GAIgASgIUgtzaG93RGlzcGxheRJaCg9kZXJpdmF0aW9uX3R5cGUYAyACKA4y'
+    'MS5ody50cmV6b3IubWVzc2FnZXMuY2FyZGFuby5DYXJkYW5vRGVyaXZhdGlvblR5cGVSDmRlcm'
+    'l2YXRpb25UeXBl');
+
+@$core.Deprecated('Use cardanoPublicKeyDescriptor instead')
+const CardanoPublicKey$json = {
+  '1': 'CardanoPublicKey',
+  '2': [
+    {'1': 'xpub', '3': 1, '4': 2, '5': 9, '10': 'xpub'},
+    {'1': 'node', '3': 2, '4': 2, '5': 11, '6': '.hw.trezor.messages.common.HDNodeType', '10': 'node'},
+  ],
+};
+
+/// Descriptor for `CardanoPublicKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoPublicKeyDescriptor = $convert.base64Decode(
+    'ChBDYXJkYW5vUHVibGljS2V5EhIKBHhwdWIYASACKAlSBHhwdWISOQoEbm9kZRgCIAIoCzIlLm'
+    'h3LnRyZXpvci5tZXNzYWdlcy5jb21tb24uSEROb2RlVHlwZVIEbm9kZQ==');
+
+@$core.Deprecated('Use cardanoSignTxInitDescriptor instead')
+const CardanoSignTxInit$json = {
+  '1': 'CardanoSignTxInit',
+  '2': [
+    {'1': 'signing_mode', '3': 1, '4': 2, '5': 14, '6': '.hw.trezor.messages.cardano.CardanoTxSigningMode', '10': 'signingMode'},
+    {'1': 'protocol_magic', '3': 2, '4': 2, '5': 13, '10': 'protocolMagic'},
+    {'1': 'network_id', '3': 3, '4': 2, '5': 13, '10': 'networkId'},
+    {'1': 'inputs_count', '3': 4, '4': 2, '5': 13, '10': 'inputsCount'},
+    {'1': 'outputs_count', '3': 5, '4': 2, '5': 13, '10': 'outputsCount'},
+    {'1': 'fee', '3': 6, '4': 2, '5': 4, '10': 'fee'},
+    {'1': 'ttl', '3': 7, '4': 1, '5': 4, '10': 'ttl'},
+    {'1': 'certificates_count', '3': 8, '4': 2, '5': 13, '10': 'certificatesCount'},
+    {'1': 'withdrawals_count', '3': 9, '4': 2, '5': 13, '10': 'withdrawalsCount'},
+    {'1': 'has_auxiliary_data', '3': 10, '4': 2, '5': 8, '10': 'hasAuxiliaryData'},
+    {'1': 'validity_interval_start', '3': 11, '4': 1, '5': 4, '10': 'validityIntervalStart'},
+    {'1': 'witness_requests_count', '3': 12, '4': 2, '5': 13, '10': 'witnessRequestsCount'},
+    {'1': 'minting_asset_groups_count', '3': 13, '4': 2, '5': 13, '10': 'mintingAssetGroupsCount'},
+    {'1': 'derivation_type', '3': 14, '4': 2, '5': 14, '6': '.hw.trezor.messages.cardano.CardanoDerivationType', '10': 'derivationType'},
+    {'1': 'include_network_id', '3': 15, '4': 1, '5': 8, '7': 'false', '10': 'includeNetworkId'},
+    {'1': 'script_data_hash', '3': 16, '4': 1, '5': 12, '10': 'scriptDataHash'},
+    {'1': 'collateral_inputs_count', '3': 17, '4': 2, '5': 13, '10': 'collateralInputsCount'},
+    {'1': 'required_signers_count', '3': 18, '4': 2, '5': 13, '10': 'requiredSignersCount'},
+    {'1': 'has_collateral_return', '3': 19, '4': 1, '5': 8, '7': 'false', '10': 'hasCollateralReturn'},
+    {'1': 'total_collateral', '3': 20, '4': 1, '5': 4, '10': 'totalCollateral'},
+    {'1': 'reference_inputs_count', '3': 21, '4': 1, '5': 13, '7': '0', '10': 'referenceInputsCount'},
+    {'1': 'chunkify', '3': 22, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `CardanoSignTxInit`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoSignTxInitDescriptor = $convert.base64Decode(
+    'ChFDYXJkYW5vU2lnblR4SW5pdBJTCgxzaWduaW5nX21vZGUYASACKA4yMC5ody50cmV6b3IubW'
+    'Vzc2FnZXMuY2FyZGFuby5DYXJkYW5vVHhTaWduaW5nTW9kZVILc2lnbmluZ01vZGUSJQoOcHJv'
+    'dG9jb2xfbWFnaWMYAiACKA1SDXByb3RvY29sTWFnaWMSHQoKbmV0d29ya19pZBgDIAIoDVIJbm'
+    'V0d29ya0lkEiEKDGlucHV0c19jb3VudBgEIAIoDVILaW5wdXRzQ291bnQSIwoNb3V0cHV0c19j'
+    'b3VudBgFIAIoDVIMb3V0cHV0c0NvdW50EhAKA2ZlZRgGIAIoBFIDZmVlEhAKA3R0bBgHIAEoBF'
+    'IDdHRsEi0KEmNlcnRpZmljYXRlc19jb3VudBgIIAIoDVIRY2VydGlmaWNhdGVzQ291bnQSKwoR'
+    'd2l0aGRyYXdhbHNfY291bnQYCSACKA1SEHdpdGhkcmF3YWxzQ291bnQSLAoSaGFzX2F1eGlsaW'
+    'FyeV9kYXRhGAogAigIUhBoYXNBdXhpbGlhcnlEYXRhEjYKF3ZhbGlkaXR5X2ludGVydmFsX3N0'
+    'YXJ0GAsgASgEUhV2YWxpZGl0eUludGVydmFsU3RhcnQSNAoWd2l0bmVzc19yZXF1ZXN0c19jb3'
+    'VudBgMIAIoDVIUd2l0bmVzc1JlcXVlc3RzQ291bnQSOwoabWludGluZ19hc3NldF9ncm91cHNf'
+    'Y291bnQYDSACKA1SF21pbnRpbmdBc3NldEdyb3Vwc0NvdW50EloKD2Rlcml2YXRpb25fdHlwZR'
+    'gOIAIoDjIxLmh3LnRyZXpvci5tZXNzYWdlcy5jYXJkYW5vLkNhcmRhbm9EZXJpdmF0aW9uVHlw'
+    'ZVIOZGVyaXZhdGlvblR5cGUSMwoSaW5jbHVkZV9uZXR3b3JrX2lkGA8gASgIOgVmYWxzZVIQaW'
+    '5jbHVkZU5ldHdvcmtJZBIoChBzY3JpcHRfZGF0YV9oYXNoGBAgASgMUg5zY3JpcHREYXRhSGFz'
+    'aBI2Chdjb2xsYXRlcmFsX2lucHV0c19jb3VudBgRIAIoDVIVY29sbGF0ZXJhbElucHV0c0NvdW'
+    '50EjQKFnJlcXVpcmVkX3NpZ25lcnNfY291bnQYEiACKA1SFHJlcXVpcmVkU2lnbmVyc0NvdW50'
+    'EjkKFWhhc19jb2xsYXRlcmFsX3JldHVybhgTIAEoCDoFZmFsc2VSE2hhc0NvbGxhdGVyYWxSZX'
+    'R1cm4SKQoQdG90YWxfY29sbGF0ZXJhbBgUIAEoBFIPdG90YWxDb2xsYXRlcmFsEjcKFnJlZmVy'
+    'ZW5jZV9pbnB1dHNfY291bnQYFSABKA06ATBSFHJlZmVyZW5jZUlucHV0c0NvdW50EhoKCGNodW'
+    '5raWZ5GBYgASgIUghjaHVua2lmeQ==');
+
+@$core.Deprecated('Use cardanoTxInputDescriptor instead')
+const CardanoTxInput$json = {
+  '1': 'CardanoTxInput',
+  '2': [
+    {'1': 'prev_hash', '3': 1, '4': 2, '5': 12, '10': 'prevHash'},
+    {'1': 'prev_index', '3': 2, '4': 2, '5': 13, '10': 'prevIndex'},
+  ],
+};
+
+/// Descriptor for `CardanoTxInput`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxInputDescriptor = $convert.base64Decode(
+    'Cg5DYXJkYW5vVHhJbnB1dBIbCglwcmV2X2hhc2gYASACKAxSCHByZXZIYXNoEh0KCnByZXZfaW'
+    '5kZXgYAiACKA1SCXByZXZJbmRleA==');
+
+@$core.Deprecated('Use cardanoTxOutputDescriptor instead')
+const CardanoTxOutput$json = {
+  '1': 'CardanoTxOutput',
+  '2': [
+    {'1': 'address', '3': 1, '4': 1, '5': 9, '10': 'address'},
+    {'1': 'address_parameters', '3': 2, '4': 1, '5': 11, '6': '.hw.trezor.messages.cardano.CardanoAddressParametersType', '10': 'addressParameters'},
+    {'1': 'amount', '3': 3, '4': 2, '5': 4, '10': 'amount'},
+    {'1': 'asset_groups_count', '3': 4, '4': 2, '5': 13, '10': 'assetGroupsCount'},
+    {'1': 'datum_hash', '3': 5, '4': 1, '5': 12, '10': 'datumHash'},
+    {'1': 'format', '3': 6, '4': 1, '5': 14, '6': '.hw.trezor.messages.cardano.CardanoTxOutputSerializationFormat', '7': 'ARRAY_LEGACY', '10': 'format'},
+    {'1': 'inline_datum_size', '3': 7, '4': 1, '5': 13, '7': '0', '10': 'inlineDatumSize'},
+    {'1': 'reference_script_size', '3': 8, '4': 1, '5': 13, '7': '0', '10': 'referenceScriptSize'},
+  ],
+};
+
+/// Descriptor for `CardanoTxOutput`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxOutputDescriptor = $convert.base64Decode(
+    'Cg9DYXJkYW5vVHhPdXRwdXQSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxJnChJhZGRyZXNzX3'
+    'BhcmFtZXRlcnMYAiABKAsyOC5ody50cmV6b3IubWVzc2FnZXMuY2FyZGFuby5DYXJkYW5vQWRk'
+    'cmVzc1BhcmFtZXRlcnNUeXBlUhFhZGRyZXNzUGFyYW1ldGVycxIWCgZhbW91bnQYAyACKARSBm'
+    'Ftb3VudBIsChJhc3NldF9ncm91cHNfY291bnQYBCACKA1SEGFzc2V0R3JvdXBzQ291bnQSHQoK'
+    'ZGF0dW1faGFzaBgFIAEoDFIJZGF0dW1IYXNoEmQKBmZvcm1hdBgGIAEoDjI+Lmh3LnRyZXpvci'
+    '5tZXNzYWdlcy5jYXJkYW5vLkNhcmRhbm9UeE91dHB1dFNlcmlhbGl6YXRpb25Gb3JtYXQ6DEFS'
+    'UkFZX0xFR0FDWVIGZm9ybWF0Ei0KEWlubGluZV9kYXR1bV9zaXplGAcgASgNOgEwUg9pbmxpbm'
+    'VEYXR1bVNpemUSNQoVcmVmZXJlbmNlX3NjcmlwdF9zaXplGAggASgNOgEwUhNyZWZlcmVuY2VT'
+    'Y3JpcHRTaXpl');
+
+@$core.Deprecated('Use cardanoAssetGroupDescriptor instead')
+const CardanoAssetGroup$json = {
+  '1': 'CardanoAssetGroup',
+  '2': [
+    {'1': 'policy_id', '3': 1, '4': 2, '5': 12, '10': 'policyId'},
+    {'1': 'tokens_count', '3': 2, '4': 2, '5': 13, '10': 'tokensCount'},
+  ],
+};
+
+/// Descriptor for `CardanoAssetGroup`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoAssetGroupDescriptor = $convert.base64Decode(
+    'ChFDYXJkYW5vQXNzZXRHcm91cBIbCglwb2xpY3lfaWQYASACKAxSCHBvbGljeUlkEiEKDHRva2'
+    'Vuc19jb3VudBgCIAIoDVILdG9rZW5zQ291bnQ=');
+
+@$core.Deprecated('Use cardanoTokenDescriptor instead')
+const CardanoToken$json = {
+  '1': 'CardanoToken',
+  '2': [
+    {'1': 'asset_name_bytes', '3': 1, '4': 2, '5': 12, '10': 'assetNameBytes'},
+    {'1': 'amount', '3': 2, '4': 1, '5': 4, '10': 'amount'},
+    {'1': 'mint_amount', '3': 3, '4': 1, '5': 18, '10': 'mintAmount'},
+  ],
+};
+
+/// Descriptor for `CardanoToken`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTokenDescriptor = $convert.base64Decode(
+    'CgxDYXJkYW5vVG9rZW4SKAoQYXNzZXRfbmFtZV9ieXRlcxgBIAIoDFIOYXNzZXROYW1lQnl0ZX'
+    'MSFgoGYW1vdW50GAIgASgEUgZhbW91bnQSHwoLbWludF9hbW91bnQYAyABKBJSCm1pbnRBbW91'
+    'bnQ=');
+
+@$core.Deprecated('Use cardanoTxInlineDatumChunkDescriptor instead')
+const CardanoTxInlineDatumChunk$json = {
+  '1': 'CardanoTxInlineDatumChunk',
+  '2': [
+    {'1': 'data', '3': 1, '4': 2, '5': 12, '10': 'data'},
+  ],
+};
+
+/// Descriptor for `CardanoTxInlineDatumChunk`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxInlineDatumChunkDescriptor = $convert.base64Decode(
+    'ChlDYXJkYW5vVHhJbmxpbmVEYXR1bUNodW5rEhIKBGRhdGEYASACKAxSBGRhdGE=');
+
+@$core.Deprecated('Use cardanoTxReferenceScriptChunkDescriptor instead')
+const CardanoTxReferenceScriptChunk$json = {
+  '1': 'CardanoTxReferenceScriptChunk',
+  '2': [
+    {'1': 'data', '3': 1, '4': 2, '5': 12, '10': 'data'},
+  ],
+};
+
+/// Descriptor for `CardanoTxReferenceScriptChunk`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxReferenceScriptChunkDescriptor = $convert.base64Decode(
+    'Ch1DYXJkYW5vVHhSZWZlcmVuY2VTY3JpcHRDaHVuaxISCgRkYXRhGAEgAigMUgRkYXRh');
+
+@$core.Deprecated('Use cardanoPoolOwnerDescriptor instead')
+const CardanoPoolOwner$json = {
+  '1': 'CardanoPoolOwner',
+  '2': [
+    {'1': 'staking_key_path', '3': 1, '4': 3, '5': 13, '10': 'stakingKeyPath'},
+    {'1': 'staking_key_hash', '3': 2, '4': 1, '5': 12, '10': 'stakingKeyHash'},
+  ],
+};
+
+/// Descriptor for `CardanoPoolOwner`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoPoolOwnerDescriptor = $convert.base64Decode(
+    'ChBDYXJkYW5vUG9vbE93bmVyEigKEHN0YWtpbmdfa2V5X3BhdGgYASADKA1SDnN0YWtpbmdLZX'
+    'lQYXRoEigKEHN0YWtpbmdfa2V5X2hhc2gYAiABKAxSDnN0YWtpbmdLZXlIYXNo');
+
+@$core.Deprecated('Use cardanoPoolRelayParametersDescriptor instead')
+const CardanoPoolRelayParameters$json = {
+  '1': 'CardanoPoolRelayParameters',
+  '2': [
+    {'1': 'type', '3': 1, '4': 2, '5': 14, '6': '.hw.trezor.messages.cardano.CardanoPoolRelayType', '10': 'type'},
+    {'1': 'ipv4_address', '3': 2, '4': 1, '5': 12, '10': 'ipv4Address'},
+    {'1': 'ipv6_address', '3': 3, '4': 1, '5': 12, '10': 'ipv6Address'},
+    {'1': 'host_name', '3': 4, '4': 1, '5': 9, '10': 'hostName'},
+    {'1': 'port', '3': 5, '4': 1, '5': 13, '10': 'port'},
+  ],
+};
+
+/// Descriptor for `CardanoPoolRelayParameters`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoPoolRelayParametersDescriptor = $convert.base64Decode(
+    'ChpDYXJkYW5vUG9vbFJlbGF5UGFyYW1ldGVycxJECgR0eXBlGAEgAigOMjAuaHcudHJlem9yLm'
+    '1lc3NhZ2VzLmNhcmRhbm8uQ2FyZGFub1Bvb2xSZWxheVR5cGVSBHR5cGUSIQoMaXB2NF9hZGRy'
+    'ZXNzGAIgASgMUgtpcHY0QWRkcmVzcxIhCgxpcHY2X2FkZHJlc3MYAyABKAxSC2lwdjZBZGRyZX'
+    'NzEhsKCWhvc3RfbmFtZRgEIAEoCVIIaG9zdE5hbWUSEgoEcG9ydBgFIAEoDVIEcG9ydA==');
+
+@$core.Deprecated('Use cardanoPoolMetadataTypeDescriptor instead')
+const CardanoPoolMetadataType$json = {
+  '1': 'CardanoPoolMetadataType',
+  '2': [
+    {'1': 'url', '3': 1, '4': 2, '5': 9, '10': 'url'},
+    {'1': 'hash', '3': 2, '4': 2, '5': 12, '10': 'hash'},
+  ],
+};
+
+/// Descriptor for `CardanoPoolMetadataType`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoPoolMetadataTypeDescriptor = $convert.base64Decode(
+    'ChdDYXJkYW5vUG9vbE1ldGFkYXRhVHlwZRIQCgN1cmwYASACKAlSA3VybBISCgRoYXNoGAIgAi'
+    'gMUgRoYXNo');
+
+@$core.Deprecated('Use cardanoPoolParametersTypeDescriptor instead')
+const CardanoPoolParametersType$json = {
+  '1': 'CardanoPoolParametersType',
+  '2': [
+    {'1': 'pool_id', '3': 1, '4': 2, '5': 12, '10': 'poolId'},
+    {'1': 'vrf_key_hash', '3': 2, '4': 2, '5': 12, '10': 'vrfKeyHash'},
+    {'1': 'pledge', '3': 3, '4': 2, '5': 4, '10': 'pledge'},
+    {'1': 'cost', '3': 4, '4': 2, '5': 4, '10': 'cost'},
+    {'1': 'margin_numerator', '3': 5, '4': 2, '5': 4, '10': 'marginNumerator'},
+    {'1': 'margin_denominator', '3': 6, '4': 2, '5': 4, '10': 'marginDenominator'},
+    {'1': 'reward_account', '3': 7, '4': 2, '5': 9, '10': 'rewardAccount'},
+    {'1': 'metadata', '3': 10, '4': 1, '5': 11, '6': '.hw.trezor.messages.cardano.CardanoPoolMetadataType', '10': 'metadata'},
+    {'1': 'owners_count', '3': 11, '4': 2, '5': 13, '10': 'ownersCount'},
+    {'1': 'relays_count', '3': 12, '4': 2, '5': 13, '10': 'relaysCount'},
+  ],
+};
+
+/// Descriptor for `CardanoPoolParametersType`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoPoolParametersTypeDescriptor = $convert.base64Decode(
+    'ChlDYXJkYW5vUG9vbFBhcmFtZXRlcnNUeXBlEhcKB3Bvb2xfaWQYASACKAxSBnBvb2xJZBIgCg'
+    'x2cmZfa2V5X2hhc2gYAiACKAxSCnZyZktleUhhc2gSFgoGcGxlZGdlGAMgAigEUgZwbGVkZ2US'
+    'EgoEY29zdBgEIAIoBFIEY29zdBIpChBtYXJnaW5fbnVtZXJhdG9yGAUgAigEUg9tYXJnaW5OdW'
+    '1lcmF0b3ISLQoSbWFyZ2luX2Rlbm9taW5hdG9yGAYgAigEUhFtYXJnaW5EZW5vbWluYXRvchIl'
+    'Cg5yZXdhcmRfYWNjb3VudBgHIAIoCVINcmV3YXJkQWNjb3VudBJPCghtZXRhZGF0YRgKIAEoCz'
+    'IzLmh3LnRyZXpvci5tZXNzYWdlcy5jYXJkYW5vLkNhcmRhbm9Qb29sTWV0YWRhdGFUeXBlUght'
+    'ZXRhZGF0YRIhCgxvd25lcnNfY291bnQYCyACKA1SC293bmVyc0NvdW50EiEKDHJlbGF5c19jb3'
+    'VudBgMIAIoDVILcmVsYXlzQ291bnQ=');
+
+@$core.Deprecated('Use cardanoTxCertificateDescriptor instead')
+const CardanoTxCertificate$json = {
+  '1': 'CardanoTxCertificate',
+  '2': [
+    {'1': 'type', '3': 1, '4': 2, '5': 14, '6': '.hw.trezor.messages.cardano.CardanoCertificateType', '10': 'type'},
+    {'1': 'path', '3': 2, '4': 3, '5': 13, '10': 'path'},
+    {'1': 'pool', '3': 3, '4': 1, '5': 12, '10': 'pool'},
+    {'1': 'pool_parameters', '3': 4, '4': 1, '5': 11, '6': '.hw.trezor.messages.cardano.CardanoPoolParametersType', '10': 'poolParameters'},
+    {'1': 'script_hash', '3': 5, '4': 1, '5': 12, '10': 'scriptHash'},
+    {'1': 'key_hash', '3': 6, '4': 1, '5': 12, '10': 'keyHash'},
+  ],
+};
+
+/// Descriptor for `CardanoTxCertificate`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxCertificateDescriptor = $convert.base64Decode(
+    'ChRDYXJkYW5vVHhDZXJ0aWZpY2F0ZRJGCgR0eXBlGAEgAigOMjIuaHcudHJlem9yLm1lc3NhZ2'
+    'VzLmNhcmRhbm8uQ2FyZGFub0NlcnRpZmljYXRlVHlwZVIEdHlwZRISCgRwYXRoGAIgAygNUgRw'
+    'YXRoEhIKBHBvb2wYAyABKAxSBHBvb2wSXgoPcG9vbF9wYXJhbWV0ZXJzGAQgASgLMjUuaHcudH'
+    'Jlem9yLm1lc3NhZ2VzLmNhcmRhbm8uQ2FyZGFub1Bvb2xQYXJhbWV0ZXJzVHlwZVIOcG9vbFBh'
+    'cmFtZXRlcnMSHwoLc2NyaXB0X2hhc2gYBSABKAxSCnNjcmlwdEhhc2gSGQoIa2V5X2hhc2gYBi'
+    'ABKAxSB2tleUhhc2g=');
+
+@$core.Deprecated('Use cardanoTxWithdrawalDescriptor instead')
+const CardanoTxWithdrawal$json = {
+  '1': 'CardanoTxWithdrawal',
+  '2': [
+    {'1': 'path', '3': 1, '4': 3, '5': 13, '10': 'path'},
+    {'1': 'amount', '3': 2, '4': 2, '5': 4, '10': 'amount'},
+    {'1': 'script_hash', '3': 3, '4': 1, '5': 12, '10': 'scriptHash'},
+    {'1': 'key_hash', '3': 4, '4': 1, '5': 12, '10': 'keyHash'},
+  ],
+};
+
+/// Descriptor for `CardanoTxWithdrawal`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxWithdrawalDescriptor = $convert.base64Decode(
+    'ChNDYXJkYW5vVHhXaXRoZHJhd2FsEhIKBHBhdGgYASADKA1SBHBhdGgSFgoGYW1vdW50GAIgAi'
+    'gEUgZhbW91bnQSHwoLc2NyaXB0X2hhc2gYAyABKAxSCnNjcmlwdEhhc2gSGQoIa2V5X2hhc2gY'
+    'BCABKAxSB2tleUhhc2g=');
+
+@$core.Deprecated('Use cardanoCVoteRegistrationDelegationDescriptor instead')
+const CardanoCVoteRegistrationDelegation$json = {
+  '1': 'CardanoCVoteRegistrationDelegation',
+  '2': [
+    {'1': 'vote_public_key', '3': 1, '4': 2, '5': 12, '10': 'votePublicKey'},
+    {'1': 'weight', '3': 2, '4': 2, '5': 13, '10': 'weight'},
+  ],
+};
+
+/// Descriptor for `CardanoCVoteRegistrationDelegation`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoCVoteRegistrationDelegationDescriptor = $convert.base64Decode(
+    'CiJDYXJkYW5vQ1ZvdGVSZWdpc3RyYXRpb25EZWxlZ2F0aW9uEiYKD3ZvdGVfcHVibGljX2tleR'
+    'gBIAIoDFINdm90ZVB1YmxpY0tleRIWCgZ3ZWlnaHQYAiACKA1SBndlaWdodA==');
+
+@$core.Deprecated('Use cardanoCVoteRegistrationParametersTypeDescriptor instead')
+const CardanoCVoteRegistrationParametersType$json = {
+  '1': 'CardanoCVoteRegistrationParametersType',
+  '2': [
+    {'1': 'vote_public_key', '3': 1, '4': 1, '5': 12, '10': 'votePublicKey'},
+    {'1': 'staking_path', '3': 2, '4': 3, '5': 13, '10': 'stakingPath'},
+    {'1': 'payment_address_parameters', '3': 3, '4': 1, '5': 11, '6': '.hw.trezor.messages.cardano.CardanoAddressParametersType', '10': 'paymentAddressParameters'},
+    {'1': 'nonce', '3': 4, '4': 2, '5': 4, '10': 'nonce'},
+    {'1': 'format', '3': 5, '4': 1, '5': 14, '6': '.hw.trezor.messages.cardano.CardanoCVoteRegistrationFormat', '7': 'CIP15', '10': 'format'},
+    {'1': 'delegations', '3': 6, '4': 3, '5': 11, '6': '.hw.trezor.messages.cardano.CardanoCVoteRegistrationDelegation', '10': 'delegations'},
+    {'1': 'voting_purpose', '3': 7, '4': 1, '5': 4, '10': 'votingPurpose'},
+    {'1': 'payment_address', '3': 8, '4': 1, '5': 9, '10': 'paymentAddress'},
+  ],
+};
+
+/// Descriptor for `CardanoCVoteRegistrationParametersType`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoCVoteRegistrationParametersTypeDescriptor = $convert.base64Decode(
+    'CiZDYXJkYW5vQ1ZvdGVSZWdpc3RyYXRpb25QYXJhbWV0ZXJzVHlwZRImCg92b3RlX3B1YmxpY1'
+    '9rZXkYASABKAxSDXZvdGVQdWJsaWNLZXkSIQoMc3Rha2luZ19wYXRoGAIgAygNUgtzdGFraW5n'
+    'UGF0aBJ2ChpwYXltZW50X2FkZHJlc3NfcGFyYW1ldGVycxgDIAEoCzI4Lmh3LnRyZXpvci5tZX'
+    'NzYWdlcy5jYXJkYW5vLkNhcmRhbm9BZGRyZXNzUGFyYW1ldGVyc1R5cGVSGHBheW1lbnRBZGRy'
+    'ZXNzUGFyYW1ldGVycxIUCgVub25jZRgEIAIoBFIFbm9uY2USWQoGZm9ybWF0GAUgASgOMjouaH'
+    'cudHJlem9yLm1lc3NhZ2VzLmNhcmRhbm8uQ2FyZGFub0NWb3RlUmVnaXN0cmF0aW9uRm9ybWF0'
+    'OgVDSVAxNVIGZm9ybWF0EmAKC2RlbGVnYXRpb25zGAYgAygLMj4uaHcudHJlem9yLm1lc3NhZ2'
+    'VzLmNhcmRhbm8uQ2FyZGFub0NWb3RlUmVnaXN0cmF0aW9uRGVsZWdhdGlvblILZGVsZWdhdGlv'
+    'bnMSJQoOdm90aW5nX3B1cnBvc2UYByABKARSDXZvdGluZ1B1cnBvc2USJwoPcGF5bWVudF9hZG'
+    'RyZXNzGAggASgJUg5wYXltZW50QWRkcmVzcw==');
+
+@$core.Deprecated('Use cardanoTxAuxiliaryDataDescriptor instead')
+const CardanoTxAuxiliaryData$json = {
+  '1': 'CardanoTxAuxiliaryData',
+  '2': [
+    {'1': 'cvote_registration_parameters', '3': 1, '4': 1, '5': 11, '6': '.hw.trezor.messages.cardano.CardanoCVoteRegistrationParametersType', '10': 'cvoteRegistrationParameters'},
+    {'1': 'hash', '3': 2, '4': 1, '5': 12, '10': 'hash'},
+  ],
+};
+
+/// Descriptor for `CardanoTxAuxiliaryData`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxAuxiliaryDataDescriptor = $convert.base64Decode(
+    'ChZDYXJkYW5vVHhBdXhpbGlhcnlEYXRhEoYBCh1jdm90ZV9yZWdpc3RyYXRpb25fcGFyYW1ldG'
+    'VycxgBIAEoCzJCLmh3LnRyZXpvci5tZXNzYWdlcy5jYXJkYW5vLkNhcmRhbm9DVm90ZVJlZ2lz'
+    'dHJhdGlvblBhcmFtZXRlcnNUeXBlUhtjdm90ZVJlZ2lzdHJhdGlvblBhcmFtZXRlcnMSEgoEaG'
+    'FzaBgCIAEoDFIEaGFzaA==');
+
+@$core.Deprecated('Use cardanoTxMintDescriptor instead')
+const CardanoTxMint$json = {
+  '1': 'CardanoTxMint',
+  '2': [
+    {'1': 'asset_groups_count', '3': 1, '4': 2, '5': 13, '10': 'assetGroupsCount'},
+  ],
+};
+
+/// Descriptor for `CardanoTxMint`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxMintDescriptor = $convert.base64Decode(
+    'Cg1DYXJkYW5vVHhNaW50EiwKEmFzc2V0X2dyb3Vwc19jb3VudBgBIAIoDVIQYXNzZXRHcm91cH'
+    'NDb3VudA==');
+
+@$core.Deprecated('Use cardanoTxCollateralInputDescriptor instead')
+const CardanoTxCollateralInput$json = {
+  '1': 'CardanoTxCollateralInput',
+  '2': [
+    {'1': 'prev_hash', '3': 1, '4': 2, '5': 12, '10': 'prevHash'},
+    {'1': 'prev_index', '3': 2, '4': 2, '5': 13, '10': 'prevIndex'},
+  ],
+};
+
+/// Descriptor for `CardanoTxCollateralInput`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxCollateralInputDescriptor = $convert.base64Decode(
+    'ChhDYXJkYW5vVHhDb2xsYXRlcmFsSW5wdXQSGwoJcHJldl9oYXNoGAEgAigMUghwcmV2SGFzaB'
+    'IdCgpwcmV2X2luZGV4GAIgAigNUglwcmV2SW5kZXg=');
+
+@$core.Deprecated('Use cardanoTxRequiredSignerDescriptor instead')
+const CardanoTxRequiredSigner$json = {
+  '1': 'CardanoTxRequiredSigner',
+  '2': [
+    {'1': 'key_hash', '3': 1, '4': 1, '5': 12, '10': 'keyHash'},
+    {'1': 'key_path', '3': 2, '4': 3, '5': 13, '10': 'keyPath'},
+  ],
+};
+
+/// Descriptor for `CardanoTxRequiredSigner`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxRequiredSignerDescriptor = $convert.base64Decode(
+    'ChdDYXJkYW5vVHhSZXF1aXJlZFNpZ25lchIZCghrZXlfaGFzaBgBIAEoDFIHa2V5SGFzaBIZCg'
+    'hrZXlfcGF0aBgCIAMoDVIHa2V5UGF0aA==');
+
+@$core.Deprecated('Use cardanoTxReferenceInputDescriptor instead')
+const CardanoTxReferenceInput$json = {
+  '1': 'CardanoTxReferenceInput',
+  '2': [
+    {'1': 'prev_hash', '3': 1, '4': 2, '5': 12, '10': 'prevHash'},
+    {'1': 'prev_index', '3': 2, '4': 2, '5': 13, '10': 'prevIndex'},
+  ],
+};
+
+/// Descriptor for `CardanoTxReferenceInput`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxReferenceInputDescriptor = $convert.base64Decode(
+    'ChdDYXJkYW5vVHhSZWZlcmVuY2VJbnB1dBIbCglwcmV2X2hhc2gYASACKAxSCHByZXZIYXNoEh'
+    '0KCnByZXZfaW5kZXgYAiACKA1SCXByZXZJbmRleA==');
+
+@$core.Deprecated('Use cardanoTxItemAckDescriptor instead')
+const CardanoTxItemAck$json = {
+  '1': 'CardanoTxItemAck',
+};
+
+/// Descriptor for `CardanoTxItemAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxItemAckDescriptor = $convert.base64Decode(
+    'ChBDYXJkYW5vVHhJdGVtQWNr');
+
+@$core.Deprecated('Use cardanoTxAuxiliaryDataSupplementDescriptor instead')
+const CardanoTxAuxiliaryDataSupplement$json = {
+  '1': 'CardanoTxAuxiliaryDataSupplement',
+  '2': [
+    {'1': 'type', '3': 1, '4': 2, '5': 14, '6': '.hw.trezor.messages.cardano.CardanoTxAuxiliaryDataSupplementType', '10': 'type'},
+    {'1': 'auxiliary_data_hash', '3': 2, '4': 1, '5': 12, '10': 'auxiliaryDataHash'},
+    {'1': 'cvote_registration_signature', '3': 3, '4': 1, '5': 12, '10': 'cvoteRegistrationSignature'},
+  ],
+};
+
+/// Descriptor for `CardanoTxAuxiliaryDataSupplement`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxAuxiliaryDataSupplementDescriptor = $convert.base64Decode(
+    'CiBDYXJkYW5vVHhBdXhpbGlhcnlEYXRhU3VwcGxlbWVudBJUCgR0eXBlGAEgAigOMkAuaHcudH'
+    'Jlem9yLm1lc3NhZ2VzLmNhcmRhbm8uQ2FyZGFub1R4QXV4aWxpYXJ5RGF0YVN1cHBsZW1lbnRU'
+    'eXBlUgR0eXBlEi4KE2F1eGlsaWFyeV9kYXRhX2hhc2gYAiABKAxSEWF1eGlsaWFyeURhdGFIYX'
+    'NoEkAKHGN2b3RlX3JlZ2lzdHJhdGlvbl9zaWduYXR1cmUYAyABKAxSGmN2b3RlUmVnaXN0cmF0'
+    'aW9uU2lnbmF0dXJl');
+
+@$core.Deprecated('Use cardanoTxWitnessRequestDescriptor instead')
+const CardanoTxWitnessRequest$json = {
+  '1': 'CardanoTxWitnessRequest',
+  '2': [
+    {'1': 'path', '3': 1, '4': 3, '5': 13, '10': 'path'},
+  ],
+};
+
+/// Descriptor for `CardanoTxWitnessRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxWitnessRequestDescriptor = $convert.base64Decode(
+    'ChdDYXJkYW5vVHhXaXRuZXNzUmVxdWVzdBISCgRwYXRoGAEgAygNUgRwYXRo');
+
+@$core.Deprecated('Use cardanoTxWitnessResponseDescriptor instead')
+const CardanoTxWitnessResponse$json = {
+  '1': 'CardanoTxWitnessResponse',
+  '2': [
+    {'1': 'type', '3': 1, '4': 2, '5': 14, '6': '.hw.trezor.messages.cardano.CardanoTxWitnessType', '10': 'type'},
+    {'1': 'pub_key', '3': 2, '4': 2, '5': 12, '10': 'pubKey'},
+    {'1': 'signature', '3': 3, '4': 2, '5': 12, '10': 'signature'},
+    {'1': 'chain_code', '3': 4, '4': 1, '5': 12, '10': 'chainCode'},
+  ],
+};
+
+/// Descriptor for `CardanoTxWitnessResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxWitnessResponseDescriptor = $convert.base64Decode(
+    'ChhDYXJkYW5vVHhXaXRuZXNzUmVzcG9uc2USRAoEdHlwZRgBIAIoDjIwLmh3LnRyZXpvci5tZX'
+    'NzYWdlcy5jYXJkYW5vLkNhcmRhbm9UeFdpdG5lc3NUeXBlUgR0eXBlEhcKB3B1Yl9rZXkYAiAC'
+    'KAxSBnB1YktleRIcCglzaWduYXR1cmUYAyACKAxSCXNpZ25hdHVyZRIdCgpjaGFpbl9jb2RlGA'
+    'QgASgMUgljaGFpbkNvZGU=');
+
+@$core.Deprecated('Use cardanoTxHostAckDescriptor instead')
+const CardanoTxHostAck$json = {
+  '1': 'CardanoTxHostAck',
+};
+
+/// Descriptor for `CardanoTxHostAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxHostAckDescriptor = $convert.base64Decode(
+    'ChBDYXJkYW5vVHhIb3N0QWNr');
+
+@$core.Deprecated('Use cardanoTxBodyHashDescriptor instead')
+const CardanoTxBodyHash$json = {
+  '1': 'CardanoTxBodyHash',
+  '2': [
+    {'1': 'tx_hash', '3': 1, '4': 2, '5': 12, '10': 'txHash'},
+  ],
+};
+
+/// Descriptor for `CardanoTxBodyHash`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoTxBodyHashDescriptor = $convert.base64Decode(
+    'ChFDYXJkYW5vVHhCb2R5SGFzaBIXCgd0eF9oYXNoGAEgAigMUgZ0eEhhc2g=');
+
+@$core.Deprecated('Use cardanoSignTxFinishedDescriptor instead')
+const CardanoSignTxFinished$json = {
+  '1': 'CardanoSignTxFinished',
+};
+
+/// Descriptor for `CardanoSignTxFinished`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cardanoSignTxFinishedDescriptor = $convert.base64Decode(
+    'ChVDYXJkYW5vU2lnblR4RmluaXNoZWQ=');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-cardano.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-cardano.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-cardano.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-cardano.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-common.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-common.pb.dart
@@ -1,0 +1,711 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-common.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'messages-common.pbenum.dart';
+
+export 'messages-common.pbenum.dart';
+
+/// *
+///  Response: Success of the previous request
+///  @end
+class Success extends $pb.GeneratedMessage {
+  factory Success({
+    $core.String? message,
+  }) {
+    final $result = create();
+    if (message != null) {
+      $result.message = message;
+    }
+    return $result;
+  }
+  Success._() : super();
+  factory Success.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Success.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Success', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.common'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'message')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Success clone() => Success()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Success copyWith(void Function(Success) updates) => super.copyWith((message) => updates(message as Success)) as Success;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Success create() => Success._();
+  Success createEmptyInstance() => create();
+  static $pb.PbList<Success> createRepeated() => $pb.PbList<Success>();
+  @$core.pragma('dart2js:noInline')
+  static Success getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Success>(create);
+  static Success? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get message => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set message($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasMessage() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearMessage() => clearField(1);
+}
+
+/// *
+///  Response: Failure of the previous request
+///  @end
+class Failure extends $pb.GeneratedMessage {
+  factory Failure({
+    Failure_FailureType? code,
+    $core.String? message,
+  }) {
+    final $result = create();
+    if (code != null) {
+      $result.code = code;
+    }
+    if (message != null) {
+      $result.message = message;
+    }
+    return $result;
+  }
+  Failure._() : super();
+  factory Failure.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Failure.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Failure', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.common'), createEmptyInstance: create)
+    ..e<Failure_FailureType>(1, _omitFieldNames ? '' : 'code', $pb.PbFieldType.OE, defaultOrMaker: Failure_FailureType.Failure_UnexpectedMessage, valueOf: Failure_FailureType.valueOf, enumValues: Failure_FailureType.values)
+    ..aOS(2, _omitFieldNames ? '' : 'message')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Failure clone() => Failure()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Failure copyWith(void Function(Failure) updates) => super.copyWith((message) => updates(message as Failure)) as Failure;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Failure create() => Failure._();
+  Failure createEmptyInstance() => create();
+  static $pb.PbList<Failure> createRepeated() => $pb.PbList<Failure>();
+  @$core.pragma('dart2js:noInline')
+  static Failure getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Failure>(create);
+  static Failure? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  Failure_FailureType get code => $_getN(0);
+  @$pb.TagNumber(1)
+  set code(Failure_FailureType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasCode() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCode() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get message => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set message($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMessage() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMessage() => clearField(2);
+}
+
+/// *
+///  Response: Device is waiting for HW button press.
+///  @auxstart
+///  @next ButtonAck
+class ButtonRequest extends $pb.GeneratedMessage {
+  factory ButtonRequest({
+    ButtonRequest_ButtonRequestType? code,
+    $core.int? pages,
+  }) {
+    final $result = create();
+    if (code != null) {
+      $result.code = code;
+    }
+    if (pages != null) {
+      $result.pages = pages;
+    }
+    return $result;
+  }
+  ButtonRequest._() : super();
+  factory ButtonRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ButtonRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ButtonRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.common'), createEmptyInstance: create)
+    ..e<ButtonRequest_ButtonRequestType>(1, _omitFieldNames ? '' : 'code', $pb.PbFieldType.OE, defaultOrMaker: ButtonRequest_ButtonRequestType.ButtonRequest_Other, valueOf: ButtonRequest_ButtonRequestType.valueOf, enumValues: ButtonRequest_ButtonRequestType.values)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'pages', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ButtonRequest clone() => ButtonRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ButtonRequest copyWith(void Function(ButtonRequest) updates) => super.copyWith((message) => updates(message as ButtonRequest)) as ButtonRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ButtonRequest create() => ButtonRequest._();
+  ButtonRequest createEmptyInstance() => create();
+  static $pb.PbList<ButtonRequest> createRepeated() => $pb.PbList<ButtonRequest>();
+  @$core.pragma('dart2js:noInline')
+  static ButtonRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ButtonRequest>(create);
+  static ButtonRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  ButtonRequest_ButtonRequestType get code => $_getN(0);
+  @$pb.TagNumber(1)
+  set code(ButtonRequest_ButtonRequestType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasCode() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCode() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get pages => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set pages($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPages() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPages() => clearField(2);
+}
+
+/// *
+///  Request: Computer agrees to wait for HW button press
+///  @auxend
+class ButtonAck extends $pb.GeneratedMessage {
+  factory ButtonAck() => create();
+  ButtonAck._() : super();
+  factory ButtonAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ButtonAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ButtonAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.common'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ButtonAck clone() => ButtonAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ButtonAck copyWith(void Function(ButtonAck) updates) => super.copyWith((message) => updates(message as ButtonAck)) as ButtonAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ButtonAck create() => ButtonAck._();
+  ButtonAck createEmptyInstance() => create();
+  static $pb.PbList<ButtonAck> createRepeated() => $pb.PbList<ButtonAck>();
+  @$core.pragma('dart2js:noInline')
+  static ButtonAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ButtonAck>(create);
+  static ButtonAck? _defaultInstance;
+}
+
+/// *
+///  Response: Device is asking computer to show PIN matrix and awaits PIN encoded using this matrix scheme
+///  @auxstart
+///  @next PinMatrixAck
+class PinMatrixRequest extends $pb.GeneratedMessage {
+  factory PinMatrixRequest({
+    PinMatrixRequest_PinMatrixRequestType? type,
+  }) {
+    final $result = create();
+    if (type != null) {
+      $result.type = type;
+    }
+    return $result;
+  }
+  PinMatrixRequest._() : super();
+  factory PinMatrixRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PinMatrixRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PinMatrixRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.common'), createEmptyInstance: create)
+    ..e<PinMatrixRequest_PinMatrixRequestType>(1, _omitFieldNames ? '' : 'type', $pb.PbFieldType.OE, defaultOrMaker: PinMatrixRequest_PinMatrixRequestType.PinMatrixRequestType_Current, valueOf: PinMatrixRequest_PinMatrixRequestType.valueOf, enumValues: PinMatrixRequest_PinMatrixRequestType.values)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PinMatrixRequest clone() => PinMatrixRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PinMatrixRequest copyWith(void Function(PinMatrixRequest) updates) => super.copyWith((message) => updates(message as PinMatrixRequest)) as PinMatrixRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PinMatrixRequest create() => PinMatrixRequest._();
+  PinMatrixRequest createEmptyInstance() => create();
+  static $pb.PbList<PinMatrixRequest> createRepeated() => $pb.PbList<PinMatrixRequest>();
+  @$core.pragma('dart2js:noInline')
+  static PinMatrixRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PinMatrixRequest>(create);
+  static PinMatrixRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  PinMatrixRequest_PinMatrixRequestType get type => $_getN(0);
+  @$pb.TagNumber(1)
+  set type(PinMatrixRequest_PinMatrixRequestType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearType() => clearField(1);
+}
+
+/// *
+///  Request: Computer responds with encoded PIN
+///  @auxend
+class PinMatrixAck extends $pb.GeneratedMessage {
+  factory PinMatrixAck({
+    $core.String? pin,
+  }) {
+    final $result = create();
+    if (pin != null) {
+      $result.pin = pin;
+    }
+    return $result;
+  }
+  PinMatrixAck._() : super();
+  factory PinMatrixAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PinMatrixAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PinMatrixAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.common'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'pin')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PinMatrixAck clone() => PinMatrixAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PinMatrixAck copyWith(void Function(PinMatrixAck) updates) => super.copyWith((message) => updates(message as PinMatrixAck)) as PinMatrixAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PinMatrixAck create() => PinMatrixAck._();
+  PinMatrixAck createEmptyInstance() => create();
+  static $pb.PbList<PinMatrixAck> createRepeated() => $pb.PbList<PinMatrixAck>();
+  @$core.pragma('dart2js:noInline')
+  static PinMatrixAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PinMatrixAck>(create);
+  static PinMatrixAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get pin => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set pin($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPin() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPin() => clearField(1);
+}
+
+/// *
+///  Response: Device awaits encryption passphrase
+///  @auxstart
+///  @next PassphraseAck
+class PassphraseRequest extends $pb.GeneratedMessage {
+  factory PassphraseRequest({
+  @$core.Deprecated('This field is deprecated.')
+    $core.bool? onDevice,
+  }) {
+    final $result = create();
+    if (onDevice != null) {
+      // ignore: deprecated_member_use_from_same_package
+      $result.onDevice = onDevice;
+    }
+    return $result;
+  }
+  PassphraseRequest._() : super();
+  factory PassphraseRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PassphraseRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PassphraseRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.common'), createEmptyInstance: create)
+    ..aOB(1, _omitFieldNames ? '' : 'OnDevice')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PassphraseRequest clone() => PassphraseRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PassphraseRequest copyWith(void Function(PassphraseRequest) updates) => super.copyWith((message) => updates(message as PassphraseRequest)) as PassphraseRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PassphraseRequest create() => PassphraseRequest._();
+  PassphraseRequest createEmptyInstance() => create();
+  static $pb.PbList<PassphraseRequest> createRepeated() => $pb.PbList<PassphraseRequest>();
+  @$core.pragma('dart2js:noInline')
+  static PassphraseRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PassphraseRequest>(create);
+  static PassphraseRequest? _defaultInstance;
+
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(1)
+  $core.bool get onDevice => $_getBF(0);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(1)
+  set onDevice($core.bool v) { $_setBool(0, v); }
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(1)
+  $core.bool hasOnDevice() => $_has(0);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(1)
+  void clearOnDevice() => clearField(1);
+}
+
+/// *
+///  Request: Send passphrase back
+///  @auxend
+class PassphraseAck extends $pb.GeneratedMessage {
+  factory PassphraseAck({
+    $core.String? passphrase,
+  @$core.Deprecated('This field is deprecated.')
+    $core.List<$core.int>? state,
+    $core.bool? onDevice,
+  }) {
+    final $result = create();
+    if (passphrase != null) {
+      $result.passphrase = passphrase;
+    }
+    if (state != null) {
+      // ignore: deprecated_member_use_from_same_package
+      $result.state = state;
+    }
+    if (onDevice != null) {
+      $result.onDevice = onDevice;
+    }
+    return $result;
+  }
+  PassphraseAck._() : super();
+  factory PassphraseAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PassphraseAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PassphraseAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.common'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'passphrase')
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'State', $pb.PbFieldType.OY)
+    ..aOB(3, _omitFieldNames ? '' : 'onDevice')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PassphraseAck clone() => PassphraseAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PassphraseAck copyWith(void Function(PassphraseAck) updates) => super.copyWith((message) => updates(message as PassphraseAck)) as PassphraseAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PassphraseAck create() => PassphraseAck._();
+  PassphraseAck createEmptyInstance() => create();
+  static $pb.PbList<PassphraseAck> createRepeated() => $pb.PbList<PassphraseAck>();
+  @$core.pragma('dart2js:noInline')
+  static PassphraseAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PassphraseAck>(create);
+  static PassphraseAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get passphrase => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set passphrase($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPassphrase() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPassphrase() => clearField(1);
+
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get state => $_getN(1);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(2)
+  set state($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(2)
+  $core.bool hasState() => $_has(1);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(2)
+  void clearState() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get onDevice => $_getBF(2);
+  @$pb.TagNumber(3)
+  set onDevice($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasOnDevice() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearOnDevice() => clearField(3);
+}
+
+/// *
+///  Response: Device awaits passphrase state
+///  Deprecated in 2.3.0
+///  @next Deprecated_PassphraseStateAck
+class Deprecated_PassphraseStateRequest extends $pb.GeneratedMessage {
+  factory Deprecated_PassphraseStateRequest({
+    $core.List<$core.int>? state,
+  }) {
+    final $result = create();
+    if (state != null) {
+      $result.state = state;
+    }
+    return $result;
+  }
+  Deprecated_PassphraseStateRequest._() : super();
+  factory Deprecated_PassphraseStateRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Deprecated_PassphraseStateRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Deprecated_PassphraseStateRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.common'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'state', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Deprecated_PassphraseStateRequest clone() => Deprecated_PassphraseStateRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Deprecated_PassphraseStateRequest copyWith(void Function(Deprecated_PassphraseStateRequest) updates) => super.copyWith((message) => updates(message as Deprecated_PassphraseStateRequest)) as Deprecated_PassphraseStateRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Deprecated_PassphraseStateRequest create() => Deprecated_PassphraseStateRequest._();
+  Deprecated_PassphraseStateRequest createEmptyInstance() => create();
+  static $pb.PbList<Deprecated_PassphraseStateRequest> createRepeated() => $pb.PbList<Deprecated_PassphraseStateRequest>();
+  @$core.pragma('dart2js:noInline')
+  static Deprecated_PassphraseStateRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Deprecated_PassphraseStateRequest>(create);
+  static Deprecated_PassphraseStateRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get state => $_getN(0);
+  @$pb.TagNumber(1)
+  set state($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasState() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearState() => clearField(1);
+}
+
+/// *
+///  Request: Send passphrase state back
+///  Deprecated in 2.3.0
+///  @auxend
+class Deprecated_PassphraseStateAck extends $pb.GeneratedMessage {
+  factory Deprecated_PassphraseStateAck() => create();
+  Deprecated_PassphraseStateAck._() : super();
+  factory Deprecated_PassphraseStateAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Deprecated_PassphraseStateAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Deprecated_PassphraseStateAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.common'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Deprecated_PassphraseStateAck clone() => Deprecated_PassphraseStateAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Deprecated_PassphraseStateAck copyWith(void Function(Deprecated_PassphraseStateAck) updates) => super.copyWith((message) => updates(message as Deprecated_PassphraseStateAck)) as Deprecated_PassphraseStateAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Deprecated_PassphraseStateAck create() => Deprecated_PassphraseStateAck._();
+  Deprecated_PassphraseStateAck createEmptyInstance() => create();
+  static $pb.PbList<Deprecated_PassphraseStateAck> createRepeated() => $pb.PbList<Deprecated_PassphraseStateAck>();
+  @$core.pragma('dart2js:noInline')
+  static Deprecated_PassphraseStateAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Deprecated_PassphraseStateAck>(create);
+  static Deprecated_PassphraseStateAck? _defaultInstance;
+}
+
+/// *
+///  Structure representing BIP32 (hierarchical deterministic) node
+///  Used for imports of private key into the device and exporting public key out of device
+///  @embed
+class HDNodeType extends $pb.GeneratedMessage {
+  factory HDNodeType({
+    $core.int? depth,
+    $core.int? fingerprint,
+    $core.int? childNum,
+    $core.List<$core.int>? chainCode,
+    $core.List<$core.int>? privateKey,
+    $core.List<$core.int>? publicKey,
+  }) {
+    final $result = create();
+    if (depth != null) {
+      $result.depth = depth;
+    }
+    if (fingerprint != null) {
+      $result.fingerprint = fingerprint;
+    }
+    if (childNum != null) {
+      $result.childNum = childNum;
+    }
+    if (chainCode != null) {
+      $result.chainCode = chainCode;
+    }
+    if (privateKey != null) {
+      $result.privateKey = privateKey;
+    }
+    if (publicKey != null) {
+      $result.publicKey = publicKey;
+    }
+    return $result;
+  }
+  HDNodeType._() : super();
+  factory HDNodeType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory HDNodeType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'HDNodeType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.common'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'depth', $pb.PbFieldType.QU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'fingerprint', $pb.PbFieldType.QU3)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'childNum', $pb.PbFieldType.QU3)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'chainCode', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'privateKey', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'publicKey', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  HDNodeType clone() => HDNodeType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  HDNodeType copyWith(void Function(HDNodeType) updates) => super.copyWith((message) => updates(message as HDNodeType)) as HDNodeType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static HDNodeType create() => HDNodeType._();
+  HDNodeType createEmptyInstance() => create();
+  static $pb.PbList<HDNodeType> createRepeated() => $pb.PbList<HDNodeType>();
+  @$core.pragma('dart2js:noInline')
+  static HDNodeType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<HDNodeType>(create);
+  static HDNodeType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get depth => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set depth($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDepth() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDepth() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get fingerprint => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set fingerprint($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasFingerprint() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearFingerprint() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get childNum => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set childNum($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasChildNum() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearChildNum() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get chainCode => $_getN(3);
+  @$pb.TagNumber(4)
+  set chainCode($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasChainCode() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearChainCode() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get privateKey => $_getN(4);
+  @$pb.TagNumber(5)
+  set privateKey($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasPrivateKey() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearPrivateKey() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get publicKey => $_getN(5);
+  @$pb.TagNumber(6)
+  set publicKey($core.List<$core.int> v) { $_setBytes(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasPublicKey() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearPublicKey() => clearField(6);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-common.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-common.pbenum.dart
@@ -1,0 +1,134 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-common.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+class Failure_FailureType extends $pb.ProtobufEnum {
+  static const Failure_FailureType Failure_UnexpectedMessage = Failure_FailureType._(1, _omitEnumNames ? '' : 'Failure_UnexpectedMessage');
+  static const Failure_FailureType Failure_ButtonExpected = Failure_FailureType._(2, _omitEnumNames ? '' : 'Failure_ButtonExpected');
+  static const Failure_FailureType Failure_DataError = Failure_FailureType._(3, _omitEnumNames ? '' : 'Failure_DataError');
+  static const Failure_FailureType Failure_ActionCancelled = Failure_FailureType._(4, _omitEnumNames ? '' : 'Failure_ActionCancelled');
+  static const Failure_FailureType Failure_PinExpected = Failure_FailureType._(5, _omitEnumNames ? '' : 'Failure_PinExpected');
+  static const Failure_FailureType Failure_PinCancelled = Failure_FailureType._(6, _omitEnumNames ? '' : 'Failure_PinCancelled');
+  static const Failure_FailureType Failure_PinInvalid = Failure_FailureType._(7, _omitEnumNames ? '' : 'Failure_PinInvalid');
+  static const Failure_FailureType Failure_InvalidSignature = Failure_FailureType._(8, _omitEnumNames ? '' : 'Failure_InvalidSignature');
+  static const Failure_FailureType Failure_ProcessError = Failure_FailureType._(9, _omitEnumNames ? '' : 'Failure_ProcessError');
+  static const Failure_FailureType Failure_NotEnoughFunds = Failure_FailureType._(10, _omitEnumNames ? '' : 'Failure_NotEnoughFunds');
+  static const Failure_FailureType Failure_NotInitialized = Failure_FailureType._(11, _omitEnumNames ? '' : 'Failure_NotInitialized');
+  static const Failure_FailureType Failure_PinMismatch = Failure_FailureType._(12, _omitEnumNames ? '' : 'Failure_PinMismatch');
+  static const Failure_FailureType Failure_WipeCodeMismatch = Failure_FailureType._(13, _omitEnumNames ? '' : 'Failure_WipeCodeMismatch');
+  static const Failure_FailureType Failure_InvalidSession = Failure_FailureType._(14, _omitEnumNames ? '' : 'Failure_InvalidSession');
+  static const Failure_FailureType Failure_FirmwareError = Failure_FailureType._(99, _omitEnumNames ? '' : 'Failure_FirmwareError');
+
+  static const $core.List<Failure_FailureType> values = <Failure_FailureType> [
+    Failure_UnexpectedMessage,
+    Failure_ButtonExpected,
+    Failure_DataError,
+    Failure_ActionCancelled,
+    Failure_PinExpected,
+    Failure_PinCancelled,
+    Failure_PinInvalid,
+    Failure_InvalidSignature,
+    Failure_ProcessError,
+    Failure_NotEnoughFunds,
+    Failure_NotInitialized,
+    Failure_PinMismatch,
+    Failure_WipeCodeMismatch,
+    Failure_InvalidSession,
+    Failure_FirmwareError,
+  ];
+
+  static final $core.Map<$core.int, Failure_FailureType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static Failure_FailureType? valueOf($core.int value) => _byValue[value];
+
+  const Failure_FailureType._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Type of button request
+class ButtonRequest_ButtonRequestType extends $pb.ProtobufEnum {
+  static const ButtonRequest_ButtonRequestType ButtonRequest_Other = ButtonRequest_ButtonRequestType._(1, _omitEnumNames ? '' : 'ButtonRequest_Other');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_FeeOverThreshold = ButtonRequest_ButtonRequestType._(2, _omitEnumNames ? '' : 'ButtonRequest_FeeOverThreshold');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_ConfirmOutput = ButtonRequest_ButtonRequestType._(3, _omitEnumNames ? '' : 'ButtonRequest_ConfirmOutput');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_ResetDevice = ButtonRequest_ButtonRequestType._(4, _omitEnumNames ? '' : 'ButtonRequest_ResetDevice');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_ConfirmWord = ButtonRequest_ButtonRequestType._(5, _omitEnumNames ? '' : 'ButtonRequest_ConfirmWord');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_WipeDevice = ButtonRequest_ButtonRequestType._(6, _omitEnumNames ? '' : 'ButtonRequest_WipeDevice');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_ProtectCall = ButtonRequest_ButtonRequestType._(7, _omitEnumNames ? '' : 'ButtonRequest_ProtectCall');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_SignTx = ButtonRequest_ButtonRequestType._(8, _omitEnumNames ? '' : 'ButtonRequest_SignTx');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_FirmwareCheck = ButtonRequest_ButtonRequestType._(9, _omitEnumNames ? '' : 'ButtonRequest_FirmwareCheck');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_Address = ButtonRequest_ButtonRequestType._(10, _omitEnumNames ? '' : 'ButtonRequest_Address');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_PublicKey = ButtonRequest_ButtonRequestType._(11, _omitEnumNames ? '' : 'ButtonRequest_PublicKey');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_MnemonicWordCount = ButtonRequest_ButtonRequestType._(12, _omitEnumNames ? '' : 'ButtonRequest_MnemonicWordCount');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_MnemonicInput = ButtonRequest_ButtonRequestType._(13, _omitEnumNames ? '' : 'ButtonRequest_MnemonicInput');
+  static const ButtonRequest_ButtonRequestType Deprecated_ButtonRequest_PassphraseType_ = ButtonRequest_ButtonRequestType._(14, _omitEnumNames ? '' : '_Deprecated_ButtonRequest_PassphraseType');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_UnknownDerivationPath = ButtonRequest_ButtonRequestType._(15, _omitEnumNames ? '' : 'ButtonRequest_UnknownDerivationPath');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_RecoveryHomepage = ButtonRequest_ButtonRequestType._(16, _omitEnumNames ? '' : 'ButtonRequest_RecoveryHomepage');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_Success = ButtonRequest_ButtonRequestType._(17, _omitEnumNames ? '' : 'ButtonRequest_Success');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_Warning = ButtonRequest_ButtonRequestType._(18, _omitEnumNames ? '' : 'ButtonRequest_Warning');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_PassphraseEntry = ButtonRequest_ButtonRequestType._(19, _omitEnumNames ? '' : 'ButtonRequest_PassphraseEntry');
+  static const ButtonRequest_ButtonRequestType ButtonRequest_PinEntry = ButtonRequest_ButtonRequestType._(20, _omitEnumNames ? '' : 'ButtonRequest_PinEntry');
+
+  static const $core.List<ButtonRequest_ButtonRequestType> values = <ButtonRequest_ButtonRequestType> [
+    ButtonRequest_Other,
+    ButtonRequest_FeeOverThreshold,
+    ButtonRequest_ConfirmOutput,
+    ButtonRequest_ResetDevice,
+    ButtonRequest_ConfirmWord,
+    ButtonRequest_WipeDevice,
+    ButtonRequest_ProtectCall,
+    ButtonRequest_SignTx,
+    ButtonRequest_FirmwareCheck,
+    ButtonRequest_Address,
+    ButtonRequest_PublicKey,
+    ButtonRequest_MnemonicWordCount,
+    ButtonRequest_MnemonicInput,
+    Deprecated_ButtonRequest_PassphraseType_,
+    ButtonRequest_UnknownDerivationPath,
+    ButtonRequest_RecoveryHomepage,
+    ButtonRequest_Success,
+    ButtonRequest_Warning,
+    ButtonRequest_PassphraseEntry,
+    ButtonRequest_PinEntry,
+  ];
+
+  static final $core.Map<$core.int, ButtonRequest_ButtonRequestType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static ButtonRequest_ButtonRequestType? valueOf($core.int value) => _byValue[value];
+
+  const ButtonRequest_ButtonRequestType._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Type of PIN request
+class PinMatrixRequest_PinMatrixRequestType extends $pb.ProtobufEnum {
+  static const PinMatrixRequest_PinMatrixRequestType PinMatrixRequestType_Current = PinMatrixRequest_PinMatrixRequestType._(1, _omitEnumNames ? '' : 'PinMatrixRequestType_Current');
+  static const PinMatrixRequest_PinMatrixRequestType PinMatrixRequestType_NewFirst = PinMatrixRequest_PinMatrixRequestType._(2, _omitEnumNames ? '' : 'PinMatrixRequestType_NewFirst');
+  static const PinMatrixRequest_PinMatrixRequestType PinMatrixRequestType_NewSecond = PinMatrixRequest_PinMatrixRequestType._(3, _omitEnumNames ? '' : 'PinMatrixRequestType_NewSecond');
+  static const PinMatrixRequest_PinMatrixRequestType PinMatrixRequestType_WipeCodeFirst = PinMatrixRequest_PinMatrixRequestType._(4, _omitEnumNames ? '' : 'PinMatrixRequestType_WipeCodeFirst');
+  static const PinMatrixRequest_PinMatrixRequestType PinMatrixRequestType_WipeCodeSecond = PinMatrixRequest_PinMatrixRequestType._(5, _omitEnumNames ? '' : 'PinMatrixRequestType_WipeCodeSecond');
+
+  static const $core.List<PinMatrixRequest_PinMatrixRequestType> values = <PinMatrixRequest_PinMatrixRequestType> [
+    PinMatrixRequestType_Current,
+    PinMatrixRequestType_NewFirst,
+    PinMatrixRequestType_NewSecond,
+    PinMatrixRequestType_WipeCodeFirst,
+    PinMatrixRequestType_WipeCodeSecond,
+  ];
+
+  static final $core.Map<$core.int, PinMatrixRequest_PinMatrixRequestType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static PinMatrixRequest_PinMatrixRequestType? valueOf($core.int value) => _byValue[value];
+
+  const PinMatrixRequest_PinMatrixRequestType._($core.int v, $core.String n) : super(v, n);
+}
+
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-common.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-common.pbjson.dart
@@ -1,0 +1,267 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-common.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use successDescriptor instead')
+const Success$json = {
+  '1': 'Success',
+  '2': [
+    {'1': 'message', '3': 1, '4': 1, '5': 9, '7': '', '10': 'message'},
+  ],
+};
+
+/// Descriptor for `Success`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List successDescriptor = $convert.base64Decode(
+    'CgdTdWNjZXNzEhoKB21lc3NhZ2UYASABKAk6AFIHbWVzc2FnZQ==');
+
+@$core.Deprecated('Use failureDescriptor instead')
+const Failure$json = {
+  '1': 'Failure',
+  '2': [
+    {'1': 'code', '3': 1, '4': 1, '5': 14, '6': '.hw.trezor.messages.common.Failure.FailureType', '10': 'code'},
+    {'1': 'message', '3': 2, '4': 1, '5': 9, '10': 'message'},
+  ],
+  '4': [Failure_FailureType$json],
+};
+
+@$core.Deprecated('Use failureDescriptor instead')
+const Failure_FailureType$json = {
+  '1': 'FailureType',
+  '2': [
+    {'1': 'Failure_UnexpectedMessage', '2': 1},
+    {'1': 'Failure_ButtonExpected', '2': 2},
+    {'1': 'Failure_DataError', '2': 3},
+    {'1': 'Failure_ActionCancelled', '2': 4},
+    {'1': 'Failure_PinExpected', '2': 5},
+    {'1': 'Failure_PinCancelled', '2': 6},
+    {'1': 'Failure_PinInvalid', '2': 7},
+    {'1': 'Failure_InvalidSignature', '2': 8},
+    {'1': 'Failure_ProcessError', '2': 9},
+    {'1': 'Failure_NotEnoughFunds', '2': 10},
+    {'1': 'Failure_NotInitialized', '2': 11},
+    {'1': 'Failure_PinMismatch', '2': 12},
+    {'1': 'Failure_WipeCodeMismatch', '2': 13},
+    {'1': 'Failure_InvalidSession', '2': 14},
+    {'1': 'Failure_FirmwareError', '2': 99},
+  ],
+};
+
+/// Descriptor for `Failure`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List failureDescriptor = $convert.base64Decode(
+    'CgdGYWlsdXJlEkIKBGNvZGUYASABKA4yLi5ody50cmV6b3IubWVzc2FnZXMuY29tbW9uLkZhaW'
+    'x1cmUuRmFpbHVyZVR5cGVSBGNvZGUSGAoHbWVzc2FnZRgCIAEoCVIHbWVzc2FnZSKlAwoLRmFp'
+    'bHVyZVR5cGUSHQoZRmFpbHVyZV9VbmV4cGVjdGVkTWVzc2FnZRABEhoKFkZhaWx1cmVfQnV0dG'
+    '9uRXhwZWN0ZWQQAhIVChFGYWlsdXJlX0RhdGFFcnJvchADEhsKF0ZhaWx1cmVfQWN0aW9uQ2Fu'
+    'Y2VsbGVkEAQSFwoTRmFpbHVyZV9QaW5FeHBlY3RlZBAFEhgKFEZhaWx1cmVfUGluQ2FuY2VsbG'
+    'VkEAYSFgoSRmFpbHVyZV9QaW5JbnZhbGlkEAcSHAoYRmFpbHVyZV9JbnZhbGlkU2lnbmF0dXJl'
+    'EAgSGAoURmFpbHVyZV9Qcm9jZXNzRXJyb3IQCRIaChZGYWlsdXJlX05vdEVub3VnaEZ1bmRzEA'
+    'oSGgoWRmFpbHVyZV9Ob3RJbml0aWFsaXplZBALEhcKE0ZhaWx1cmVfUGluTWlzbWF0Y2gQDBIc'
+    'ChhGYWlsdXJlX1dpcGVDb2RlTWlzbWF0Y2gQDRIaChZGYWlsdXJlX0ludmFsaWRTZXNzaW9uEA'
+    '4SGQoVRmFpbHVyZV9GaXJtd2FyZUVycm9yEGM=');
+
+@$core.Deprecated('Use buttonRequestDescriptor instead')
+const ButtonRequest$json = {
+  '1': 'ButtonRequest',
+  '2': [
+    {'1': 'code', '3': 1, '4': 1, '5': 14, '6': '.hw.trezor.messages.common.ButtonRequest.ButtonRequestType', '10': 'code'},
+    {'1': 'pages', '3': 2, '4': 1, '5': 13, '10': 'pages'},
+  ],
+  '4': [ButtonRequest_ButtonRequestType$json],
+};
+
+@$core.Deprecated('Use buttonRequestDescriptor instead')
+const ButtonRequest_ButtonRequestType$json = {
+  '1': 'ButtonRequestType',
+  '2': [
+    {'1': 'ButtonRequest_Other', '2': 1},
+    {'1': 'ButtonRequest_FeeOverThreshold', '2': 2},
+    {'1': 'ButtonRequest_ConfirmOutput', '2': 3},
+    {'1': 'ButtonRequest_ResetDevice', '2': 4},
+    {'1': 'ButtonRequest_ConfirmWord', '2': 5},
+    {'1': 'ButtonRequest_WipeDevice', '2': 6},
+    {'1': 'ButtonRequest_ProtectCall', '2': 7},
+    {'1': 'ButtonRequest_SignTx', '2': 8},
+    {'1': 'ButtonRequest_FirmwareCheck', '2': 9},
+    {'1': 'ButtonRequest_Address', '2': 10},
+    {'1': 'ButtonRequest_PublicKey', '2': 11},
+    {'1': 'ButtonRequest_MnemonicWordCount', '2': 12},
+    {'1': 'ButtonRequest_MnemonicInput', '2': 13},
+    {
+      '1': '_Deprecated_ButtonRequest_PassphraseType',
+      '2': 14,
+      '3': {'1': true},
+    },
+    {'1': 'ButtonRequest_UnknownDerivationPath', '2': 15},
+    {'1': 'ButtonRequest_RecoveryHomepage', '2': 16},
+    {'1': 'ButtonRequest_Success', '2': 17},
+    {'1': 'ButtonRequest_Warning', '2': 18},
+    {'1': 'ButtonRequest_PassphraseEntry', '2': 19},
+    {'1': 'ButtonRequest_PinEntry', '2': 20},
+  ],
+};
+
+/// Descriptor for `ButtonRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List buttonRequestDescriptor = $convert.base64Decode(
+    'Cg1CdXR0b25SZXF1ZXN0Ek4KBGNvZGUYASABKA4yOi5ody50cmV6b3IubWVzc2FnZXMuY29tbW'
+    '9uLkJ1dHRvblJlcXVlc3QuQnV0dG9uUmVxdWVzdFR5cGVSBGNvZGUSFAoFcGFnZXMYAiABKA1S'
+    'BXBhZ2VzIpkFChFCdXR0b25SZXF1ZXN0VHlwZRIXChNCdXR0b25SZXF1ZXN0X090aGVyEAESIg'
+    'oeQnV0dG9uUmVxdWVzdF9GZWVPdmVyVGhyZXNob2xkEAISHwobQnV0dG9uUmVxdWVzdF9Db25m'
+    'aXJtT3V0cHV0EAMSHQoZQnV0dG9uUmVxdWVzdF9SZXNldERldmljZRAEEh0KGUJ1dHRvblJlcX'
+    'Vlc3RfQ29uZmlybVdvcmQQBRIcChhCdXR0b25SZXF1ZXN0X1dpcGVEZXZpY2UQBhIdChlCdXR0'
+    'b25SZXF1ZXN0X1Byb3RlY3RDYWxsEAcSGAoUQnV0dG9uUmVxdWVzdF9TaWduVHgQCBIfChtCdX'
+    'R0b25SZXF1ZXN0X0Zpcm13YXJlQ2hlY2sQCRIZChVCdXR0b25SZXF1ZXN0X0FkZHJlc3MQChIb'
+    'ChdCdXR0b25SZXF1ZXN0X1B1YmxpY0tleRALEiMKH0J1dHRvblJlcXVlc3RfTW5lbW9uaWNXb3'
+    'JkQ291bnQQDBIfChtCdXR0b25SZXF1ZXN0X01uZW1vbmljSW5wdXQQDRIwCihfRGVwcmVjYXRl'
+    'ZF9CdXR0b25SZXF1ZXN0X1Bhc3NwaHJhc2VUeXBlEA4aAggBEicKI0J1dHRvblJlcXVlc3RfVW'
+    '5rbm93bkRlcml2YXRpb25QYXRoEA8SIgoeQnV0dG9uUmVxdWVzdF9SZWNvdmVyeUhvbWVwYWdl'
+    'EBASGQoVQnV0dG9uUmVxdWVzdF9TdWNjZXNzEBESGQoVQnV0dG9uUmVxdWVzdF9XYXJuaW5nEB'
+    'ISIQodQnV0dG9uUmVxdWVzdF9QYXNzcGhyYXNlRW50cnkQExIaChZCdXR0b25SZXF1ZXN0X1Bp'
+    'bkVudHJ5EBQ=');
+
+@$core.Deprecated('Use buttonAckDescriptor instead')
+const ButtonAck$json = {
+  '1': 'ButtonAck',
+};
+
+/// Descriptor for `ButtonAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List buttonAckDescriptor = $convert.base64Decode(
+    'CglCdXR0b25BY2s=');
+
+@$core.Deprecated('Use pinMatrixRequestDescriptor instead')
+const PinMatrixRequest$json = {
+  '1': 'PinMatrixRequest',
+  '2': [
+    {'1': 'type', '3': 1, '4': 1, '5': 14, '6': '.hw.trezor.messages.common.PinMatrixRequest.PinMatrixRequestType', '10': 'type'},
+  ],
+  '4': [PinMatrixRequest_PinMatrixRequestType$json],
+};
+
+@$core.Deprecated('Use pinMatrixRequestDescriptor instead')
+const PinMatrixRequest_PinMatrixRequestType$json = {
+  '1': 'PinMatrixRequestType',
+  '2': [
+    {'1': 'PinMatrixRequestType_Current', '2': 1},
+    {'1': 'PinMatrixRequestType_NewFirst', '2': 2},
+    {'1': 'PinMatrixRequestType_NewSecond', '2': 3},
+    {'1': 'PinMatrixRequestType_WipeCodeFirst', '2': 4},
+    {'1': 'PinMatrixRequestType_WipeCodeSecond', '2': 5},
+  ],
+};
+
+/// Descriptor for `PinMatrixRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List pinMatrixRequestDescriptor = $convert.base64Decode(
+    'ChBQaW5NYXRyaXhSZXF1ZXN0ElQKBHR5cGUYASABKA4yQC5ody50cmV6b3IubWVzc2FnZXMuY2'
+    '9tbW9uLlBpbk1hdHJpeFJlcXVlc3QuUGluTWF0cml4UmVxdWVzdFR5cGVSBHR5cGUi0AEKFFBp'
+    'bk1hdHJpeFJlcXVlc3RUeXBlEiAKHFBpbk1hdHJpeFJlcXVlc3RUeXBlX0N1cnJlbnQQARIhCh'
+    '1QaW5NYXRyaXhSZXF1ZXN0VHlwZV9OZXdGaXJzdBACEiIKHlBpbk1hdHJpeFJlcXVlc3RUeXBl'
+    'X05ld1NlY29uZBADEiYKIlBpbk1hdHJpeFJlcXVlc3RUeXBlX1dpcGVDb2RlRmlyc3QQBBInCi'
+    'NQaW5NYXRyaXhSZXF1ZXN0VHlwZV9XaXBlQ29kZVNlY29uZBAF');
+
+@$core.Deprecated('Use pinMatrixAckDescriptor instead')
+const PinMatrixAck$json = {
+  '1': 'PinMatrixAck',
+  '2': [
+    {'1': 'pin', '3': 1, '4': 2, '5': 9, '10': 'pin'},
+  ],
+};
+
+/// Descriptor for `PinMatrixAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List pinMatrixAckDescriptor = $convert.base64Decode(
+    'CgxQaW5NYXRyaXhBY2sSEAoDcGluGAEgAigJUgNwaW4=');
+
+@$core.Deprecated('Use passphraseRequestDescriptor instead')
+const PassphraseRequest$json = {
+  '1': 'PassphraseRequest',
+  '2': [
+    {
+      '1': '_on_device',
+      '3': 1,
+      '4': 1,
+      '5': 8,
+      '8': {'3': true},
+      '10': 'OnDevice',
+    },
+  ],
+};
+
+/// Descriptor for `PassphraseRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List passphraseRequestDescriptor = $convert.base64Decode(
+    'ChFQYXNzcGhyYXNlUmVxdWVzdBIgCgpfb25fZGV2aWNlGAEgASgIQgIYAVIIT25EZXZpY2U=');
+
+@$core.Deprecated('Use passphraseAckDescriptor instead')
+const PassphraseAck$json = {
+  '1': 'PassphraseAck',
+  '2': [
+    {'1': 'passphrase', '3': 1, '4': 1, '5': 9, '10': 'passphrase'},
+    {
+      '1': '_state',
+      '3': 2,
+      '4': 1,
+      '5': 12,
+      '8': {'3': true},
+      '10': 'State',
+    },
+    {'1': 'on_device', '3': 3, '4': 1, '5': 8, '10': 'onDevice'},
+  ],
+};
+
+/// Descriptor for `PassphraseAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List passphraseAckDescriptor = $convert.base64Decode(
+    'Cg1QYXNzcGhyYXNlQWNrEh4KCnBhc3NwaHJhc2UYASABKAlSCnBhc3NwaHJhc2USGQoGX3N0YX'
+    'RlGAIgASgMQgIYAVIFU3RhdGUSGwoJb25fZGV2aWNlGAMgASgIUghvbkRldmljZQ==');
+
+@$core.Deprecated('Use deprecated_PassphraseStateRequestDescriptor instead')
+const Deprecated_PassphraseStateRequest$json = {
+  '1': 'Deprecated_PassphraseStateRequest',
+  '2': [
+    {'1': 'state', '3': 1, '4': 1, '5': 12, '10': 'state'},
+  ],
+  '7': {'3': true},
+};
+
+/// Descriptor for `Deprecated_PassphraseStateRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List deprecated_PassphraseStateRequestDescriptor = $convert.base64Decode(
+    'CiFEZXByZWNhdGVkX1Bhc3NwaHJhc2VTdGF0ZVJlcXVlc3QSFAoFc3RhdGUYASABKAxSBXN0YX'
+    'RlOgIYAQ==');
+
+@$core.Deprecated('Use deprecated_PassphraseStateAckDescriptor instead')
+const Deprecated_PassphraseStateAck$json = {
+  '1': 'Deprecated_PassphraseStateAck',
+  '7': {'3': true},
+};
+
+/// Descriptor for `Deprecated_PassphraseStateAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List deprecated_PassphraseStateAckDescriptor = $convert.base64Decode(
+    'Ch1EZXByZWNhdGVkX1Bhc3NwaHJhc2VTdGF0ZUFjazoCGAE=');
+
+@$core.Deprecated('Use hDNodeTypeDescriptor instead')
+const HDNodeType$json = {
+  '1': 'HDNodeType',
+  '2': [
+    {'1': 'depth', '3': 1, '4': 2, '5': 13, '10': 'depth'},
+    {'1': 'fingerprint', '3': 2, '4': 2, '5': 13, '10': 'fingerprint'},
+    {'1': 'child_num', '3': 3, '4': 2, '5': 13, '10': 'childNum'},
+    {'1': 'chain_code', '3': 4, '4': 2, '5': 12, '10': 'chainCode'},
+    {'1': 'private_key', '3': 5, '4': 1, '5': 12, '10': 'privateKey'},
+    {'1': 'public_key', '3': 6, '4': 2, '5': 12, '10': 'publicKey'},
+  ],
+};
+
+/// Descriptor for `HDNodeType`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List hDNodeTypeDescriptor = $convert.base64Decode(
+    'CgpIRE5vZGVUeXBlEhQKBWRlcHRoGAEgAigNUgVkZXB0aBIgCgtmaW5nZXJwcmludBgCIAIoDV'
+    'ILZmluZ2VycHJpbnQSGwoJY2hpbGRfbnVtGAMgAigNUghjaGlsZE51bRIdCgpjaGFpbl9jb2Rl'
+    'GAQgAigMUgljaGFpbkNvZGUSHwoLcHJpdmF0ZV9rZXkYBSABKAxSCnByaXZhdGVLZXkSHQoKcH'
+    'VibGljX2tleRgGIAIoDFIJcHVibGljS2V5');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-common.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-common.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-common.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-common.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-crypto.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-crypto.pb.dart
@@ -1,0 +1,930 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-crypto.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+/// *
+///  Request: Ask device to encrypt or decrypt value of given key
+///  @start
+///  @next CipheredKeyValue
+///  @next Failure
+class CipherKeyValue extends $pb.GeneratedMessage {
+  factory CipherKeyValue({
+    $core.Iterable<$core.int>? addressN,
+    $core.String? key,
+    $core.List<$core.int>? value,
+    $core.bool? encrypt,
+    $core.bool? askOnEncrypt,
+    $core.bool? askOnDecrypt,
+    $core.List<$core.int>? iv,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (key != null) {
+      $result.key = key;
+    }
+    if (value != null) {
+      $result.value = value;
+    }
+    if (encrypt != null) {
+      $result.encrypt = encrypt;
+    }
+    if (askOnEncrypt != null) {
+      $result.askOnEncrypt = askOnEncrypt;
+    }
+    if (askOnDecrypt != null) {
+      $result.askOnDecrypt = askOnDecrypt;
+    }
+    if (iv != null) {
+      $result.iv = iv;
+    }
+    return $result;
+  }
+  CipherKeyValue._() : super();
+  factory CipherKeyValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CipherKeyValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CipherKeyValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.crypto'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aQS(2, _omitFieldNames ? '' : 'key')
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'value', $pb.PbFieldType.QY)
+    ..aOB(4, _omitFieldNames ? '' : 'encrypt')
+    ..aOB(5, _omitFieldNames ? '' : 'askOnEncrypt')
+    ..aOB(6, _omitFieldNames ? '' : 'askOnDecrypt')
+    ..a<$core.List<$core.int>>(7, _omitFieldNames ? '' : 'iv', $pb.PbFieldType.OY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CipherKeyValue clone() => CipherKeyValue()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CipherKeyValue copyWith(void Function(CipherKeyValue) updates) => super.copyWith((message) => updates(message as CipherKeyValue)) as CipherKeyValue;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CipherKeyValue create() => CipherKeyValue._();
+  CipherKeyValue createEmptyInstance() => create();
+  static $pb.PbList<CipherKeyValue> createRepeated() => $pb.PbList<CipherKeyValue>();
+  @$core.pragma('dart2js:noInline')
+  static CipherKeyValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CipherKeyValue>(create);
+  static CipherKeyValue? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.String get key => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set key($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasKey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearKey() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get value => $_getN(2);
+  @$pb.TagNumber(3)
+  set value($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasValue() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearValue() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.bool get encrypt => $_getBF(3);
+  @$pb.TagNumber(4)
+  set encrypt($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasEncrypt() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearEncrypt() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.bool get askOnEncrypt => $_getBF(4);
+  @$pb.TagNumber(5)
+  set askOnEncrypt($core.bool v) { $_setBool(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasAskOnEncrypt() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearAskOnEncrypt() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.bool get askOnDecrypt => $_getBF(5);
+  @$pb.TagNumber(6)
+  set askOnDecrypt($core.bool v) { $_setBool(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasAskOnDecrypt() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearAskOnDecrypt() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.List<$core.int> get iv => $_getN(6);
+  @$pb.TagNumber(7)
+  set iv($core.List<$core.int> v) { $_setBytes(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasIv() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearIv() => clearField(7);
+}
+
+/// *
+///  Response: Return ciphered/deciphered value
+///  @end
+class CipheredKeyValue extends $pb.GeneratedMessage {
+  factory CipheredKeyValue({
+    $core.List<$core.int>? value,
+  }) {
+    final $result = create();
+    if (value != null) {
+      $result.value = value;
+    }
+    return $result;
+  }
+  CipheredKeyValue._() : super();
+  factory CipheredKeyValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CipheredKeyValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CipheredKeyValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.crypto'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CipheredKeyValue clone() => CipheredKeyValue()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CipheredKeyValue copyWith(void Function(CipheredKeyValue) updates) => super.copyWith((message) => updates(message as CipheredKeyValue)) as CipheredKeyValue;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CipheredKeyValue create() => CipheredKeyValue._();
+  CipheredKeyValue createEmptyInstance() => create();
+  static $pb.PbList<CipheredKeyValue> createRepeated() => $pb.PbList<CipheredKeyValue>();
+  @$core.pragma('dart2js:noInline')
+  static CipheredKeyValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CipheredKeyValue>(create);
+  static CipheredKeyValue? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get value => $_getN(0);
+  @$pb.TagNumber(1)
+  set value($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasValue() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearValue() => clearField(1);
+}
+
+/// *
+///  Structure representing identity data
+///  @embed
+class IdentityType extends $pb.GeneratedMessage {
+  factory IdentityType({
+    $core.String? proto,
+    $core.String? user,
+    $core.String? host,
+    $core.String? port,
+    $core.String? path,
+    $core.int? index,
+  }) {
+    final $result = create();
+    if (proto != null) {
+      $result.proto = proto;
+    }
+    if (user != null) {
+      $result.user = user;
+    }
+    if (host != null) {
+      $result.host = host;
+    }
+    if (port != null) {
+      $result.port = port;
+    }
+    if (path != null) {
+      $result.path = path;
+    }
+    if (index != null) {
+      $result.index = index;
+    }
+    return $result;
+  }
+  IdentityType._() : super();
+  factory IdentityType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory IdentityType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'IdentityType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.crypto'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'proto')
+    ..aOS(2, _omitFieldNames ? '' : 'user')
+    ..aOS(3, _omitFieldNames ? '' : 'host')
+    ..aOS(4, _omitFieldNames ? '' : 'port')
+    ..aOS(5, _omitFieldNames ? '' : 'path')
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'index', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  IdentityType clone() => IdentityType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  IdentityType copyWith(void Function(IdentityType) updates) => super.copyWith((message) => updates(message as IdentityType)) as IdentityType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static IdentityType create() => IdentityType._();
+  IdentityType createEmptyInstance() => create();
+  static $pb.PbList<IdentityType> createRepeated() => $pb.PbList<IdentityType>();
+  @$core.pragma('dart2js:noInline')
+  static IdentityType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<IdentityType>(create);
+  static IdentityType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get proto => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set proto($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasProto() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearProto() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get user => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set user($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasUser() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearUser() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get host => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set host($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasHost() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearHost() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get port => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set port($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasPort() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearPort() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.String get path => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set path($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasPath() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearPath() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.int get index => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set index($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasIndex() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearIndex() => clearField(6);
+}
+
+/// *
+///  Request: Ask device to sign identity
+///  @start
+///  @next SignedIdentity
+///  @next Failure
+class SignIdentity extends $pb.GeneratedMessage {
+  factory SignIdentity({
+    IdentityType? identity,
+    $core.List<$core.int>? challengeHidden,
+    $core.String? challengeVisual,
+    $core.String? ecdsaCurveName,
+  }) {
+    final $result = create();
+    if (identity != null) {
+      $result.identity = identity;
+    }
+    if (challengeHidden != null) {
+      $result.challengeHidden = challengeHidden;
+    }
+    if (challengeVisual != null) {
+      $result.challengeVisual = challengeVisual;
+    }
+    if (ecdsaCurveName != null) {
+      $result.ecdsaCurveName = ecdsaCurveName;
+    }
+    return $result;
+  }
+  SignIdentity._() : super();
+  factory SignIdentity.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignIdentity.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignIdentity', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.crypto'), createEmptyInstance: create)
+    ..aQM<IdentityType>(1, _omitFieldNames ? '' : 'identity', subBuilder: IdentityType.create)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'challengeHidden', $pb.PbFieldType.OY)
+    ..aOS(3, _omitFieldNames ? '' : 'challengeVisual')
+    ..aOS(4, _omitFieldNames ? '' : 'ecdsaCurveName')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SignIdentity clone() => SignIdentity()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignIdentity copyWith(void Function(SignIdentity) updates) => super.copyWith((message) => updates(message as SignIdentity)) as SignIdentity;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SignIdentity create() => SignIdentity._();
+  SignIdentity createEmptyInstance() => create();
+  static $pb.PbList<SignIdentity> createRepeated() => $pb.PbList<SignIdentity>();
+  @$core.pragma('dart2js:noInline')
+  static SignIdentity getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignIdentity>(create);
+  static SignIdentity? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  IdentityType get identity => $_getN(0);
+  @$pb.TagNumber(1)
+  set identity(IdentityType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasIdentity() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearIdentity() => clearField(1);
+  @$pb.TagNumber(1)
+  IdentityType ensureIdentity() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get challengeHidden => $_getN(1);
+  @$pb.TagNumber(2)
+  set challengeHidden($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasChallengeHidden() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearChallengeHidden() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get challengeVisual => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set challengeVisual($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasChallengeVisual() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearChallengeVisual() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get ecdsaCurveName => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set ecdsaCurveName($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasEcdsaCurveName() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearEcdsaCurveName() => clearField(4);
+}
+
+/// *
+///  Response: Device provides signed identity
+///  @end
+class SignedIdentity extends $pb.GeneratedMessage {
+  factory SignedIdentity({
+    $core.String? address,
+    $core.List<$core.int>? publicKey,
+    $core.List<$core.int>? signature,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    if (publicKey != null) {
+      $result.publicKey = publicKey;
+    }
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    return $result;
+  }
+  SignedIdentity._() : super();
+  factory SignedIdentity.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignedIdentity.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignedIdentity', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.crypto'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'address')
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'publicKey', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SignedIdentity clone() => SignedIdentity()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignedIdentity copyWith(void Function(SignedIdentity) updates) => super.copyWith((message) => updates(message as SignedIdentity)) as SignedIdentity;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SignedIdentity create() => SignedIdentity._();
+  SignedIdentity createEmptyInstance() => create();
+  static $pb.PbList<SignedIdentity> createRepeated() => $pb.PbList<SignedIdentity>();
+  @$core.pragma('dart2js:noInline')
+  static SignedIdentity getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignedIdentity>(create);
+  static SignedIdentity? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get publicKey => $_getN(1);
+  @$pb.TagNumber(2)
+  set publicKey($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPublicKey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPublicKey() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get signature => $_getN(2);
+  @$pb.TagNumber(3)
+  set signature($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSignature() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSignature() => clearField(3);
+}
+
+/// *
+///  Request: Ask device to generate ECDH session key
+///  @start
+///  @next ECDHSessionKey
+///  @next Failure
+class GetECDHSessionKey extends $pb.GeneratedMessage {
+  factory GetECDHSessionKey({
+    IdentityType? identity,
+    $core.List<$core.int>? peerPublicKey,
+    $core.String? ecdsaCurveName,
+  }) {
+    final $result = create();
+    if (identity != null) {
+      $result.identity = identity;
+    }
+    if (peerPublicKey != null) {
+      $result.peerPublicKey = peerPublicKey;
+    }
+    if (ecdsaCurveName != null) {
+      $result.ecdsaCurveName = ecdsaCurveName;
+    }
+    return $result;
+  }
+  GetECDHSessionKey._() : super();
+  factory GetECDHSessionKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetECDHSessionKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetECDHSessionKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.crypto'), createEmptyInstance: create)
+    ..aQM<IdentityType>(1, _omitFieldNames ? '' : 'identity', subBuilder: IdentityType.create)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'peerPublicKey', $pb.PbFieldType.QY)
+    ..aOS(3, _omitFieldNames ? '' : 'ecdsaCurveName')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetECDHSessionKey clone() => GetECDHSessionKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetECDHSessionKey copyWith(void Function(GetECDHSessionKey) updates) => super.copyWith((message) => updates(message as GetECDHSessionKey)) as GetECDHSessionKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetECDHSessionKey create() => GetECDHSessionKey._();
+  GetECDHSessionKey createEmptyInstance() => create();
+  static $pb.PbList<GetECDHSessionKey> createRepeated() => $pb.PbList<GetECDHSessionKey>();
+  @$core.pragma('dart2js:noInline')
+  static GetECDHSessionKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetECDHSessionKey>(create);
+  static GetECDHSessionKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  IdentityType get identity => $_getN(0);
+  @$pb.TagNumber(1)
+  set identity(IdentityType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasIdentity() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearIdentity() => clearField(1);
+  @$pb.TagNumber(1)
+  IdentityType ensureIdentity() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get peerPublicKey => $_getN(1);
+  @$pb.TagNumber(2)
+  set peerPublicKey($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPeerPublicKey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPeerPublicKey() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get ecdsaCurveName => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set ecdsaCurveName($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasEcdsaCurveName() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearEcdsaCurveName() => clearField(3);
+}
+
+/// *
+///  Response: Device provides ECDH session key
+///  @end
+class ECDHSessionKey extends $pb.GeneratedMessage {
+  factory ECDHSessionKey({
+    $core.List<$core.int>? sessionKey,
+    $core.List<$core.int>? publicKey,
+  }) {
+    final $result = create();
+    if (sessionKey != null) {
+      $result.sessionKey = sessionKey;
+    }
+    if (publicKey != null) {
+      $result.publicKey = publicKey;
+    }
+    return $result;
+  }
+  ECDHSessionKey._() : super();
+  factory ECDHSessionKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ECDHSessionKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ECDHSessionKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.crypto'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'sessionKey', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'publicKey', $pb.PbFieldType.OY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ECDHSessionKey clone() => ECDHSessionKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ECDHSessionKey copyWith(void Function(ECDHSessionKey) updates) => super.copyWith((message) => updates(message as ECDHSessionKey)) as ECDHSessionKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ECDHSessionKey create() => ECDHSessionKey._();
+  ECDHSessionKey createEmptyInstance() => create();
+  static $pb.PbList<ECDHSessionKey> createRepeated() => $pb.PbList<ECDHSessionKey>();
+  @$core.pragma('dart2js:noInline')
+  static ECDHSessionKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ECDHSessionKey>(create);
+  static ECDHSessionKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get sessionKey => $_getN(0);
+  @$pb.TagNumber(1)
+  set sessionKey($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSessionKey() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSessionKey() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get publicKey => $_getN(1);
+  @$pb.TagNumber(2)
+  set publicKey($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPublicKey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPublicKey() => clearField(2);
+}
+
+/// *
+///  Request: Ask device to commit to CoSi signing
+///  @start
+///  @next CosiCommitment
+///  @next Failure
+class CosiCommit extends $pb.GeneratedMessage {
+  factory CosiCommit({
+    $core.Iterable<$core.int>? addressN,
+  @$core.Deprecated('This field is deprecated.')
+    $core.List<$core.int>? data,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (data != null) {
+      // ignore: deprecated_member_use_from_same_package
+      $result.data = data;
+    }
+    return $result;
+  }
+  CosiCommit._() : super();
+  factory CosiCommit.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CosiCommit.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CosiCommit', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.crypto'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'data', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CosiCommit clone() => CosiCommit()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CosiCommit copyWith(void Function(CosiCommit) updates) => super.copyWith((message) => updates(message as CosiCommit)) as CosiCommit;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CosiCommit create() => CosiCommit._();
+  CosiCommit createEmptyInstance() => create();
+  static $pb.PbList<CosiCommit> createRepeated() => $pb.PbList<CosiCommit>();
+  @$core.pragma('dart2js:noInline')
+  static CosiCommit getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CosiCommit>(create);
+  static CosiCommit? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get data => $_getN(1);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(2)
+  set data($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(2)
+  $core.bool hasData() => $_has(1);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(2)
+  void clearData() => clearField(2);
+}
+
+/// *
+///  Response: Contains a CoSi commitment
+///  @end
+class CosiCommitment extends $pb.GeneratedMessage {
+  factory CosiCommitment({
+    $core.List<$core.int>? commitment,
+    $core.List<$core.int>? pubkey,
+  }) {
+    final $result = create();
+    if (commitment != null) {
+      $result.commitment = commitment;
+    }
+    if (pubkey != null) {
+      $result.pubkey = pubkey;
+    }
+    return $result;
+  }
+  CosiCommitment._() : super();
+  factory CosiCommitment.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CosiCommitment.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CosiCommitment', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.crypto'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'commitment', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'pubkey', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CosiCommitment clone() => CosiCommitment()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CosiCommitment copyWith(void Function(CosiCommitment) updates) => super.copyWith((message) => updates(message as CosiCommitment)) as CosiCommitment;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CosiCommitment create() => CosiCommitment._();
+  CosiCommitment createEmptyInstance() => create();
+  static $pb.PbList<CosiCommitment> createRepeated() => $pb.PbList<CosiCommitment>();
+  @$core.pragma('dart2js:noInline')
+  static CosiCommitment getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CosiCommitment>(create);
+  static CosiCommitment? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get commitment => $_getN(0);
+  @$pb.TagNumber(1)
+  set commitment($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasCommitment() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCommitment() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get pubkey => $_getN(1);
+  @$pb.TagNumber(2)
+  set pubkey($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPubkey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPubkey() => clearField(2);
+}
+
+/// *
+///  Request: Ask device to sign using CoSi
+///  @start
+///  @next CosiSignature
+///  @next Failure
+class CosiSign extends $pb.GeneratedMessage {
+  factory CosiSign({
+    $core.Iterable<$core.int>? addressN,
+    $core.List<$core.int>? data,
+    $core.List<$core.int>? globalCommitment,
+    $core.List<$core.int>? globalPubkey,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (data != null) {
+      $result.data = data;
+    }
+    if (globalCommitment != null) {
+      $result.globalCommitment = globalCommitment;
+    }
+    if (globalPubkey != null) {
+      $result.globalPubkey = globalPubkey;
+    }
+    return $result;
+  }
+  CosiSign._() : super();
+  factory CosiSign.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CosiSign.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CosiSign', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.crypto'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'data', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'globalCommitment', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'globalPubkey', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CosiSign clone() => CosiSign()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CosiSign copyWith(void Function(CosiSign) updates) => super.copyWith((message) => updates(message as CosiSign)) as CosiSign;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CosiSign create() => CosiSign._();
+  CosiSign createEmptyInstance() => create();
+  static $pb.PbList<CosiSign> createRepeated() => $pb.PbList<CosiSign>();
+  @$core.pragma('dart2js:noInline')
+  static CosiSign getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CosiSign>(create);
+  static CosiSign? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get data => $_getN(1);
+  @$pb.TagNumber(2)
+  set data($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasData() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearData() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get globalCommitment => $_getN(2);
+  @$pb.TagNumber(3)
+  set globalCommitment($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasGlobalCommitment() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearGlobalCommitment() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get globalPubkey => $_getN(3);
+  @$pb.TagNumber(4)
+  set globalPubkey($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasGlobalPubkey() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearGlobalPubkey() => clearField(4);
+}
+
+/// *
+///  Response: Contains a CoSi signature
+///  @end
+class CosiSignature extends $pb.GeneratedMessage {
+  factory CosiSignature({
+    $core.List<$core.int>? signature,
+  }) {
+    final $result = create();
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    return $result;
+  }
+  CosiSignature._() : super();
+  factory CosiSignature.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CosiSignature.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CosiSignature', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.crypto'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CosiSignature clone() => CosiSignature()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CosiSignature copyWith(void Function(CosiSignature) updates) => super.copyWith((message) => updates(message as CosiSignature)) as CosiSignature;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CosiSignature create() => CosiSignature._();
+  CosiSignature createEmptyInstance() => create();
+  static $pb.PbList<CosiSignature> createRepeated() => $pb.PbList<CosiSignature>();
+  @$core.pragma('dart2js:noInline')
+  static CosiSignature getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CosiSignature>(create);
+  static CosiSignature? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get signature => $_getN(0);
+  @$pb.TagNumber(1)
+  set signature($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSignature() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSignature() => clearField(1);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-crypto.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-crypto.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-crypto.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-crypto.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-crypto.pbjson.dart
@@ -1,0 +1,195 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-crypto.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use cipherKeyValueDescriptor instead')
+const CipherKeyValue$json = {
+  '1': 'CipherKeyValue',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'key', '3': 2, '4': 2, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 3, '4': 2, '5': 12, '10': 'value'},
+    {'1': 'encrypt', '3': 4, '4': 1, '5': 8, '10': 'encrypt'},
+    {'1': 'ask_on_encrypt', '3': 5, '4': 1, '5': 8, '10': 'askOnEncrypt'},
+    {'1': 'ask_on_decrypt', '3': 6, '4': 1, '5': 8, '10': 'askOnDecrypt'},
+    {'1': 'iv', '3': 7, '4': 1, '5': 12, '10': 'iv'},
+  ],
+};
+
+/// Descriptor for `CipherKeyValue`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cipherKeyValueDescriptor = $convert.base64Decode(
+    'Cg5DaXBoZXJLZXlWYWx1ZRIbCglhZGRyZXNzX24YASADKA1SCGFkZHJlc3NOEhAKA2tleRgCIA'
+    'IoCVIDa2V5EhQKBXZhbHVlGAMgAigMUgV2YWx1ZRIYCgdlbmNyeXB0GAQgASgIUgdlbmNyeXB0'
+    'EiQKDmFza19vbl9lbmNyeXB0GAUgASgIUgxhc2tPbkVuY3J5cHQSJAoOYXNrX29uX2RlY3J5cH'
+    'QYBiABKAhSDGFza09uRGVjcnlwdBIOCgJpdhgHIAEoDFICaXY=');
+
+@$core.Deprecated('Use cipheredKeyValueDescriptor instead')
+const CipheredKeyValue$json = {
+  '1': 'CipheredKeyValue',
+  '2': [
+    {'1': 'value', '3': 1, '4': 2, '5': 12, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `CipheredKeyValue`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cipheredKeyValueDescriptor = $convert.base64Decode(
+    'ChBDaXBoZXJlZEtleVZhbHVlEhQKBXZhbHVlGAEgAigMUgV2YWx1ZQ==');
+
+@$core.Deprecated('Use identityTypeDescriptor instead')
+const IdentityType$json = {
+  '1': 'IdentityType',
+  '2': [
+    {'1': 'proto', '3': 1, '4': 1, '5': 9, '10': 'proto'},
+    {'1': 'user', '3': 2, '4': 1, '5': 9, '10': 'user'},
+    {'1': 'host', '3': 3, '4': 1, '5': 9, '10': 'host'},
+    {'1': 'port', '3': 4, '4': 1, '5': 9, '10': 'port'},
+    {'1': 'path', '3': 5, '4': 1, '5': 9, '10': 'path'},
+    {'1': 'index', '3': 6, '4': 1, '5': 13, '7': '0', '10': 'index'},
+  ],
+};
+
+/// Descriptor for `IdentityType`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List identityTypeDescriptor = $convert.base64Decode(
+    'CgxJZGVudGl0eVR5cGUSFAoFcHJvdG8YASABKAlSBXByb3RvEhIKBHVzZXIYAiABKAlSBHVzZX'
+    'ISEgoEaG9zdBgDIAEoCVIEaG9zdBISCgRwb3J0GAQgASgJUgRwb3J0EhIKBHBhdGgYBSABKAlS'
+    'BHBhdGgSFwoFaW5kZXgYBiABKA06ATBSBWluZGV4');
+
+@$core.Deprecated('Use signIdentityDescriptor instead')
+const SignIdentity$json = {
+  '1': 'SignIdentity',
+  '2': [
+    {'1': 'identity', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.crypto.IdentityType', '10': 'identity'},
+    {'1': 'challenge_hidden', '3': 2, '4': 1, '5': 12, '7': '', '10': 'challengeHidden'},
+    {'1': 'challenge_visual', '3': 3, '4': 1, '5': 9, '7': '', '10': 'challengeVisual'},
+    {'1': 'ecdsa_curve_name', '3': 4, '4': 1, '5': 9, '10': 'ecdsaCurveName'},
+  ],
+};
+
+/// Descriptor for `SignIdentity`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List signIdentityDescriptor = $convert.base64Decode(
+    'CgxTaWduSWRlbnRpdHkSQwoIaWRlbnRpdHkYASACKAsyJy5ody50cmV6b3IubWVzc2FnZXMuY3'
+    'J5cHRvLklkZW50aXR5VHlwZVIIaWRlbnRpdHkSKwoQY2hhbGxlbmdlX2hpZGRlbhgCIAEoDDoA'
+    'Ug9jaGFsbGVuZ2VIaWRkZW4SKwoQY2hhbGxlbmdlX3Zpc3VhbBgDIAEoCToAUg9jaGFsbGVuZ2'
+    'VWaXN1YWwSKAoQZWNkc2FfY3VydmVfbmFtZRgEIAEoCVIOZWNkc2FDdXJ2ZU5hbWU=');
+
+@$core.Deprecated('Use signedIdentityDescriptor instead')
+const SignedIdentity$json = {
+  '1': 'SignedIdentity',
+  '2': [
+    {'1': 'address', '3': 1, '4': 1, '5': 9, '10': 'address'},
+    {'1': 'public_key', '3': 2, '4': 2, '5': 12, '10': 'publicKey'},
+    {'1': 'signature', '3': 3, '4': 2, '5': 12, '10': 'signature'},
+  ],
+};
+
+/// Descriptor for `SignedIdentity`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List signedIdentityDescriptor = $convert.base64Decode(
+    'Cg5TaWduZWRJZGVudGl0eRIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh0KCnB1YmxpY19rZX'
+    'kYAiACKAxSCXB1YmxpY0tleRIcCglzaWduYXR1cmUYAyACKAxSCXNpZ25hdHVyZQ==');
+
+@$core.Deprecated('Use getECDHSessionKeyDescriptor instead')
+const GetECDHSessionKey$json = {
+  '1': 'GetECDHSessionKey',
+  '2': [
+    {'1': 'identity', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.crypto.IdentityType', '10': 'identity'},
+    {'1': 'peer_public_key', '3': 2, '4': 2, '5': 12, '10': 'peerPublicKey'},
+    {'1': 'ecdsa_curve_name', '3': 3, '4': 1, '5': 9, '10': 'ecdsaCurveName'},
+  ],
+};
+
+/// Descriptor for `GetECDHSessionKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getECDHSessionKeyDescriptor = $convert.base64Decode(
+    'ChFHZXRFQ0RIU2Vzc2lvbktleRJDCghpZGVudGl0eRgBIAIoCzInLmh3LnRyZXpvci5tZXNzYW'
+    'dlcy5jcnlwdG8uSWRlbnRpdHlUeXBlUghpZGVudGl0eRImCg9wZWVyX3B1YmxpY19rZXkYAiAC'
+    'KAxSDXBlZXJQdWJsaWNLZXkSKAoQZWNkc2FfY3VydmVfbmFtZRgDIAEoCVIOZWNkc2FDdXJ2ZU'
+    '5hbWU=');
+
+@$core.Deprecated('Use eCDHSessionKeyDescriptor instead')
+const ECDHSessionKey$json = {
+  '1': 'ECDHSessionKey',
+  '2': [
+    {'1': 'session_key', '3': 1, '4': 2, '5': 12, '10': 'sessionKey'},
+    {'1': 'public_key', '3': 2, '4': 1, '5': 12, '10': 'publicKey'},
+  ],
+};
+
+/// Descriptor for `ECDHSessionKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List eCDHSessionKeyDescriptor = $convert.base64Decode(
+    'Cg5FQ0RIU2Vzc2lvbktleRIfCgtzZXNzaW9uX2tleRgBIAIoDFIKc2Vzc2lvbktleRIdCgpwdW'
+    'JsaWNfa2V5GAIgASgMUglwdWJsaWNLZXk=');
+
+@$core.Deprecated('Use cosiCommitDescriptor instead')
+const CosiCommit$json = {
+  '1': 'CosiCommit',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {
+      '1': 'data',
+      '3': 2,
+      '4': 1,
+      '5': 12,
+      '8': {'3': true},
+      '10': 'data',
+    },
+  ],
+};
+
+/// Descriptor for `CosiCommit`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cosiCommitDescriptor = $convert.base64Decode(
+    'CgpDb3NpQ29tbWl0EhsKCWFkZHJlc3NfbhgBIAMoDVIIYWRkcmVzc04SFgoEZGF0YRgCIAEoDE'
+    'ICGAFSBGRhdGE=');
+
+@$core.Deprecated('Use cosiCommitmentDescriptor instead')
+const CosiCommitment$json = {
+  '1': 'CosiCommitment',
+  '2': [
+    {'1': 'commitment', '3': 1, '4': 2, '5': 12, '10': 'commitment'},
+    {'1': 'pubkey', '3': 2, '4': 2, '5': 12, '10': 'pubkey'},
+  ],
+};
+
+/// Descriptor for `CosiCommitment`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cosiCommitmentDescriptor = $convert.base64Decode(
+    'Cg5Db3NpQ29tbWl0bWVudBIeCgpjb21taXRtZW50GAEgAigMUgpjb21taXRtZW50EhYKBnB1Ym'
+    'tleRgCIAIoDFIGcHVia2V5');
+
+@$core.Deprecated('Use cosiSignDescriptor instead')
+const CosiSign$json = {
+  '1': 'CosiSign',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'data', '3': 2, '4': 2, '5': 12, '10': 'data'},
+    {'1': 'global_commitment', '3': 3, '4': 2, '5': 12, '10': 'globalCommitment'},
+    {'1': 'global_pubkey', '3': 4, '4': 2, '5': 12, '10': 'globalPubkey'},
+  ],
+};
+
+/// Descriptor for `CosiSign`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cosiSignDescriptor = $convert.base64Decode(
+    'CghDb3NpU2lnbhIbCglhZGRyZXNzX24YASADKA1SCGFkZHJlc3NOEhIKBGRhdGEYAiACKAxSBG'
+    'RhdGESKwoRZ2xvYmFsX2NvbW1pdG1lbnQYAyACKAxSEGdsb2JhbENvbW1pdG1lbnQSIwoNZ2xv'
+    'YmFsX3B1YmtleRgEIAIoDFIMZ2xvYmFsUHVia2V5');
+
+@$core.Deprecated('Use cosiSignatureDescriptor instead')
+const CosiSignature$json = {
+  '1': 'CosiSignature',
+  '2': [
+    {'1': 'signature', '3': 1, '4': 2, '5': 12, '10': 'signature'},
+  ],
+};
+
+/// Descriptor for `CosiSignature`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cosiSignatureDescriptor = $convert.base64Decode(
+    'Cg1Db3NpU2lnbmF0dXJlEhwKCXNpZ25hdHVyZRgBIAIoDFIJc2lnbmF0dXJl');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-crypto.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-crypto.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-crypto.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-crypto.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-debug.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-debug.pb.dart
@@ -1,0 +1,1165 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-debug.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'messages-common.pb.dart' as $0;
+import 'messages-debug.pbenum.dart';
+import 'messages-management.pbenum.dart' as $1;
+
+export 'messages-debug.pbenum.dart';
+
+/// *
+///  Request: "Press" the button on the device
+///  @start
+///  @next DebugLinkLayout
+class DebugLinkDecision extends $pb.GeneratedMessage {
+  factory DebugLinkDecision({
+    DebugLinkDecision_DebugButton? button,
+    DebugLinkDecision_DebugSwipeDirection? swipe,
+    $core.String? input,
+    $core.int? x,
+    $core.int? y,
+    $core.bool? wait,
+    $core.int? holdMs,
+    DebugLinkDecision_DebugPhysicalButton? physicalButton,
+  }) {
+    final $result = create();
+    if (button != null) {
+      $result.button = button;
+    }
+    if (swipe != null) {
+      $result.swipe = swipe;
+    }
+    if (input != null) {
+      $result.input = input;
+    }
+    if (x != null) {
+      $result.x = x;
+    }
+    if (y != null) {
+      $result.y = y;
+    }
+    if (wait != null) {
+      $result.wait = wait;
+    }
+    if (holdMs != null) {
+      $result.holdMs = holdMs;
+    }
+    if (physicalButton != null) {
+      $result.physicalButton = physicalButton;
+    }
+    return $result;
+  }
+  DebugLinkDecision._() : super();
+  factory DebugLinkDecision.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugLinkDecision.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugLinkDecision', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.debug'), createEmptyInstance: create)
+    ..e<DebugLinkDecision_DebugButton>(1, _omitFieldNames ? '' : 'button', $pb.PbFieldType.OE, defaultOrMaker: DebugLinkDecision_DebugButton.NO, valueOf: DebugLinkDecision_DebugButton.valueOf, enumValues: DebugLinkDecision_DebugButton.values)
+    ..e<DebugLinkDecision_DebugSwipeDirection>(2, _omitFieldNames ? '' : 'swipe', $pb.PbFieldType.OE, defaultOrMaker: DebugLinkDecision_DebugSwipeDirection.UP, valueOf: DebugLinkDecision_DebugSwipeDirection.valueOf, enumValues: DebugLinkDecision_DebugSwipeDirection.values)
+    ..aOS(3, _omitFieldNames ? '' : 'input')
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'x', $pb.PbFieldType.OU3)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'y', $pb.PbFieldType.OU3)
+    ..aOB(6, _omitFieldNames ? '' : 'wait')
+    ..a<$core.int>(7, _omitFieldNames ? '' : 'holdMs', $pb.PbFieldType.OU3)
+    ..e<DebugLinkDecision_DebugPhysicalButton>(8, _omitFieldNames ? '' : 'physicalButton', $pb.PbFieldType.OE, defaultOrMaker: DebugLinkDecision_DebugPhysicalButton.LEFT_BTN, valueOf: DebugLinkDecision_DebugPhysicalButton.valueOf, enumValues: DebugLinkDecision_DebugPhysicalButton.values)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugLinkDecision clone() => DebugLinkDecision()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugLinkDecision copyWith(void Function(DebugLinkDecision) updates) => super.copyWith((message) => updates(message as DebugLinkDecision)) as DebugLinkDecision;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkDecision create() => DebugLinkDecision._();
+  DebugLinkDecision createEmptyInstance() => create();
+  static $pb.PbList<DebugLinkDecision> createRepeated() => $pb.PbList<DebugLinkDecision>();
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkDecision getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugLinkDecision>(create);
+  static DebugLinkDecision? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  DebugLinkDecision_DebugButton get button => $_getN(0);
+  @$pb.TagNumber(1)
+  set button(DebugLinkDecision_DebugButton v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasButton() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearButton() => clearField(1);
+
+  @$pb.TagNumber(2)
+  DebugLinkDecision_DebugSwipeDirection get swipe => $_getN(1);
+  @$pb.TagNumber(2)
+  set swipe(DebugLinkDecision_DebugSwipeDirection v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSwipe() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSwipe() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get input => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set input($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasInput() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearInput() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get x => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set x($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasX() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearX() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get y => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set y($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasY() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearY() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.bool get wait => $_getBF(5);
+  @$pb.TagNumber(6)
+  set wait($core.bool v) { $_setBool(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasWait() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearWait() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.int get holdMs => $_getIZ(6);
+  @$pb.TagNumber(7)
+  set holdMs($core.int v) { $_setUnsignedInt32(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasHoldMs() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearHoldMs() => clearField(7);
+
+  @$pb.TagNumber(8)
+  DebugLinkDecision_DebugPhysicalButton get physicalButton => $_getN(7);
+  @$pb.TagNumber(8)
+  set physicalButton(DebugLinkDecision_DebugPhysicalButton v) { setField(8, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasPhysicalButton() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearPhysicalButton() => clearField(8);
+}
+
+/// *
+///  Response: Device text layout as a list of tokens as returned by Rust
+///  @end
+class DebugLinkLayout extends $pb.GeneratedMessage {
+  factory DebugLinkLayout({
+    $core.Iterable<$core.String>? tokens,
+  }) {
+    final $result = create();
+    if (tokens != null) {
+      $result.tokens.addAll(tokens);
+    }
+    return $result;
+  }
+  DebugLinkLayout._() : super();
+  factory DebugLinkLayout.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugLinkLayout.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugLinkLayout', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.debug'), createEmptyInstance: create)
+    ..pPS(1, _omitFieldNames ? '' : 'tokens')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugLinkLayout clone() => DebugLinkLayout()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugLinkLayout copyWith(void Function(DebugLinkLayout) updates) => super.copyWith((message) => updates(message as DebugLinkLayout)) as DebugLinkLayout;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkLayout create() => DebugLinkLayout._();
+  DebugLinkLayout createEmptyInstance() => create();
+  static $pb.PbList<DebugLinkLayout> createRepeated() => $pb.PbList<DebugLinkLayout>();
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkLayout getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugLinkLayout>(create);
+  static DebugLinkLayout? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.String> get tokens => $_getList(0);
+}
+
+/// *
+///  Request: Re-seed RNG with given value
+///  @start
+///  @next Success
+class DebugLinkReseedRandom extends $pb.GeneratedMessage {
+  factory DebugLinkReseedRandom({
+    $core.int? value,
+  }) {
+    final $result = create();
+    if (value != null) {
+      $result.value = value;
+    }
+    return $result;
+  }
+  DebugLinkReseedRandom._() : super();
+  factory DebugLinkReseedRandom.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugLinkReseedRandom.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugLinkReseedRandom', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.debug'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugLinkReseedRandom clone() => DebugLinkReseedRandom()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugLinkReseedRandom copyWith(void Function(DebugLinkReseedRandom) updates) => super.copyWith((message) => updates(message as DebugLinkReseedRandom)) as DebugLinkReseedRandom;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkReseedRandom create() => DebugLinkReseedRandom._();
+  DebugLinkReseedRandom createEmptyInstance() => create();
+  static $pb.PbList<DebugLinkReseedRandom> createRepeated() => $pb.PbList<DebugLinkReseedRandom>();
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkReseedRandom getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugLinkReseedRandom>(create);
+  static DebugLinkReseedRandom? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get value => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set value($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasValue() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearValue() => clearField(1);
+}
+
+/// *
+///  Request: Start or stop recording screen changes into given target directory
+///  @start
+///  @next Success
+class DebugLinkRecordScreen extends $pb.GeneratedMessage {
+  factory DebugLinkRecordScreen({
+    $core.String? targetDirectory,
+    $core.int? refreshIndex,
+  }) {
+    final $result = create();
+    if (targetDirectory != null) {
+      $result.targetDirectory = targetDirectory;
+    }
+    if (refreshIndex != null) {
+      $result.refreshIndex = refreshIndex;
+    }
+    return $result;
+  }
+  DebugLinkRecordScreen._() : super();
+  factory DebugLinkRecordScreen.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugLinkRecordScreen.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugLinkRecordScreen', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.debug'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'targetDirectory')
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'refreshIndex', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugLinkRecordScreen clone() => DebugLinkRecordScreen()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugLinkRecordScreen copyWith(void Function(DebugLinkRecordScreen) updates) => super.copyWith((message) => updates(message as DebugLinkRecordScreen)) as DebugLinkRecordScreen;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkRecordScreen create() => DebugLinkRecordScreen._();
+  DebugLinkRecordScreen createEmptyInstance() => create();
+  static $pb.PbList<DebugLinkRecordScreen> createRepeated() => $pb.PbList<DebugLinkRecordScreen>();
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkRecordScreen getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugLinkRecordScreen>(create);
+  static DebugLinkRecordScreen? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get targetDirectory => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set targetDirectory($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTargetDirectory() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTargetDirectory() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get refreshIndex => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set refreshIndex($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasRefreshIndex() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearRefreshIndex() => clearField(2);
+}
+
+/// *
+///  Request: Computer asks for device state
+///  @start
+///  @next DebugLinkState
+class DebugLinkGetState extends $pb.GeneratedMessage {
+  factory DebugLinkGetState({
+    $core.bool? waitWordList,
+    $core.bool? waitWordPos,
+    $core.bool? waitLayout,
+  }) {
+    final $result = create();
+    if (waitWordList != null) {
+      $result.waitWordList = waitWordList;
+    }
+    if (waitWordPos != null) {
+      $result.waitWordPos = waitWordPos;
+    }
+    if (waitLayout != null) {
+      $result.waitLayout = waitLayout;
+    }
+    return $result;
+  }
+  DebugLinkGetState._() : super();
+  factory DebugLinkGetState.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugLinkGetState.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugLinkGetState', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.debug'), createEmptyInstance: create)
+    ..aOB(1, _omitFieldNames ? '' : 'waitWordList')
+    ..aOB(2, _omitFieldNames ? '' : 'waitWordPos')
+    ..aOB(3, _omitFieldNames ? '' : 'waitLayout')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugLinkGetState clone() => DebugLinkGetState()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugLinkGetState copyWith(void Function(DebugLinkGetState) updates) => super.copyWith((message) => updates(message as DebugLinkGetState)) as DebugLinkGetState;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkGetState create() => DebugLinkGetState._();
+  DebugLinkGetState createEmptyInstance() => create();
+  static $pb.PbList<DebugLinkGetState> createRepeated() => $pb.PbList<DebugLinkGetState>();
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkGetState getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugLinkGetState>(create);
+  static DebugLinkGetState? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.bool get waitWordList => $_getBF(0);
+  @$pb.TagNumber(1)
+  set waitWordList($core.bool v) { $_setBool(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWaitWordList() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWaitWordList() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.bool get waitWordPos => $_getBF(1);
+  @$pb.TagNumber(2)
+  set waitWordPos($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasWaitWordPos() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearWaitWordPos() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get waitLayout => $_getBF(2);
+  @$pb.TagNumber(3)
+  set waitLayout($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasWaitLayout() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearWaitLayout() => clearField(3);
+}
+
+/// *
+///  Response: Device current state
+///  @end
+class DebugLinkState extends $pb.GeneratedMessage {
+  factory DebugLinkState({
+    $core.List<$core.int>? layout,
+    $core.String? pin,
+    $core.String? matrix,
+    $core.List<$core.int>? mnemonicSecret,
+    $0.HDNodeType? node,
+    $core.bool? passphraseProtection,
+    $core.String? resetWord,
+    $core.List<$core.int>? resetEntropy,
+    $core.String? recoveryFakeWord,
+    $core.int? recoveryWordPos,
+    $core.int? resetWordPos,
+    $1.BackupType? mnemonicType,
+    $core.Iterable<$core.String>? tokens,
+  }) {
+    final $result = create();
+    if (layout != null) {
+      $result.layout = layout;
+    }
+    if (pin != null) {
+      $result.pin = pin;
+    }
+    if (matrix != null) {
+      $result.matrix = matrix;
+    }
+    if (mnemonicSecret != null) {
+      $result.mnemonicSecret = mnemonicSecret;
+    }
+    if (node != null) {
+      $result.node = node;
+    }
+    if (passphraseProtection != null) {
+      $result.passphraseProtection = passphraseProtection;
+    }
+    if (resetWord != null) {
+      $result.resetWord = resetWord;
+    }
+    if (resetEntropy != null) {
+      $result.resetEntropy = resetEntropy;
+    }
+    if (recoveryFakeWord != null) {
+      $result.recoveryFakeWord = recoveryFakeWord;
+    }
+    if (recoveryWordPos != null) {
+      $result.recoveryWordPos = recoveryWordPos;
+    }
+    if (resetWordPos != null) {
+      $result.resetWordPos = resetWordPos;
+    }
+    if (mnemonicType != null) {
+      $result.mnemonicType = mnemonicType;
+    }
+    if (tokens != null) {
+      $result.tokens.addAll(tokens);
+    }
+    return $result;
+  }
+  DebugLinkState._() : super();
+  factory DebugLinkState.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugLinkState.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugLinkState', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.debug'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'layout', $pb.PbFieldType.OY)
+    ..aOS(2, _omitFieldNames ? '' : 'pin')
+    ..aOS(3, _omitFieldNames ? '' : 'matrix')
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'mnemonicSecret', $pb.PbFieldType.OY)
+    ..aOM<$0.HDNodeType>(5, _omitFieldNames ? '' : 'node', subBuilder: $0.HDNodeType.create)
+    ..aOB(6, _omitFieldNames ? '' : 'passphraseProtection')
+    ..aOS(7, _omitFieldNames ? '' : 'resetWord')
+    ..a<$core.List<$core.int>>(8, _omitFieldNames ? '' : 'resetEntropy', $pb.PbFieldType.OY)
+    ..aOS(9, _omitFieldNames ? '' : 'recoveryFakeWord')
+    ..a<$core.int>(10, _omitFieldNames ? '' : 'recoveryWordPos', $pb.PbFieldType.OU3)
+    ..a<$core.int>(11, _omitFieldNames ? '' : 'resetWordPos', $pb.PbFieldType.OU3)
+    ..e<$1.BackupType>(12, _omitFieldNames ? '' : 'mnemonicType', $pb.PbFieldType.OE, defaultOrMaker: $1.BackupType.Bip39, valueOf: $1.BackupType.valueOf, enumValues: $1.BackupType.values)
+    ..pPS(13, _omitFieldNames ? '' : 'tokens')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugLinkState clone() => DebugLinkState()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugLinkState copyWith(void Function(DebugLinkState) updates) => super.copyWith((message) => updates(message as DebugLinkState)) as DebugLinkState;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkState create() => DebugLinkState._();
+  DebugLinkState createEmptyInstance() => create();
+  static $pb.PbList<DebugLinkState> createRepeated() => $pb.PbList<DebugLinkState>();
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkState getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugLinkState>(create);
+  static DebugLinkState? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get layout => $_getN(0);
+  @$pb.TagNumber(1)
+  set layout($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasLayout() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearLayout() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get pin => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set pin($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPin() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPin() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get matrix => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set matrix($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasMatrix() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearMatrix() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get mnemonicSecret => $_getN(3);
+  @$pb.TagNumber(4)
+  set mnemonicSecret($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasMnemonicSecret() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMnemonicSecret() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $0.HDNodeType get node => $_getN(4);
+  @$pb.TagNumber(5)
+  set node($0.HDNodeType v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasNode() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearNode() => clearField(5);
+  @$pb.TagNumber(5)
+  $0.HDNodeType ensureNode() => $_ensure(4);
+
+  @$pb.TagNumber(6)
+  $core.bool get passphraseProtection => $_getBF(5);
+  @$pb.TagNumber(6)
+  set passphraseProtection($core.bool v) { $_setBool(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasPassphraseProtection() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearPassphraseProtection() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.String get resetWord => $_getSZ(6);
+  @$pb.TagNumber(7)
+  set resetWord($core.String v) { $_setString(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasResetWord() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearResetWord() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.List<$core.int> get resetEntropy => $_getN(7);
+  @$pb.TagNumber(8)
+  set resetEntropy($core.List<$core.int> v) { $_setBytes(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasResetEntropy() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearResetEntropy() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.String get recoveryFakeWord => $_getSZ(8);
+  @$pb.TagNumber(9)
+  set recoveryFakeWord($core.String v) { $_setString(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasRecoveryFakeWord() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearRecoveryFakeWord() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.int get recoveryWordPos => $_getIZ(9);
+  @$pb.TagNumber(10)
+  set recoveryWordPos($core.int v) { $_setUnsignedInt32(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasRecoveryWordPos() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearRecoveryWordPos() => clearField(10);
+
+  @$pb.TagNumber(11)
+  $core.int get resetWordPos => $_getIZ(10);
+  @$pb.TagNumber(11)
+  set resetWordPos($core.int v) { $_setUnsignedInt32(10, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasResetWordPos() => $_has(10);
+  @$pb.TagNumber(11)
+  void clearResetWordPos() => clearField(11);
+
+  @$pb.TagNumber(12)
+  $1.BackupType get mnemonicType => $_getN(11);
+  @$pb.TagNumber(12)
+  set mnemonicType($1.BackupType v) { setField(12, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasMnemonicType() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearMnemonicType() => clearField(12);
+
+  @$pb.TagNumber(13)
+  $core.List<$core.String> get tokens => $_getList(12);
+}
+
+/// *
+///  Request: Ask device to restart
+///  @start
+class DebugLinkStop extends $pb.GeneratedMessage {
+  factory DebugLinkStop() => create();
+  DebugLinkStop._() : super();
+  factory DebugLinkStop.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugLinkStop.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugLinkStop', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.debug'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugLinkStop clone() => DebugLinkStop()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugLinkStop copyWith(void Function(DebugLinkStop) updates) => super.copyWith((message) => updates(message as DebugLinkStop)) as DebugLinkStop;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkStop create() => DebugLinkStop._();
+  DebugLinkStop createEmptyInstance() => create();
+  static $pb.PbList<DebugLinkStop> createRepeated() => $pb.PbList<DebugLinkStop>();
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkStop getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugLinkStop>(create);
+  static DebugLinkStop? _defaultInstance;
+}
+
+/// *
+///  Response: Device wants host to log event
+///  @ignore
+class DebugLinkLog extends $pb.GeneratedMessage {
+  factory DebugLinkLog({
+    $core.int? level,
+    $core.String? bucket,
+    $core.String? text,
+  }) {
+    final $result = create();
+    if (level != null) {
+      $result.level = level;
+    }
+    if (bucket != null) {
+      $result.bucket = bucket;
+    }
+    if (text != null) {
+      $result.text = text;
+    }
+    return $result;
+  }
+  DebugLinkLog._() : super();
+  factory DebugLinkLog.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugLinkLog.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugLinkLog', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.debug'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'level', $pb.PbFieldType.OU3)
+    ..aOS(2, _omitFieldNames ? '' : 'bucket')
+    ..aOS(3, _omitFieldNames ? '' : 'text')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugLinkLog clone() => DebugLinkLog()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugLinkLog copyWith(void Function(DebugLinkLog) updates) => super.copyWith((message) => updates(message as DebugLinkLog)) as DebugLinkLog;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkLog create() => DebugLinkLog._();
+  DebugLinkLog createEmptyInstance() => create();
+  static $pb.PbList<DebugLinkLog> createRepeated() => $pb.PbList<DebugLinkLog>();
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkLog getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugLinkLog>(create);
+  static DebugLinkLog? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get level => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set level($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasLevel() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearLevel() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get bucket => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set bucket($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasBucket() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearBucket() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get text => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set text($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasText() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearText() => clearField(3);
+}
+
+/// *
+///  Request: Read memory from device
+///  @start
+///  @next DebugLinkMemory
+class DebugLinkMemoryRead extends $pb.GeneratedMessage {
+  factory DebugLinkMemoryRead({
+    $core.int? address,
+    $core.int? length,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    if (length != null) {
+      $result.length = length;
+    }
+    return $result;
+  }
+  DebugLinkMemoryRead._() : super();
+  factory DebugLinkMemoryRead.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugLinkMemoryRead.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugLinkMemoryRead', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.debug'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'address', $pb.PbFieldType.OU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'length', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugLinkMemoryRead clone() => DebugLinkMemoryRead()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugLinkMemoryRead copyWith(void Function(DebugLinkMemoryRead) updates) => super.copyWith((message) => updates(message as DebugLinkMemoryRead)) as DebugLinkMemoryRead;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkMemoryRead create() => DebugLinkMemoryRead._();
+  DebugLinkMemoryRead createEmptyInstance() => create();
+  static $pb.PbList<DebugLinkMemoryRead> createRepeated() => $pb.PbList<DebugLinkMemoryRead>();
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkMemoryRead getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugLinkMemoryRead>(create);
+  static DebugLinkMemoryRead? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get address => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set address($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get length => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set length($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasLength() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearLength() => clearField(2);
+}
+
+/// *
+///  Response: Device sends memory back
+///  @end
+class DebugLinkMemory extends $pb.GeneratedMessage {
+  factory DebugLinkMemory({
+    $core.List<$core.int>? memory,
+  }) {
+    final $result = create();
+    if (memory != null) {
+      $result.memory = memory;
+    }
+    return $result;
+  }
+  DebugLinkMemory._() : super();
+  factory DebugLinkMemory.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugLinkMemory.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugLinkMemory', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.debug'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'memory', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugLinkMemory clone() => DebugLinkMemory()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugLinkMemory copyWith(void Function(DebugLinkMemory) updates) => super.copyWith((message) => updates(message as DebugLinkMemory)) as DebugLinkMemory;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkMemory create() => DebugLinkMemory._();
+  DebugLinkMemory createEmptyInstance() => create();
+  static $pb.PbList<DebugLinkMemory> createRepeated() => $pb.PbList<DebugLinkMemory>();
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkMemory getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugLinkMemory>(create);
+  static DebugLinkMemory? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get memory => $_getN(0);
+  @$pb.TagNumber(1)
+  set memory($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasMemory() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearMemory() => clearField(1);
+}
+
+/// *
+///  Request: Write memory to device.
+///  WARNING: Writing to the wrong location can irreparably break the device.
+///  @start
+///  @next Success
+///  @next Failure
+class DebugLinkMemoryWrite extends $pb.GeneratedMessage {
+  factory DebugLinkMemoryWrite({
+    $core.int? address,
+    $core.List<$core.int>? memory,
+    $core.bool? flash,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    if (memory != null) {
+      $result.memory = memory;
+    }
+    if (flash != null) {
+      $result.flash = flash;
+    }
+    return $result;
+  }
+  DebugLinkMemoryWrite._() : super();
+  factory DebugLinkMemoryWrite.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugLinkMemoryWrite.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugLinkMemoryWrite', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.debug'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'address', $pb.PbFieldType.OU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'memory', $pb.PbFieldType.OY)
+    ..aOB(3, _omitFieldNames ? '' : 'flash')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugLinkMemoryWrite clone() => DebugLinkMemoryWrite()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugLinkMemoryWrite copyWith(void Function(DebugLinkMemoryWrite) updates) => super.copyWith((message) => updates(message as DebugLinkMemoryWrite)) as DebugLinkMemoryWrite;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkMemoryWrite create() => DebugLinkMemoryWrite._();
+  DebugLinkMemoryWrite createEmptyInstance() => create();
+  static $pb.PbList<DebugLinkMemoryWrite> createRepeated() => $pb.PbList<DebugLinkMemoryWrite>();
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkMemoryWrite getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugLinkMemoryWrite>(create);
+  static DebugLinkMemoryWrite? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get address => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set address($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get memory => $_getN(1);
+  @$pb.TagNumber(2)
+  set memory($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMemory() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMemory() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get flash => $_getBF(2);
+  @$pb.TagNumber(3)
+  set flash($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasFlash() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearFlash() => clearField(3);
+}
+
+/// *
+///  Request: Erase block of flash on device
+///  WARNING: Writing to the wrong location can irreparably break the device.
+///  @start
+///  @next Success
+///  @next Failure
+class DebugLinkFlashErase extends $pb.GeneratedMessage {
+  factory DebugLinkFlashErase({
+    $core.int? sector,
+  }) {
+    final $result = create();
+    if (sector != null) {
+      $result.sector = sector;
+    }
+    return $result;
+  }
+  DebugLinkFlashErase._() : super();
+  factory DebugLinkFlashErase.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugLinkFlashErase.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugLinkFlashErase', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.debug'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'sector', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugLinkFlashErase clone() => DebugLinkFlashErase()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugLinkFlashErase copyWith(void Function(DebugLinkFlashErase) updates) => super.copyWith((message) => updates(message as DebugLinkFlashErase)) as DebugLinkFlashErase;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkFlashErase create() => DebugLinkFlashErase._();
+  DebugLinkFlashErase createEmptyInstance() => create();
+  static $pb.PbList<DebugLinkFlashErase> createRepeated() => $pb.PbList<DebugLinkFlashErase>();
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkFlashErase getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugLinkFlashErase>(create);
+  static DebugLinkFlashErase? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get sector => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set sector($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSector() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSector() => clearField(1);
+}
+
+/// *
+///  Request: Erase the SD card
+///  @start
+///  @next Success
+///  @next Failure
+class DebugLinkEraseSdCard extends $pb.GeneratedMessage {
+  factory DebugLinkEraseSdCard({
+    $core.bool? format,
+  }) {
+    final $result = create();
+    if (format != null) {
+      $result.format = format;
+    }
+    return $result;
+  }
+  DebugLinkEraseSdCard._() : super();
+  factory DebugLinkEraseSdCard.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugLinkEraseSdCard.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugLinkEraseSdCard', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.debug'), createEmptyInstance: create)
+    ..aOB(1, _omitFieldNames ? '' : 'format')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugLinkEraseSdCard clone() => DebugLinkEraseSdCard()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugLinkEraseSdCard copyWith(void Function(DebugLinkEraseSdCard) updates) => super.copyWith((message) => updates(message as DebugLinkEraseSdCard)) as DebugLinkEraseSdCard;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkEraseSdCard create() => DebugLinkEraseSdCard._();
+  DebugLinkEraseSdCard createEmptyInstance() => create();
+  static $pb.PbList<DebugLinkEraseSdCard> createRepeated() => $pb.PbList<DebugLinkEraseSdCard>();
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkEraseSdCard getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugLinkEraseSdCard>(create);
+  static DebugLinkEraseSdCard? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.bool get format => $_getBF(0);
+  @$pb.TagNumber(1)
+  set format($core.bool v) { $_setBool(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasFormat() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearFormat() => clearField(1);
+}
+
+/// *
+///  Request: Start or stop tracking layout changes
+///  @start
+///  @next Success
+class DebugLinkWatchLayout extends $pb.GeneratedMessage {
+  factory DebugLinkWatchLayout({
+    $core.bool? watch,
+  }) {
+    final $result = create();
+    if (watch != null) {
+      $result.watch = watch;
+    }
+    return $result;
+  }
+  DebugLinkWatchLayout._() : super();
+  factory DebugLinkWatchLayout.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugLinkWatchLayout.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugLinkWatchLayout', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.debug'), createEmptyInstance: create)
+    ..aOB(1, _omitFieldNames ? '' : 'watch')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugLinkWatchLayout clone() => DebugLinkWatchLayout()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugLinkWatchLayout copyWith(void Function(DebugLinkWatchLayout) updates) => super.copyWith((message) => updates(message as DebugLinkWatchLayout)) as DebugLinkWatchLayout;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkWatchLayout create() => DebugLinkWatchLayout._();
+  DebugLinkWatchLayout createEmptyInstance() => create();
+  static $pb.PbList<DebugLinkWatchLayout> createRepeated() => $pb.PbList<DebugLinkWatchLayout>();
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkWatchLayout getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugLinkWatchLayout>(create);
+  static DebugLinkWatchLayout? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.bool get watch => $_getBF(0);
+  @$pb.TagNumber(1)
+  set watch($core.bool v) { $_setBool(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWatch() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWatch() => clearField(1);
+}
+
+/// *
+///  Request: Remove all the previous debug event state
+///  @start
+///  @next Success
+class DebugLinkResetDebugEvents extends $pb.GeneratedMessage {
+  factory DebugLinkResetDebugEvents() => create();
+  DebugLinkResetDebugEvents._() : super();
+  factory DebugLinkResetDebugEvents.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugLinkResetDebugEvents.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugLinkResetDebugEvents', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.debug'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugLinkResetDebugEvents clone() => DebugLinkResetDebugEvents()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugLinkResetDebugEvents copyWith(void Function(DebugLinkResetDebugEvents) updates) => super.copyWith((message) => updates(message as DebugLinkResetDebugEvents)) as DebugLinkResetDebugEvents;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkResetDebugEvents create() => DebugLinkResetDebugEvents._();
+  DebugLinkResetDebugEvents createEmptyInstance() => create();
+  static $pb.PbList<DebugLinkResetDebugEvents> createRepeated() => $pb.PbList<DebugLinkResetDebugEvents>();
+  @$core.pragma('dart2js:noInline')
+  static DebugLinkResetDebugEvents getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugLinkResetDebugEvents>(create);
+  static DebugLinkResetDebugEvents? _defaultInstance;
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-debug.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-debug.pbenum.dart
@@ -1,0 +1,75 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-debug.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+/// *
+///  Structure representing swipe direction
+class DebugLinkDecision_DebugSwipeDirection extends $pb.ProtobufEnum {
+  static const DebugLinkDecision_DebugSwipeDirection UP = DebugLinkDecision_DebugSwipeDirection._(0, _omitEnumNames ? '' : 'UP');
+  static const DebugLinkDecision_DebugSwipeDirection DOWN = DebugLinkDecision_DebugSwipeDirection._(1, _omitEnumNames ? '' : 'DOWN');
+  static const DebugLinkDecision_DebugSwipeDirection LEFT = DebugLinkDecision_DebugSwipeDirection._(2, _omitEnumNames ? '' : 'LEFT');
+  static const DebugLinkDecision_DebugSwipeDirection RIGHT = DebugLinkDecision_DebugSwipeDirection._(3, _omitEnumNames ? '' : 'RIGHT');
+
+  static const $core.List<DebugLinkDecision_DebugSwipeDirection> values = <DebugLinkDecision_DebugSwipeDirection> [
+    UP,
+    DOWN,
+    LEFT,
+    RIGHT,
+  ];
+
+  static final $core.Map<$core.int, DebugLinkDecision_DebugSwipeDirection> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static DebugLinkDecision_DebugSwipeDirection? valueOf($core.int value) => _byValue[value];
+
+  const DebugLinkDecision_DebugSwipeDirection._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Structure representing button presses
+class DebugLinkDecision_DebugButton extends $pb.ProtobufEnum {
+  static const DebugLinkDecision_DebugButton NO = DebugLinkDecision_DebugButton._(0, _omitEnumNames ? '' : 'NO');
+  static const DebugLinkDecision_DebugButton YES = DebugLinkDecision_DebugButton._(1, _omitEnumNames ? '' : 'YES');
+  static const DebugLinkDecision_DebugButton INFO = DebugLinkDecision_DebugButton._(2, _omitEnumNames ? '' : 'INFO');
+
+  static const $core.List<DebugLinkDecision_DebugButton> values = <DebugLinkDecision_DebugButton> [
+    NO,
+    YES,
+    INFO,
+  ];
+
+  static final $core.Map<$core.int, DebugLinkDecision_DebugButton> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static DebugLinkDecision_DebugButton? valueOf($core.int value) => _byValue[value];
+
+  const DebugLinkDecision_DebugButton._($core.int v, $core.String n) : super(v, n);
+}
+
+/// TODO: probably delete the middle_btn as it is not a physical one
+class DebugLinkDecision_DebugPhysicalButton extends $pb.ProtobufEnum {
+  static const DebugLinkDecision_DebugPhysicalButton LEFT_BTN = DebugLinkDecision_DebugPhysicalButton._(0, _omitEnumNames ? '' : 'LEFT_BTN');
+  static const DebugLinkDecision_DebugPhysicalButton MIDDLE_BTN = DebugLinkDecision_DebugPhysicalButton._(1, _omitEnumNames ? '' : 'MIDDLE_BTN');
+  static const DebugLinkDecision_DebugPhysicalButton RIGHT_BTN = DebugLinkDecision_DebugPhysicalButton._(2, _omitEnumNames ? '' : 'RIGHT_BTN');
+
+  static const $core.List<DebugLinkDecision_DebugPhysicalButton> values = <DebugLinkDecision_DebugPhysicalButton> [
+    LEFT_BTN,
+    MIDDLE_BTN,
+    RIGHT_BTN,
+  ];
+
+  static final $core.Map<$core.int, DebugLinkDecision_DebugPhysicalButton> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static DebugLinkDecision_DebugPhysicalButton? valueOf($core.int value) => _byValue[value];
+
+  const DebugLinkDecision_DebugPhysicalButton._($core.int v, $core.String n) : super(v, n);
+}
+
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-debug.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-debug.pbjson.dart
@@ -1,0 +1,273 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-debug.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use debugLinkDecisionDescriptor instead')
+const DebugLinkDecision$json = {
+  '1': 'DebugLinkDecision',
+  '2': [
+    {'1': 'button', '3': 1, '4': 1, '5': 14, '6': '.hw.trezor.messages.debug.DebugLinkDecision.DebugButton', '10': 'button'},
+    {'1': 'swipe', '3': 2, '4': 1, '5': 14, '6': '.hw.trezor.messages.debug.DebugLinkDecision.DebugSwipeDirection', '10': 'swipe'},
+    {'1': 'input', '3': 3, '4': 1, '5': 9, '10': 'input'},
+    {'1': 'x', '3': 4, '4': 1, '5': 13, '10': 'x'},
+    {'1': 'y', '3': 5, '4': 1, '5': 13, '10': 'y'},
+    {'1': 'wait', '3': 6, '4': 1, '5': 8, '10': 'wait'},
+    {'1': 'hold_ms', '3': 7, '4': 1, '5': 13, '10': 'holdMs'},
+    {'1': 'physical_button', '3': 8, '4': 1, '5': 14, '6': '.hw.trezor.messages.debug.DebugLinkDecision.DebugPhysicalButton', '10': 'physicalButton'},
+  ],
+  '4': [DebugLinkDecision_DebugSwipeDirection$json, DebugLinkDecision_DebugButton$json, DebugLinkDecision_DebugPhysicalButton$json],
+};
+
+@$core.Deprecated('Use debugLinkDecisionDescriptor instead')
+const DebugLinkDecision_DebugSwipeDirection$json = {
+  '1': 'DebugSwipeDirection',
+  '2': [
+    {'1': 'UP', '2': 0},
+    {'1': 'DOWN', '2': 1},
+    {'1': 'LEFT', '2': 2},
+    {'1': 'RIGHT', '2': 3},
+  ],
+};
+
+@$core.Deprecated('Use debugLinkDecisionDescriptor instead')
+const DebugLinkDecision_DebugButton$json = {
+  '1': 'DebugButton',
+  '2': [
+    {'1': 'NO', '2': 0},
+    {'1': 'YES', '2': 1},
+    {'1': 'INFO', '2': 2},
+  ],
+};
+
+@$core.Deprecated('Use debugLinkDecisionDescriptor instead')
+const DebugLinkDecision_DebugPhysicalButton$json = {
+  '1': 'DebugPhysicalButton',
+  '2': [
+    {'1': 'LEFT_BTN', '2': 0},
+    {'1': 'MIDDLE_BTN', '2': 1},
+    {'1': 'RIGHT_BTN', '2': 2},
+  ],
+};
+
+/// Descriptor for `DebugLinkDecision`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugLinkDecisionDescriptor = $convert.base64Decode(
+    'ChFEZWJ1Z0xpbmtEZWNpc2lvbhJPCgZidXR0b24YASABKA4yNy5ody50cmV6b3IubWVzc2FnZX'
+    'MuZGVidWcuRGVidWdMaW5rRGVjaXNpb24uRGVidWdCdXR0b25SBmJ1dHRvbhJVCgVzd2lwZRgC'
+    'IAEoDjI/Lmh3LnRyZXpvci5tZXNzYWdlcy5kZWJ1Zy5EZWJ1Z0xpbmtEZWNpc2lvbi5EZWJ1Z1'
+    'N3aXBlRGlyZWN0aW9uUgVzd2lwZRIUCgVpbnB1dBgDIAEoCVIFaW5wdXQSDAoBeBgEIAEoDVIB'
+    'eBIMCgF5GAUgASgNUgF5EhIKBHdhaXQYBiABKAhSBHdhaXQSFwoHaG9sZF9tcxgHIAEoDVIGaG'
+    '9sZE1zEmgKD3BoeXNpY2FsX2J1dHRvbhgIIAEoDjI/Lmh3LnRyZXpvci5tZXNzYWdlcy5kZWJ1'
+    'Zy5EZWJ1Z0xpbmtEZWNpc2lvbi5EZWJ1Z1BoeXNpY2FsQnV0dG9uUg5waHlzaWNhbEJ1dHRvbi'
+    'I8ChNEZWJ1Z1N3aXBlRGlyZWN0aW9uEgYKAlVQEAASCAoERE9XThABEggKBExFRlQQAhIJCgVS'
+    'SUdIVBADIigKC0RlYnVnQnV0dG9uEgYKAk5PEAASBwoDWUVTEAESCAoESU5GTxACIkIKE0RlYn'
+    'VnUGh5c2ljYWxCdXR0b24SDAoITEVGVF9CVE4QABIOCgpNSURETEVfQlROEAESDQoJUklHSFRf'
+    'QlROEAI=');
+
+@$core.Deprecated('Use debugLinkLayoutDescriptor instead')
+const DebugLinkLayout$json = {
+  '1': 'DebugLinkLayout',
+  '2': [
+    {'1': 'tokens', '3': 1, '4': 3, '5': 9, '10': 'tokens'},
+  ],
+};
+
+/// Descriptor for `DebugLinkLayout`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugLinkLayoutDescriptor = $convert.base64Decode(
+    'Cg9EZWJ1Z0xpbmtMYXlvdXQSFgoGdG9rZW5zGAEgAygJUgZ0b2tlbnM=');
+
+@$core.Deprecated('Use debugLinkReseedRandomDescriptor instead')
+const DebugLinkReseedRandom$json = {
+  '1': 'DebugLinkReseedRandom',
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 13, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `DebugLinkReseedRandom`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugLinkReseedRandomDescriptor = $convert.base64Decode(
+    'ChVEZWJ1Z0xpbmtSZXNlZWRSYW5kb20SFAoFdmFsdWUYASABKA1SBXZhbHVl');
+
+@$core.Deprecated('Use debugLinkRecordScreenDescriptor instead')
+const DebugLinkRecordScreen$json = {
+  '1': 'DebugLinkRecordScreen',
+  '2': [
+    {'1': 'target_directory', '3': 1, '4': 1, '5': 9, '10': 'targetDirectory'},
+    {'1': 'refresh_index', '3': 2, '4': 1, '5': 13, '7': '0', '10': 'refreshIndex'},
+  ],
+};
+
+/// Descriptor for `DebugLinkRecordScreen`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugLinkRecordScreenDescriptor = $convert.base64Decode(
+    'ChVEZWJ1Z0xpbmtSZWNvcmRTY3JlZW4SKQoQdGFyZ2V0X2RpcmVjdG9yeRgBIAEoCVIPdGFyZ2'
+    'V0RGlyZWN0b3J5EiYKDXJlZnJlc2hfaW5kZXgYAiABKA06ATBSDHJlZnJlc2hJbmRleA==');
+
+@$core.Deprecated('Use debugLinkGetStateDescriptor instead')
+const DebugLinkGetState$json = {
+  '1': 'DebugLinkGetState',
+  '2': [
+    {'1': 'wait_word_list', '3': 1, '4': 1, '5': 8, '10': 'waitWordList'},
+    {'1': 'wait_word_pos', '3': 2, '4': 1, '5': 8, '10': 'waitWordPos'},
+    {'1': 'wait_layout', '3': 3, '4': 1, '5': 8, '10': 'waitLayout'},
+  ],
+};
+
+/// Descriptor for `DebugLinkGetState`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugLinkGetStateDescriptor = $convert.base64Decode(
+    'ChFEZWJ1Z0xpbmtHZXRTdGF0ZRIkCg53YWl0X3dvcmRfbGlzdBgBIAEoCFIMd2FpdFdvcmRMaX'
+    'N0EiIKDXdhaXRfd29yZF9wb3MYAiABKAhSC3dhaXRXb3JkUG9zEh8KC3dhaXRfbGF5b3V0GAMg'
+    'ASgIUgp3YWl0TGF5b3V0');
+
+@$core.Deprecated('Use debugLinkStateDescriptor instead')
+const DebugLinkState$json = {
+  '1': 'DebugLinkState',
+  '2': [
+    {'1': 'layout', '3': 1, '4': 1, '5': 12, '10': 'layout'},
+    {'1': 'pin', '3': 2, '4': 1, '5': 9, '10': 'pin'},
+    {'1': 'matrix', '3': 3, '4': 1, '5': 9, '10': 'matrix'},
+    {'1': 'mnemonic_secret', '3': 4, '4': 1, '5': 12, '10': 'mnemonicSecret'},
+    {'1': 'node', '3': 5, '4': 1, '5': 11, '6': '.hw.trezor.messages.common.HDNodeType', '10': 'node'},
+    {'1': 'passphrase_protection', '3': 6, '4': 1, '5': 8, '10': 'passphraseProtection'},
+    {'1': 'reset_word', '3': 7, '4': 1, '5': 9, '10': 'resetWord'},
+    {'1': 'reset_entropy', '3': 8, '4': 1, '5': 12, '10': 'resetEntropy'},
+    {'1': 'recovery_fake_word', '3': 9, '4': 1, '5': 9, '10': 'recoveryFakeWord'},
+    {'1': 'recovery_word_pos', '3': 10, '4': 1, '5': 13, '10': 'recoveryWordPos'},
+    {'1': 'reset_word_pos', '3': 11, '4': 1, '5': 13, '10': 'resetWordPos'},
+    {'1': 'mnemonic_type', '3': 12, '4': 1, '5': 14, '6': '.hw.trezor.messages.management.BackupType', '10': 'mnemonicType'},
+    {'1': 'tokens', '3': 13, '4': 3, '5': 9, '10': 'tokens'},
+  ],
+};
+
+/// Descriptor for `DebugLinkState`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugLinkStateDescriptor = $convert.base64Decode(
+    'Cg5EZWJ1Z0xpbmtTdGF0ZRIWCgZsYXlvdXQYASABKAxSBmxheW91dBIQCgNwaW4YAiABKAlSA3'
+    'BpbhIWCgZtYXRyaXgYAyABKAlSBm1hdHJpeBInCg9tbmVtb25pY19zZWNyZXQYBCABKAxSDm1u'
+    'ZW1vbmljU2VjcmV0EjkKBG5vZGUYBSABKAsyJS5ody50cmV6b3IubWVzc2FnZXMuY29tbW9uLk'
+    'hETm9kZVR5cGVSBG5vZGUSMwoVcGFzc3BocmFzZV9wcm90ZWN0aW9uGAYgASgIUhRwYXNzcGhy'
+    'YXNlUHJvdGVjdGlvbhIdCgpyZXNldF93b3JkGAcgASgJUglyZXNldFdvcmQSIwoNcmVzZXRfZW'
+    '50cm9weRgIIAEoDFIMcmVzZXRFbnRyb3B5EiwKEnJlY292ZXJ5X2Zha2Vfd29yZBgJIAEoCVIQ'
+    'cmVjb3ZlcnlGYWtlV29yZBIqChFyZWNvdmVyeV93b3JkX3BvcxgKIAEoDVIPcmVjb3ZlcnlXb3'
+    'JkUG9zEiQKDnJlc2V0X3dvcmRfcG9zGAsgASgNUgxyZXNldFdvcmRQb3MSTgoNbW5lbW9uaWNf'
+    'dHlwZRgMIAEoDjIpLmh3LnRyZXpvci5tZXNzYWdlcy5tYW5hZ2VtZW50LkJhY2t1cFR5cGVSDG'
+    '1uZW1vbmljVHlwZRIWCgZ0b2tlbnMYDSADKAlSBnRva2Vucw==');
+
+@$core.Deprecated('Use debugLinkStopDescriptor instead')
+const DebugLinkStop$json = {
+  '1': 'DebugLinkStop',
+};
+
+/// Descriptor for `DebugLinkStop`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugLinkStopDescriptor = $convert.base64Decode(
+    'Cg1EZWJ1Z0xpbmtTdG9w');
+
+@$core.Deprecated('Use debugLinkLogDescriptor instead')
+const DebugLinkLog$json = {
+  '1': 'DebugLinkLog',
+  '2': [
+    {'1': 'level', '3': 1, '4': 1, '5': 13, '10': 'level'},
+    {'1': 'bucket', '3': 2, '4': 1, '5': 9, '10': 'bucket'},
+    {'1': 'text', '3': 3, '4': 1, '5': 9, '10': 'text'},
+  ],
+};
+
+/// Descriptor for `DebugLinkLog`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugLinkLogDescriptor = $convert.base64Decode(
+    'CgxEZWJ1Z0xpbmtMb2cSFAoFbGV2ZWwYASABKA1SBWxldmVsEhYKBmJ1Y2tldBgCIAEoCVIGYn'
+    'Vja2V0EhIKBHRleHQYAyABKAlSBHRleHQ=');
+
+@$core.Deprecated('Use debugLinkMemoryReadDescriptor instead')
+const DebugLinkMemoryRead$json = {
+  '1': 'DebugLinkMemoryRead',
+  '2': [
+    {'1': 'address', '3': 1, '4': 1, '5': 13, '10': 'address'},
+    {'1': 'length', '3': 2, '4': 1, '5': 13, '10': 'length'},
+  ],
+};
+
+/// Descriptor for `DebugLinkMemoryRead`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugLinkMemoryReadDescriptor = $convert.base64Decode(
+    'ChNEZWJ1Z0xpbmtNZW1vcnlSZWFkEhgKB2FkZHJlc3MYASABKA1SB2FkZHJlc3MSFgoGbGVuZ3'
+    'RoGAIgASgNUgZsZW5ndGg=');
+
+@$core.Deprecated('Use debugLinkMemoryDescriptor instead')
+const DebugLinkMemory$json = {
+  '1': 'DebugLinkMemory',
+  '2': [
+    {'1': 'memory', '3': 1, '4': 1, '5': 12, '10': 'memory'},
+  ],
+};
+
+/// Descriptor for `DebugLinkMemory`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugLinkMemoryDescriptor = $convert.base64Decode(
+    'Cg9EZWJ1Z0xpbmtNZW1vcnkSFgoGbWVtb3J5GAEgASgMUgZtZW1vcnk=');
+
+@$core.Deprecated('Use debugLinkMemoryWriteDescriptor instead')
+const DebugLinkMemoryWrite$json = {
+  '1': 'DebugLinkMemoryWrite',
+  '2': [
+    {'1': 'address', '3': 1, '4': 1, '5': 13, '10': 'address'},
+    {'1': 'memory', '3': 2, '4': 1, '5': 12, '10': 'memory'},
+    {'1': 'flash', '3': 3, '4': 1, '5': 8, '10': 'flash'},
+  ],
+};
+
+/// Descriptor for `DebugLinkMemoryWrite`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugLinkMemoryWriteDescriptor = $convert.base64Decode(
+    'ChREZWJ1Z0xpbmtNZW1vcnlXcml0ZRIYCgdhZGRyZXNzGAEgASgNUgdhZGRyZXNzEhYKBm1lbW'
+    '9yeRgCIAEoDFIGbWVtb3J5EhQKBWZsYXNoGAMgASgIUgVmbGFzaA==');
+
+@$core.Deprecated('Use debugLinkFlashEraseDescriptor instead')
+const DebugLinkFlashErase$json = {
+  '1': 'DebugLinkFlashErase',
+  '2': [
+    {'1': 'sector', '3': 1, '4': 1, '5': 13, '10': 'sector'},
+  ],
+};
+
+/// Descriptor for `DebugLinkFlashErase`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugLinkFlashEraseDescriptor = $convert.base64Decode(
+    'ChNEZWJ1Z0xpbmtGbGFzaEVyYXNlEhYKBnNlY3RvchgBIAEoDVIGc2VjdG9y');
+
+@$core.Deprecated('Use debugLinkEraseSdCardDescriptor instead')
+const DebugLinkEraseSdCard$json = {
+  '1': 'DebugLinkEraseSdCard',
+  '2': [
+    {'1': 'format', '3': 1, '4': 1, '5': 8, '10': 'format'},
+  ],
+};
+
+/// Descriptor for `DebugLinkEraseSdCard`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugLinkEraseSdCardDescriptor = $convert.base64Decode(
+    'ChREZWJ1Z0xpbmtFcmFzZVNkQ2FyZBIWCgZmb3JtYXQYASABKAhSBmZvcm1hdA==');
+
+@$core.Deprecated('Use debugLinkWatchLayoutDescriptor instead')
+const DebugLinkWatchLayout$json = {
+  '1': 'DebugLinkWatchLayout',
+  '2': [
+    {'1': 'watch', '3': 1, '4': 1, '5': 8, '10': 'watch'},
+  ],
+};
+
+/// Descriptor for `DebugLinkWatchLayout`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugLinkWatchLayoutDescriptor = $convert.base64Decode(
+    'ChREZWJ1Z0xpbmtXYXRjaExheW91dBIUCgV3YXRjaBgBIAEoCFIFd2F0Y2g=');
+
+@$core.Deprecated('Use debugLinkResetDebugEventsDescriptor instead')
+const DebugLinkResetDebugEvents$json = {
+  '1': 'DebugLinkResetDebugEvents',
+};
+
+/// Descriptor for `DebugLinkResetDebugEvents`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugLinkResetDebugEventsDescriptor = $convert.base64Decode(
+    'ChlEZWJ1Z0xpbmtSZXNldERlYnVnRXZlbnRz');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-debug.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-debug.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-debug.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-debug.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-eos.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-eos.pb.dart
@@ -1,0 +1,2418 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-eos.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+/// *
+///  Request: Ask device for Eos public key corresponding to address_n path
+///  @start
+///  @next EosPublicKey
+///  @next Failure
+class EosGetPublicKey extends $pb.GeneratedMessage {
+  factory EosGetPublicKey({
+    $core.Iterable<$core.int>? addressN,
+    $core.bool? showDisplay,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  EosGetPublicKey._() : super();
+  factory EosGetPublicKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosGetPublicKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosGetPublicKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aOB(2, _omitFieldNames ? '' : 'showDisplay')
+    ..aOB(3, _omitFieldNames ? '' : 'chunkify')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosGetPublicKey clone() => EosGetPublicKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosGetPublicKey copyWith(void Function(EosGetPublicKey) updates) => super.copyWith((message) => updates(message as EosGetPublicKey)) as EosGetPublicKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosGetPublicKey create() => EosGetPublicKey._();
+  EosGetPublicKey createEmptyInstance() => create();
+  static $pb.PbList<EosGetPublicKey> createRepeated() => $pb.PbList<EosGetPublicKey>();
+  @$core.pragma('dart2js:noInline')
+  static EosGetPublicKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosGetPublicKey>(create);
+  static EosGetPublicKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.bool get showDisplay => $_getBF(1);
+  @$pb.TagNumber(2)
+  set showDisplay($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasShowDisplay() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearShowDisplay() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get chunkify => $_getBF(2);
+  @$pb.TagNumber(3)
+  set chunkify($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasChunkify() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearChunkify() => clearField(3);
+}
+
+/// *
+///  Response: Contains an Eos public key derived from device private seed
+///  @end
+class EosPublicKey extends $pb.GeneratedMessage {
+  factory EosPublicKey({
+    $core.String? wifPublicKey,
+    $core.List<$core.int>? rawPublicKey,
+  }) {
+    final $result = create();
+    if (wifPublicKey != null) {
+      $result.wifPublicKey = wifPublicKey;
+    }
+    if (rawPublicKey != null) {
+      $result.rawPublicKey = rawPublicKey;
+    }
+    return $result;
+  }
+  EosPublicKey._() : super();
+  factory EosPublicKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosPublicKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosPublicKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'wifPublicKey')
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'rawPublicKey', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosPublicKey clone() => EosPublicKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosPublicKey copyWith(void Function(EosPublicKey) updates) => super.copyWith((message) => updates(message as EosPublicKey)) as EosPublicKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosPublicKey create() => EosPublicKey._();
+  EosPublicKey createEmptyInstance() => create();
+  static $pb.PbList<EosPublicKey> createRepeated() => $pb.PbList<EosPublicKey>();
+  @$core.pragma('dart2js:noInline')
+  static EosPublicKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosPublicKey>(create);
+  static EosPublicKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get wifPublicKey => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set wifPublicKey($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWifPublicKey() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWifPublicKey() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get rawPublicKey => $_getN(1);
+  @$pb.TagNumber(2)
+  set rawPublicKey($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasRawPublicKey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearRawPublicKey() => clearField(2);
+}
+
+/// *
+///  Structure representing EOS transaction header
+class EosSignTx_EosTxHeader extends $pb.GeneratedMessage {
+  factory EosSignTx_EosTxHeader({
+    $core.int? expiration,
+    $core.int? refBlockNum,
+    $core.int? refBlockPrefix,
+    $core.int? maxNetUsageWords,
+    $core.int? maxCpuUsageMs,
+    $core.int? delaySec,
+  }) {
+    final $result = create();
+    if (expiration != null) {
+      $result.expiration = expiration;
+    }
+    if (refBlockNum != null) {
+      $result.refBlockNum = refBlockNum;
+    }
+    if (refBlockPrefix != null) {
+      $result.refBlockPrefix = refBlockPrefix;
+    }
+    if (maxNetUsageWords != null) {
+      $result.maxNetUsageWords = maxNetUsageWords;
+    }
+    if (maxCpuUsageMs != null) {
+      $result.maxCpuUsageMs = maxCpuUsageMs;
+    }
+    if (delaySec != null) {
+      $result.delaySec = delaySec;
+    }
+    return $result;
+  }
+  EosSignTx_EosTxHeader._() : super();
+  factory EosSignTx_EosTxHeader.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosSignTx_EosTxHeader.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosSignTx.EosTxHeader', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'expiration', $pb.PbFieldType.QU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'refBlockNum', $pb.PbFieldType.QU3)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'refBlockPrefix', $pb.PbFieldType.QU3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'maxNetUsageWords', $pb.PbFieldType.QU3)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'maxCpuUsageMs', $pb.PbFieldType.QU3)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'delaySec', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosSignTx_EosTxHeader clone() => EosSignTx_EosTxHeader()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosSignTx_EosTxHeader copyWith(void Function(EosSignTx_EosTxHeader) updates) => super.copyWith((message) => updates(message as EosSignTx_EosTxHeader)) as EosSignTx_EosTxHeader;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosSignTx_EosTxHeader create() => EosSignTx_EosTxHeader._();
+  EosSignTx_EosTxHeader createEmptyInstance() => create();
+  static $pb.PbList<EosSignTx_EosTxHeader> createRepeated() => $pb.PbList<EosSignTx_EosTxHeader>();
+  @$core.pragma('dart2js:noInline')
+  static EosSignTx_EosTxHeader getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosSignTx_EosTxHeader>(create);
+  static EosSignTx_EosTxHeader? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get expiration => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set expiration($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasExpiration() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearExpiration() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get refBlockNum => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set refBlockNum($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasRefBlockNum() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearRefBlockNum() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get refBlockPrefix => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set refBlockPrefix($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasRefBlockPrefix() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearRefBlockPrefix() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get maxNetUsageWords => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set maxNetUsageWords($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasMaxNetUsageWords() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMaxNetUsageWords() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get maxCpuUsageMs => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set maxCpuUsageMs($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasMaxCpuUsageMs() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearMaxCpuUsageMs() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.int get delaySec => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set delaySec($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasDelaySec() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearDelaySec() => clearField(6);
+}
+
+/// *
+///  Request: Ask device to sign transaction
+///  @start
+///  @next EosTxRequest
+///  @next Failure
+class EosSignTx extends $pb.GeneratedMessage {
+  factory EosSignTx({
+    $core.Iterable<$core.int>? addressN,
+    $core.List<$core.int>? chainId,
+    EosSignTx_EosTxHeader? header,
+    $core.int? numActions,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (chainId != null) {
+      $result.chainId = chainId;
+    }
+    if (header != null) {
+      $result.header = header;
+    }
+    if (numActions != null) {
+      $result.numActions = numActions;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  EosSignTx._() : super();
+  factory EosSignTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosSignTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosSignTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'chainId', $pb.PbFieldType.QY)
+    ..aQM<EosSignTx_EosTxHeader>(3, _omitFieldNames ? '' : 'header', subBuilder: EosSignTx_EosTxHeader.create)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'numActions', $pb.PbFieldType.QU3)
+    ..aOB(5, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosSignTx clone() => EosSignTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosSignTx copyWith(void Function(EosSignTx) updates) => super.copyWith((message) => updates(message as EosSignTx)) as EosSignTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosSignTx create() => EosSignTx._();
+  EosSignTx createEmptyInstance() => create();
+  static $pb.PbList<EosSignTx> createRepeated() => $pb.PbList<EosSignTx>();
+  @$core.pragma('dart2js:noInline')
+  static EosSignTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosSignTx>(create);
+  static EosSignTx? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get chainId => $_getN(1);
+  @$pb.TagNumber(2)
+  set chainId($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasChainId() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearChainId() => clearField(2);
+
+  @$pb.TagNumber(3)
+  EosSignTx_EosTxHeader get header => $_getN(2);
+  @$pb.TagNumber(3)
+  set header(EosSignTx_EosTxHeader v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasHeader() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearHeader() => clearField(3);
+  @$pb.TagNumber(3)
+  EosSignTx_EosTxHeader ensureHeader() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  $core.int get numActions => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set numActions($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasNumActions() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearNumActions() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.bool get chunkify => $_getBF(4);
+  @$pb.TagNumber(5)
+  set chunkify($core.bool v) { $_setBool(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasChunkify() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearChunkify() => clearField(5);
+}
+
+/// *
+///  Response: Device asks to upload next action
+///  @next EosTxActionAck
+class EosTxActionRequest extends $pb.GeneratedMessage {
+  factory EosTxActionRequest({
+    $core.int? dataSize,
+  }) {
+    final $result = create();
+    if (dataSize != null) {
+      $result.dataSize = dataSize;
+    }
+    return $result;
+  }
+  EosTxActionRequest._() : super();
+  factory EosTxActionRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'dataSize', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionRequest clone() => EosTxActionRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionRequest copyWith(void Function(EosTxActionRequest) updates) => super.copyWith((message) => updates(message as EosTxActionRequest)) as EosTxActionRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionRequest create() => EosTxActionRequest._();
+  EosTxActionRequest createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionRequest> createRepeated() => $pb.PbList<EosTxActionRequest>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionRequest>(create);
+  static EosTxActionRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get dataSize => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set dataSize($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDataSize() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDataSize() => clearField(1);
+}
+
+/// *
+///  Structure representing asset type
+class EosTxActionAck_EosAsset extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosAsset({
+    $fixnum.Int64? amount,
+    $fixnum.Int64? symbol,
+  }) {
+    final $result = create();
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (symbol != null) {
+      $result.symbol = symbol;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosAsset._() : super();
+  factory EosTxActionAck_EosAsset.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosAsset.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosAsset', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'symbol', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosAsset clone() => EosTxActionAck_EosAsset()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosAsset copyWith(void Function(EosTxActionAck_EosAsset) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosAsset)) as EosTxActionAck_EosAsset;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosAsset create() => EosTxActionAck_EosAsset._();
+  EosTxActionAck_EosAsset createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosAsset> createRepeated() => $pb.PbList<EosTxActionAck_EosAsset>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosAsset getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosAsset>(create);
+  static EosTxActionAck_EosAsset? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get amount => $_getI64(0);
+  @$pb.TagNumber(1)
+  set amount($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAmount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAmount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get symbol => $_getI64(1);
+  @$pb.TagNumber(2)
+  set symbol($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSymbol() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSymbol() => clearField(2);
+}
+
+/// *
+///  Structure representing action permission level
+class EosTxActionAck_EosPermissionLevel extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosPermissionLevel({
+    $fixnum.Int64? actor,
+    $fixnum.Int64? permission,
+  }) {
+    final $result = create();
+    if (actor != null) {
+      $result.actor = actor;
+    }
+    if (permission != null) {
+      $result.permission = permission;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosPermissionLevel._() : super();
+  factory EosTxActionAck_EosPermissionLevel.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosPermissionLevel.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosPermissionLevel', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'actor', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'permission', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosPermissionLevel clone() => EosTxActionAck_EosPermissionLevel()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosPermissionLevel copyWith(void Function(EosTxActionAck_EosPermissionLevel) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosPermissionLevel)) as EosTxActionAck_EosPermissionLevel;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosPermissionLevel create() => EosTxActionAck_EosPermissionLevel._();
+  EosTxActionAck_EosPermissionLevel createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosPermissionLevel> createRepeated() => $pb.PbList<EosTxActionAck_EosPermissionLevel>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosPermissionLevel getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosPermissionLevel>(create);
+  static EosTxActionAck_EosPermissionLevel? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get actor => $_getI64(0);
+  @$pb.TagNumber(1)
+  set actor($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasActor() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearActor() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get permission => $_getI64(1);
+  @$pb.TagNumber(2)
+  set permission($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPermission() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPermission() => clearField(2);
+}
+
+/// *
+///  Structure representing auth key
+class EosTxActionAck_EosAuthorizationKey extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosAuthorizationKey({
+    $core.int? type,
+    $core.List<$core.int>? key,
+    $core.Iterable<$core.int>? addressN,
+    $core.int? weight,
+  }) {
+    final $result = create();
+    if (type != null) {
+      $result.type = type;
+    }
+    if (key != null) {
+      $result.key = key;
+    }
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (weight != null) {
+      $result.weight = weight;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosAuthorizationKey._() : super();
+  factory EosTxActionAck_EosAuthorizationKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosAuthorizationKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosAuthorizationKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'type', $pb.PbFieldType.QU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'key', $pb.PbFieldType.OY)
+    ..p<$core.int>(3, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'weight', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosAuthorizationKey clone() => EosTxActionAck_EosAuthorizationKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosAuthorizationKey copyWith(void Function(EosTxActionAck_EosAuthorizationKey) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosAuthorizationKey)) as EosTxActionAck_EosAuthorizationKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosAuthorizationKey create() => EosTxActionAck_EosAuthorizationKey._();
+  EosTxActionAck_EosAuthorizationKey createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosAuthorizationKey> createRepeated() => $pb.PbList<EosTxActionAck_EosAuthorizationKey>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosAuthorizationKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosAuthorizationKey>(create);
+  static EosTxActionAck_EosAuthorizationKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get type => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set type($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearType() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get key => $_getN(1);
+  @$pb.TagNumber(2)
+  set key($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasKey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearKey() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get addressN => $_getList(2);
+
+  @$pb.TagNumber(4)
+  $core.int get weight => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set weight($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasWeight() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearWeight() => clearField(4);
+}
+
+/// *
+///  Structure representing auth account
+class EosTxActionAck_EosAuthorizationAccount extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosAuthorizationAccount({
+    EosTxActionAck_EosPermissionLevel? account,
+    $core.int? weight,
+  }) {
+    final $result = create();
+    if (account != null) {
+      $result.account = account;
+    }
+    if (weight != null) {
+      $result.weight = weight;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosAuthorizationAccount._() : super();
+  factory EosTxActionAck_EosAuthorizationAccount.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosAuthorizationAccount.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosAuthorizationAccount', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..aQM<EosTxActionAck_EosPermissionLevel>(1, _omitFieldNames ? '' : 'account', subBuilder: EosTxActionAck_EosPermissionLevel.create)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'weight', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosAuthorizationAccount clone() => EosTxActionAck_EosAuthorizationAccount()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosAuthorizationAccount copyWith(void Function(EosTxActionAck_EosAuthorizationAccount) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosAuthorizationAccount)) as EosTxActionAck_EosAuthorizationAccount;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosAuthorizationAccount create() => EosTxActionAck_EosAuthorizationAccount._();
+  EosTxActionAck_EosAuthorizationAccount createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosAuthorizationAccount> createRepeated() => $pb.PbList<EosTxActionAck_EosAuthorizationAccount>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosAuthorizationAccount getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosAuthorizationAccount>(create);
+  static EosTxActionAck_EosAuthorizationAccount? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  EosTxActionAck_EosPermissionLevel get account => $_getN(0);
+  @$pb.TagNumber(1)
+  set account(EosTxActionAck_EosPermissionLevel v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAccount() => clearField(1);
+  @$pb.TagNumber(1)
+  EosTxActionAck_EosPermissionLevel ensureAccount() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $core.int get weight => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set weight($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasWeight() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearWeight() => clearField(2);
+}
+
+/// *
+///  Structure representing auth delays
+class EosTxActionAck_EosAuthorizationWait extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosAuthorizationWait({
+    $core.int? waitSec,
+    $core.int? weight,
+  }) {
+    final $result = create();
+    if (waitSec != null) {
+      $result.waitSec = waitSec;
+    }
+    if (weight != null) {
+      $result.weight = weight;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosAuthorizationWait._() : super();
+  factory EosTxActionAck_EosAuthorizationWait.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosAuthorizationWait.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosAuthorizationWait', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'waitSec', $pb.PbFieldType.QU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'weight', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosAuthorizationWait clone() => EosTxActionAck_EosAuthorizationWait()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosAuthorizationWait copyWith(void Function(EosTxActionAck_EosAuthorizationWait) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosAuthorizationWait)) as EosTxActionAck_EosAuthorizationWait;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosAuthorizationWait create() => EosTxActionAck_EosAuthorizationWait._();
+  EosTxActionAck_EosAuthorizationWait createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosAuthorizationWait> createRepeated() => $pb.PbList<EosTxActionAck_EosAuthorizationWait>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosAuthorizationWait getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosAuthorizationWait>(create);
+  static EosTxActionAck_EosAuthorizationWait? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get waitSec => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set waitSec($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWaitSec() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWaitSec() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get weight => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set weight($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasWeight() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearWeight() => clearField(2);
+}
+
+/// *
+///  Structure representing authorization settings
+class EosTxActionAck_EosAuthorization extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosAuthorization({
+    $core.int? threshold,
+    $core.Iterable<EosTxActionAck_EosAuthorizationKey>? keys,
+    $core.Iterable<EosTxActionAck_EosAuthorizationAccount>? accounts,
+    $core.Iterable<EosTxActionAck_EosAuthorizationWait>? waits,
+  }) {
+    final $result = create();
+    if (threshold != null) {
+      $result.threshold = threshold;
+    }
+    if (keys != null) {
+      $result.keys.addAll(keys);
+    }
+    if (accounts != null) {
+      $result.accounts.addAll(accounts);
+    }
+    if (waits != null) {
+      $result.waits.addAll(waits);
+    }
+    return $result;
+  }
+  EosTxActionAck_EosAuthorization._() : super();
+  factory EosTxActionAck_EosAuthorization.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosAuthorization.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosAuthorization', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'threshold', $pb.PbFieldType.QU3)
+    ..pc<EosTxActionAck_EosAuthorizationKey>(2, _omitFieldNames ? '' : 'keys', $pb.PbFieldType.PM, subBuilder: EosTxActionAck_EosAuthorizationKey.create)
+    ..pc<EosTxActionAck_EosAuthorizationAccount>(3, _omitFieldNames ? '' : 'accounts', $pb.PbFieldType.PM, subBuilder: EosTxActionAck_EosAuthorizationAccount.create)
+    ..pc<EosTxActionAck_EosAuthorizationWait>(4, _omitFieldNames ? '' : 'waits', $pb.PbFieldType.PM, subBuilder: EosTxActionAck_EosAuthorizationWait.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosAuthorization clone() => EosTxActionAck_EosAuthorization()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosAuthorization copyWith(void Function(EosTxActionAck_EosAuthorization) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosAuthorization)) as EosTxActionAck_EosAuthorization;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosAuthorization create() => EosTxActionAck_EosAuthorization._();
+  EosTxActionAck_EosAuthorization createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosAuthorization> createRepeated() => $pb.PbList<EosTxActionAck_EosAuthorization>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosAuthorization getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosAuthorization>(create);
+  static EosTxActionAck_EosAuthorization? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get threshold => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set threshold($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasThreshold() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearThreshold() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<EosTxActionAck_EosAuthorizationKey> get keys => $_getList(1);
+
+  @$pb.TagNumber(3)
+  $core.List<EosTxActionAck_EosAuthorizationAccount> get accounts => $_getList(2);
+
+  @$pb.TagNumber(4)
+  $core.List<EosTxActionAck_EosAuthorizationWait> get waits => $_getList(3);
+}
+
+/// *
+///  Structure representing the common part of every action
+class EosTxActionAck_EosActionCommon extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosActionCommon({
+    $fixnum.Int64? account,
+    $fixnum.Int64? name,
+    $core.Iterable<EosTxActionAck_EosPermissionLevel>? authorization,
+  }) {
+    final $result = create();
+    if (account != null) {
+      $result.account = account;
+    }
+    if (name != null) {
+      $result.name = name;
+    }
+    if (authorization != null) {
+      $result.authorization.addAll(authorization);
+    }
+    return $result;
+  }
+  EosTxActionAck_EosActionCommon._() : super();
+  factory EosTxActionAck_EosActionCommon.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosActionCommon.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosActionCommon', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'account', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'name', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..pc<EosTxActionAck_EosPermissionLevel>(3, _omitFieldNames ? '' : 'authorization', $pb.PbFieldType.PM, subBuilder: EosTxActionAck_EosPermissionLevel.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionCommon clone() => EosTxActionAck_EosActionCommon()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionCommon copyWith(void Function(EosTxActionAck_EosActionCommon) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosActionCommon)) as EosTxActionAck_EosActionCommon;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionCommon create() => EosTxActionAck_EosActionCommon._();
+  EosTxActionAck_EosActionCommon createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosActionCommon> createRepeated() => $pb.PbList<EosTxActionAck_EosActionCommon>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionCommon getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosActionCommon>(create);
+  static EosTxActionAck_EosActionCommon? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get account => $_getI64(0);
+  @$pb.TagNumber(1)
+  set account($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get name => $_getI64(1);
+  @$pb.TagNumber(2)
+  set name($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasName() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearName() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<EosTxActionAck_EosPermissionLevel> get authorization => $_getList(2);
+}
+
+/// *
+///  Structure representing transfer data structure
+class EosTxActionAck_EosActionTransfer extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosActionTransfer({
+    $fixnum.Int64? sender,
+    $fixnum.Int64? receiver,
+    EosTxActionAck_EosAsset? quantity,
+    $core.String? memo,
+  }) {
+    final $result = create();
+    if (sender != null) {
+      $result.sender = sender;
+    }
+    if (receiver != null) {
+      $result.receiver = receiver;
+    }
+    if (quantity != null) {
+      $result.quantity = quantity;
+    }
+    if (memo != null) {
+      $result.memo = memo;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosActionTransfer._() : super();
+  factory EosTxActionAck_EosActionTransfer.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosActionTransfer.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosActionTransfer', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'sender', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'receiver', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aQM<EosTxActionAck_EosAsset>(3, _omitFieldNames ? '' : 'quantity', subBuilder: EosTxActionAck_EosAsset.create)
+    ..aQS(4, _omitFieldNames ? '' : 'memo')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionTransfer clone() => EosTxActionAck_EosActionTransfer()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionTransfer copyWith(void Function(EosTxActionAck_EosActionTransfer) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosActionTransfer)) as EosTxActionAck_EosActionTransfer;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionTransfer create() => EosTxActionAck_EosActionTransfer._();
+  EosTxActionAck_EosActionTransfer createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosActionTransfer> createRepeated() => $pb.PbList<EosTxActionAck_EosActionTransfer>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionTransfer getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosActionTransfer>(create);
+  static EosTxActionAck_EosActionTransfer? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get sender => $_getI64(0);
+  @$pb.TagNumber(1)
+  set sender($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSender() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSender() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get receiver => $_getI64(1);
+  @$pb.TagNumber(2)
+  set receiver($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasReceiver() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearReceiver() => clearField(2);
+
+  @$pb.TagNumber(3)
+  EosTxActionAck_EosAsset get quantity => $_getN(2);
+  @$pb.TagNumber(3)
+  set quantity(EosTxActionAck_EosAsset v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasQuantity() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearQuantity() => clearField(3);
+  @$pb.TagNumber(3)
+  EosTxActionAck_EosAsset ensureQuantity() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  $core.String get memo => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set memo($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasMemo() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMemo() => clearField(4);
+}
+
+/// *
+///  Structure representing delegation data structure
+class EosTxActionAck_EosActionDelegate extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosActionDelegate({
+    $fixnum.Int64? sender,
+    $fixnum.Int64? receiver,
+    EosTxActionAck_EosAsset? netQuantity,
+    EosTxActionAck_EosAsset? cpuQuantity,
+    $core.bool? transfer,
+  }) {
+    final $result = create();
+    if (sender != null) {
+      $result.sender = sender;
+    }
+    if (receiver != null) {
+      $result.receiver = receiver;
+    }
+    if (netQuantity != null) {
+      $result.netQuantity = netQuantity;
+    }
+    if (cpuQuantity != null) {
+      $result.cpuQuantity = cpuQuantity;
+    }
+    if (transfer != null) {
+      $result.transfer = transfer;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosActionDelegate._() : super();
+  factory EosTxActionAck_EosActionDelegate.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosActionDelegate.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosActionDelegate', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'sender', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'receiver', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aQM<EosTxActionAck_EosAsset>(3, _omitFieldNames ? '' : 'netQuantity', subBuilder: EosTxActionAck_EosAsset.create)
+    ..aQM<EosTxActionAck_EosAsset>(4, _omitFieldNames ? '' : 'cpuQuantity', subBuilder: EosTxActionAck_EosAsset.create)
+    ..a<$core.bool>(5, _omitFieldNames ? '' : 'transfer', $pb.PbFieldType.QB)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionDelegate clone() => EosTxActionAck_EosActionDelegate()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionDelegate copyWith(void Function(EosTxActionAck_EosActionDelegate) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosActionDelegate)) as EosTxActionAck_EosActionDelegate;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionDelegate create() => EosTxActionAck_EosActionDelegate._();
+  EosTxActionAck_EosActionDelegate createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosActionDelegate> createRepeated() => $pb.PbList<EosTxActionAck_EosActionDelegate>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionDelegate getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosActionDelegate>(create);
+  static EosTxActionAck_EosActionDelegate? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get sender => $_getI64(0);
+  @$pb.TagNumber(1)
+  set sender($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSender() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSender() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get receiver => $_getI64(1);
+  @$pb.TagNumber(2)
+  set receiver($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasReceiver() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearReceiver() => clearField(2);
+
+  @$pb.TagNumber(3)
+  EosTxActionAck_EosAsset get netQuantity => $_getN(2);
+  @$pb.TagNumber(3)
+  set netQuantity(EosTxActionAck_EosAsset v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasNetQuantity() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearNetQuantity() => clearField(3);
+  @$pb.TagNumber(3)
+  EosTxActionAck_EosAsset ensureNetQuantity() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  EosTxActionAck_EosAsset get cpuQuantity => $_getN(3);
+  @$pb.TagNumber(4)
+  set cpuQuantity(EosTxActionAck_EosAsset v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasCpuQuantity() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearCpuQuantity() => clearField(4);
+  @$pb.TagNumber(4)
+  EosTxActionAck_EosAsset ensureCpuQuantity() => $_ensure(3);
+
+  @$pb.TagNumber(5)
+  $core.bool get transfer => $_getBF(4);
+  @$pb.TagNumber(5)
+  set transfer($core.bool v) { $_setBool(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasTransfer() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearTransfer() => clearField(5);
+}
+
+/// *
+///  Structure representing the removal of delegated resources from `sender`
+class EosTxActionAck_EosActionUndelegate extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosActionUndelegate({
+    $fixnum.Int64? sender,
+    $fixnum.Int64? receiver,
+    EosTxActionAck_EosAsset? netQuantity,
+    EosTxActionAck_EosAsset? cpuQuantity,
+  }) {
+    final $result = create();
+    if (sender != null) {
+      $result.sender = sender;
+    }
+    if (receiver != null) {
+      $result.receiver = receiver;
+    }
+    if (netQuantity != null) {
+      $result.netQuantity = netQuantity;
+    }
+    if (cpuQuantity != null) {
+      $result.cpuQuantity = cpuQuantity;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosActionUndelegate._() : super();
+  factory EosTxActionAck_EosActionUndelegate.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosActionUndelegate.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosActionUndelegate', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'sender', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'receiver', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aQM<EosTxActionAck_EosAsset>(3, _omitFieldNames ? '' : 'netQuantity', subBuilder: EosTxActionAck_EosAsset.create)
+    ..aQM<EosTxActionAck_EosAsset>(4, _omitFieldNames ? '' : 'cpuQuantity', subBuilder: EosTxActionAck_EosAsset.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionUndelegate clone() => EosTxActionAck_EosActionUndelegate()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionUndelegate copyWith(void Function(EosTxActionAck_EosActionUndelegate) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosActionUndelegate)) as EosTxActionAck_EosActionUndelegate;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionUndelegate create() => EosTxActionAck_EosActionUndelegate._();
+  EosTxActionAck_EosActionUndelegate createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosActionUndelegate> createRepeated() => $pb.PbList<EosTxActionAck_EosActionUndelegate>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionUndelegate getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosActionUndelegate>(create);
+  static EosTxActionAck_EosActionUndelegate? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get sender => $_getI64(0);
+  @$pb.TagNumber(1)
+  set sender($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSender() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSender() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get receiver => $_getI64(1);
+  @$pb.TagNumber(2)
+  set receiver($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasReceiver() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearReceiver() => clearField(2);
+
+  @$pb.TagNumber(3)
+  EosTxActionAck_EosAsset get netQuantity => $_getN(2);
+  @$pb.TagNumber(3)
+  set netQuantity(EosTxActionAck_EosAsset v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasNetQuantity() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearNetQuantity() => clearField(3);
+  @$pb.TagNumber(3)
+  EosTxActionAck_EosAsset ensureNetQuantity() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  EosTxActionAck_EosAsset get cpuQuantity => $_getN(3);
+  @$pb.TagNumber(4)
+  set cpuQuantity(EosTxActionAck_EosAsset v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasCpuQuantity() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearCpuQuantity() => clearField(4);
+  @$pb.TagNumber(4)
+  EosTxActionAck_EosAsset ensureCpuQuantity() => $_ensure(3);
+}
+
+/// *
+///  Structure representing fallback if undelegate wasnt executed automaticaly.
+class EosTxActionAck_EosActionRefund extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosActionRefund({
+    $fixnum.Int64? owner,
+  }) {
+    final $result = create();
+    if (owner != null) {
+      $result.owner = owner;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosActionRefund._() : super();
+  factory EosTxActionAck_EosActionRefund.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosActionRefund.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosActionRefund', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'owner', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionRefund clone() => EosTxActionAck_EosActionRefund()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionRefund copyWith(void Function(EosTxActionAck_EosActionRefund) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosActionRefund)) as EosTxActionAck_EosActionRefund;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionRefund create() => EosTxActionAck_EosActionRefund._();
+  EosTxActionAck_EosActionRefund createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosActionRefund> createRepeated() => $pb.PbList<EosTxActionAck_EosActionRefund>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionRefund getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosActionRefund>(create);
+  static EosTxActionAck_EosActionRefund? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get owner => $_getI64(0);
+  @$pb.TagNumber(1)
+  set owner($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasOwner() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearOwner() => clearField(1);
+}
+
+/// *
+///  Structure representing buying RAM operation for EOS tokens
+class EosTxActionAck_EosActionBuyRam extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosActionBuyRam({
+    $fixnum.Int64? payer,
+    $fixnum.Int64? receiver,
+    EosTxActionAck_EosAsset? quantity,
+  }) {
+    final $result = create();
+    if (payer != null) {
+      $result.payer = payer;
+    }
+    if (receiver != null) {
+      $result.receiver = receiver;
+    }
+    if (quantity != null) {
+      $result.quantity = quantity;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosActionBuyRam._() : super();
+  factory EosTxActionAck_EosActionBuyRam.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosActionBuyRam.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosActionBuyRam', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'payer', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'receiver', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aQM<EosTxActionAck_EosAsset>(3, _omitFieldNames ? '' : 'quantity', subBuilder: EosTxActionAck_EosAsset.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionBuyRam clone() => EosTxActionAck_EosActionBuyRam()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionBuyRam copyWith(void Function(EosTxActionAck_EosActionBuyRam) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosActionBuyRam)) as EosTxActionAck_EosActionBuyRam;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionBuyRam create() => EosTxActionAck_EosActionBuyRam._();
+  EosTxActionAck_EosActionBuyRam createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosActionBuyRam> createRepeated() => $pb.PbList<EosTxActionAck_EosActionBuyRam>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionBuyRam getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosActionBuyRam>(create);
+  static EosTxActionAck_EosActionBuyRam? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get payer => $_getI64(0);
+  @$pb.TagNumber(1)
+  set payer($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPayer() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPayer() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get receiver => $_getI64(1);
+  @$pb.TagNumber(2)
+  set receiver($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasReceiver() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearReceiver() => clearField(2);
+
+  @$pb.TagNumber(3)
+  EosTxActionAck_EosAsset get quantity => $_getN(2);
+  @$pb.TagNumber(3)
+  set quantity(EosTxActionAck_EosAsset v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasQuantity() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearQuantity() => clearField(3);
+  @$pb.TagNumber(3)
+  EosTxActionAck_EosAsset ensureQuantity() => $_ensure(2);
+}
+
+/// *
+///  Structure representing buying bytes according to RAM market price.
+class EosTxActionAck_EosActionBuyRamBytes extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosActionBuyRamBytes({
+    $fixnum.Int64? payer,
+    $fixnum.Int64? receiver,
+    $core.int? bytes,
+  }) {
+    final $result = create();
+    if (payer != null) {
+      $result.payer = payer;
+    }
+    if (receiver != null) {
+      $result.receiver = receiver;
+    }
+    if (bytes != null) {
+      $result.bytes = bytes;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosActionBuyRamBytes._() : super();
+  factory EosTxActionAck_EosActionBuyRamBytes.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosActionBuyRamBytes.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosActionBuyRamBytes', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'payer', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'receiver', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'bytes', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionBuyRamBytes clone() => EosTxActionAck_EosActionBuyRamBytes()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionBuyRamBytes copyWith(void Function(EosTxActionAck_EosActionBuyRamBytes) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosActionBuyRamBytes)) as EosTxActionAck_EosActionBuyRamBytes;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionBuyRamBytes create() => EosTxActionAck_EosActionBuyRamBytes._();
+  EosTxActionAck_EosActionBuyRamBytes createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosActionBuyRamBytes> createRepeated() => $pb.PbList<EosTxActionAck_EosActionBuyRamBytes>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionBuyRamBytes getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosActionBuyRamBytes>(create);
+  static EosTxActionAck_EosActionBuyRamBytes? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get payer => $_getI64(0);
+  @$pb.TagNumber(1)
+  set payer($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPayer() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPayer() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get receiver => $_getI64(1);
+  @$pb.TagNumber(2)
+  set receiver($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasReceiver() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearReceiver() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get bytes => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set bytes($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasBytes() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearBytes() => clearField(3);
+}
+
+/// *
+///  Structure representing sell RAM
+class EosTxActionAck_EosActionSellRam extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosActionSellRam({
+    $fixnum.Int64? account,
+    $fixnum.Int64? bytes,
+  }) {
+    final $result = create();
+    if (account != null) {
+      $result.account = account;
+    }
+    if (bytes != null) {
+      $result.bytes = bytes;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosActionSellRam._() : super();
+  factory EosTxActionAck_EosActionSellRam.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosActionSellRam.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosActionSellRam', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'account', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'bytes', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionSellRam clone() => EosTxActionAck_EosActionSellRam()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionSellRam copyWith(void Function(EosTxActionAck_EosActionSellRam) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosActionSellRam)) as EosTxActionAck_EosActionSellRam;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionSellRam create() => EosTxActionAck_EosActionSellRam._();
+  EosTxActionAck_EosActionSellRam createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosActionSellRam> createRepeated() => $pb.PbList<EosTxActionAck_EosActionSellRam>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionSellRam getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosActionSellRam>(create);
+  static EosTxActionAck_EosActionSellRam? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get account => $_getI64(0);
+  @$pb.TagNumber(1)
+  set account($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get bytes => $_getI64(1);
+  @$pb.TagNumber(2)
+  set bytes($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasBytes() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearBytes() => clearField(2);
+}
+
+/// *
+///  Structure representing voting. Currently, there could be up to 30 producers.
+class EosTxActionAck_EosActionVoteProducer extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosActionVoteProducer({
+    $fixnum.Int64? voter,
+    $fixnum.Int64? proxy,
+    $core.Iterable<$fixnum.Int64>? producers,
+  }) {
+    final $result = create();
+    if (voter != null) {
+      $result.voter = voter;
+    }
+    if (proxy != null) {
+      $result.proxy = proxy;
+    }
+    if (producers != null) {
+      $result.producers.addAll(producers);
+    }
+    return $result;
+  }
+  EosTxActionAck_EosActionVoteProducer._() : super();
+  factory EosTxActionAck_EosActionVoteProducer.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosActionVoteProducer.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosActionVoteProducer', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'voter', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'proxy', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..p<$fixnum.Int64>(3, _omitFieldNames ? '' : 'producers', $pb.PbFieldType.PU6)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionVoteProducer clone() => EosTxActionAck_EosActionVoteProducer()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionVoteProducer copyWith(void Function(EosTxActionAck_EosActionVoteProducer) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosActionVoteProducer)) as EosTxActionAck_EosActionVoteProducer;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionVoteProducer create() => EosTxActionAck_EosActionVoteProducer._();
+  EosTxActionAck_EosActionVoteProducer createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosActionVoteProducer> createRepeated() => $pb.PbList<EosTxActionAck_EosActionVoteProducer>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionVoteProducer getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosActionVoteProducer>(create);
+  static EosTxActionAck_EosActionVoteProducer? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get voter => $_getI64(0);
+  @$pb.TagNumber(1)
+  set voter($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasVoter() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearVoter() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get proxy => $_getI64(1);
+  @$pb.TagNumber(2)
+  set proxy($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasProxy() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearProxy() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$fixnum.Int64> get producers => $_getList(2);
+}
+
+/// *
+///  Structure representing update authorization.
+class EosTxActionAck_EosActionUpdateAuth extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosActionUpdateAuth({
+    $fixnum.Int64? account,
+    $fixnum.Int64? permission,
+    $fixnum.Int64? parent,
+    EosTxActionAck_EosAuthorization? auth,
+  }) {
+    final $result = create();
+    if (account != null) {
+      $result.account = account;
+    }
+    if (permission != null) {
+      $result.permission = permission;
+    }
+    if (parent != null) {
+      $result.parent = parent;
+    }
+    if (auth != null) {
+      $result.auth = auth;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosActionUpdateAuth._() : super();
+  factory EosTxActionAck_EosActionUpdateAuth.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosActionUpdateAuth.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosActionUpdateAuth', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'account', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'permission', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'parent', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aQM<EosTxActionAck_EosAuthorization>(4, _omitFieldNames ? '' : 'auth', subBuilder: EosTxActionAck_EosAuthorization.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionUpdateAuth clone() => EosTxActionAck_EosActionUpdateAuth()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionUpdateAuth copyWith(void Function(EosTxActionAck_EosActionUpdateAuth) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosActionUpdateAuth)) as EosTxActionAck_EosActionUpdateAuth;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionUpdateAuth create() => EosTxActionAck_EosActionUpdateAuth._();
+  EosTxActionAck_EosActionUpdateAuth createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosActionUpdateAuth> createRepeated() => $pb.PbList<EosTxActionAck_EosActionUpdateAuth>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionUpdateAuth getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosActionUpdateAuth>(create);
+  static EosTxActionAck_EosActionUpdateAuth? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get account => $_getI64(0);
+  @$pb.TagNumber(1)
+  set account($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get permission => $_getI64(1);
+  @$pb.TagNumber(2)
+  set permission($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPermission() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPermission() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get parent => $_getI64(2);
+  @$pb.TagNumber(3)
+  set parent($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasParent() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearParent() => clearField(3);
+
+  @$pb.TagNumber(4)
+  EosTxActionAck_EosAuthorization get auth => $_getN(3);
+  @$pb.TagNumber(4)
+  set auth(EosTxActionAck_EosAuthorization v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasAuth() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearAuth() => clearField(4);
+  @$pb.TagNumber(4)
+  EosTxActionAck_EosAuthorization ensureAuth() => $_ensure(3);
+}
+
+/// *
+///  Structure representing delete authorization.
+class EosTxActionAck_EosActionDeleteAuth extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosActionDeleteAuth({
+    $fixnum.Int64? account,
+    $fixnum.Int64? permission,
+  }) {
+    final $result = create();
+    if (account != null) {
+      $result.account = account;
+    }
+    if (permission != null) {
+      $result.permission = permission;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosActionDeleteAuth._() : super();
+  factory EosTxActionAck_EosActionDeleteAuth.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosActionDeleteAuth.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosActionDeleteAuth', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'account', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'permission', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionDeleteAuth clone() => EosTxActionAck_EosActionDeleteAuth()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionDeleteAuth copyWith(void Function(EosTxActionAck_EosActionDeleteAuth) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosActionDeleteAuth)) as EosTxActionAck_EosActionDeleteAuth;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionDeleteAuth create() => EosTxActionAck_EosActionDeleteAuth._();
+  EosTxActionAck_EosActionDeleteAuth createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosActionDeleteAuth> createRepeated() => $pb.PbList<EosTxActionAck_EosActionDeleteAuth>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionDeleteAuth getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosActionDeleteAuth>(create);
+  static EosTxActionAck_EosActionDeleteAuth? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get account => $_getI64(0);
+  @$pb.TagNumber(1)
+  set account($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get permission => $_getI64(1);
+  @$pb.TagNumber(2)
+  set permission($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPermission() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPermission() => clearField(2);
+}
+
+/// *
+///  Structure representing link authorization to action.
+class EosTxActionAck_EosActionLinkAuth extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosActionLinkAuth({
+    $fixnum.Int64? account,
+    $fixnum.Int64? code,
+    $fixnum.Int64? type,
+    $fixnum.Int64? requirement,
+  }) {
+    final $result = create();
+    if (account != null) {
+      $result.account = account;
+    }
+    if (code != null) {
+      $result.code = code;
+    }
+    if (type != null) {
+      $result.type = type;
+    }
+    if (requirement != null) {
+      $result.requirement = requirement;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosActionLinkAuth._() : super();
+  factory EosTxActionAck_EosActionLinkAuth.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosActionLinkAuth.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosActionLinkAuth', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'account', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'code', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'type', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'requirement', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionLinkAuth clone() => EosTxActionAck_EosActionLinkAuth()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionLinkAuth copyWith(void Function(EosTxActionAck_EosActionLinkAuth) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosActionLinkAuth)) as EosTxActionAck_EosActionLinkAuth;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionLinkAuth create() => EosTxActionAck_EosActionLinkAuth._();
+  EosTxActionAck_EosActionLinkAuth createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosActionLinkAuth> createRepeated() => $pb.PbList<EosTxActionAck_EosActionLinkAuth>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionLinkAuth getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosActionLinkAuth>(create);
+  static EosTxActionAck_EosActionLinkAuth? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get account => $_getI64(0);
+  @$pb.TagNumber(1)
+  set account($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get code => $_getI64(1);
+  @$pb.TagNumber(2)
+  set code($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasCode() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCode() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get type => $_getI64(2);
+  @$pb.TagNumber(3)
+  set type($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasType() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearType() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get requirement => $_getI64(3);
+  @$pb.TagNumber(4)
+  set requirement($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasRequirement() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearRequirement() => clearField(4);
+}
+
+/// *
+///  Structure representing unlink authorization from action.
+class EosTxActionAck_EosActionUnlinkAuth extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosActionUnlinkAuth({
+    $fixnum.Int64? account,
+    $fixnum.Int64? code,
+    $fixnum.Int64? type,
+  }) {
+    final $result = create();
+    if (account != null) {
+      $result.account = account;
+    }
+    if (code != null) {
+      $result.code = code;
+    }
+    if (type != null) {
+      $result.type = type;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosActionUnlinkAuth._() : super();
+  factory EosTxActionAck_EosActionUnlinkAuth.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosActionUnlinkAuth.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosActionUnlinkAuth', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'account', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'code', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'type', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionUnlinkAuth clone() => EosTxActionAck_EosActionUnlinkAuth()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionUnlinkAuth copyWith(void Function(EosTxActionAck_EosActionUnlinkAuth) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosActionUnlinkAuth)) as EosTxActionAck_EosActionUnlinkAuth;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionUnlinkAuth create() => EosTxActionAck_EosActionUnlinkAuth._();
+  EosTxActionAck_EosActionUnlinkAuth createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosActionUnlinkAuth> createRepeated() => $pb.PbList<EosTxActionAck_EosActionUnlinkAuth>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionUnlinkAuth getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosActionUnlinkAuth>(create);
+  static EosTxActionAck_EosActionUnlinkAuth? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get account => $_getI64(0);
+  @$pb.TagNumber(1)
+  set account($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get code => $_getI64(1);
+  @$pb.TagNumber(2)
+  set code($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasCode() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCode() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get type => $_getI64(2);
+  @$pb.TagNumber(3)
+  set type($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasType() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearType() => clearField(3);
+}
+
+/// *
+///  Structure representing creation of a new account.
+class EosTxActionAck_EosActionNewAccount extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosActionNewAccount({
+    $fixnum.Int64? creator,
+    $fixnum.Int64? name,
+    EosTxActionAck_EosAuthorization? owner,
+    EosTxActionAck_EosAuthorization? active,
+  }) {
+    final $result = create();
+    if (creator != null) {
+      $result.creator = creator;
+    }
+    if (name != null) {
+      $result.name = name;
+    }
+    if (owner != null) {
+      $result.owner = owner;
+    }
+    if (active != null) {
+      $result.active = active;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosActionNewAccount._() : super();
+  factory EosTxActionAck_EosActionNewAccount.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosActionNewAccount.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosActionNewAccount', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'creator', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'name', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aQM<EosTxActionAck_EosAuthorization>(3, _omitFieldNames ? '' : 'owner', subBuilder: EosTxActionAck_EosAuthorization.create)
+    ..aQM<EosTxActionAck_EosAuthorization>(4, _omitFieldNames ? '' : 'active', subBuilder: EosTxActionAck_EosAuthorization.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionNewAccount clone() => EosTxActionAck_EosActionNewAccount()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionNewAccount copyWith(void Function(EosTxActionAck_EosActionNewAccount) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosActionNewAccount)) as EosTxActionAck_EosActionNewAccount;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionNewAccount create() => EosTxActionAck_EosActionNewAccount._();
+  EosTxActionAck_EosActionNewAccount createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosActionNewAccount> createRepeated() => $pb.PbList<EosTxActionAck_EosActionNewAccount>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionNewAccount getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosActionNewAccount>(create);
+  static EosTxActionAck_EosActionNewAccount? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get creator => $_getI64(0);
+  @$pb.TagNumber(1)
+  set creator($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasCreator() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCreator() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get name => $_getI64(1);
+  @$pb.TagNumber(2)
+  set name($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasName() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearName() => clearField(2);
+
+  @$pb.TagNumber(3)
+  EosTxActionAck_EosAuthorization get owner => $_getN(2);
+  @$pb.TagNumber(3)
+  set owner(EosTxActionAck_EosAuthorization v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasOwner() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearOwner() => clearField(3);
+  @$pb.TagNumber(3)
+  EosTxActionAck_EosAuthorization ensureOwner() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  EosTxActionAck_EosAuthorization get active => $_getN(3);
+  @$pb.TagNumber(4)
+  set active(EosTxActionAck_EosAuthorization v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasActive() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearActive() => clearField(4);
+  @$pb.TagNumber(4)
+  EosTxActionAck_EosAuthorization ensureActive() => $_ensure(3);
+}
+
+/// *
+///  Structure representing actions not implemented above.
+class EosTxActionAck_EosActionUnknown extends $pb.GeneratedMessage {
+  factory EosTxActionAck_EosActionUnknown({
+    $core.int? dataSize,
+    $core.List<$core.int>? dataChunk,
+  }) {
+    final $result = create();
+    if (dataSize != null) {
+      $result.dataSize = dataSize;
+    }
+    if (dataChunk != null) {
+      $result.dataChunk = dataChunk;
+    }
+    return $result;
+  }
+  EosTxActionAck_EosActionUnknown._() : super();
+  factory EosTxActionAck_EosActionUnknown.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck_EosActionUnknown.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck.EosActionUnknown', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'dataSize', $pb.PbFieldType.QU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'dataChunk', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionUnknown clone() => EosTxActionAck_EosActionUnknown()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck_EosActionUnknown copyWith(void Function(EosTxActionAck_EosActionUnknown) updates) => super.copyWith((message) => updates(message as EosTxActionAck_EosActionUnknown)) as EosTxActionAck_EosActionUnknown;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionUnknown create() => EosTxActionAck_EosActionUnknown._();
+  EosTxActionAck_EosActionUnknown createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck_EosActionUnknown> createRepeated() => $pb.PbList<EosTxActionAck_EosActionUnknown>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck_EosActionUnknown getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck_EosActionUnknown>(create);
+  static EosTxActionAck_EosActionUnknown? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get dataSize => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set dataSize($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDataSize() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDataSize() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get dataChunk => $_getN(1);
+  @$pb.TagNumber(2)
+  set dataChunk($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasDataChunk() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearDataChunk() => clearField(2);
+}
+
+/// *
+///  Request: Next action data that needs to be uploaded
+///  @next EosTxActionRequest
+///  @next EosSignedTx
+///  @next Failure
+class EosTxActionAck extends $pb.GeneratedMessage {
+  factory EosTxActionAck({
+    EosTxActionAck_EosActionCommon? common,
+    EosTxActionAck_EosActionTransfer? transfer,
+    EosTxActionAck_EosActionDelegate? delegate,
+    EosTxActionAck_EosActionUndelegate? undelegate,
+    EosTxActionAck_EosActionRefund? refund,
+    EosTxActionAck_EosActionBuyRam? buyRam,
+    EosTxActionAck_EosActionBuyRamBytes? buyRamBytes,
+    EosTxActionAck_EosActionSellRam? sellRam,
+    EosTxActionAck_EosActionVoteProducer? voteProducer,
+    EosTxActionAck_EosActionUpdateAuth? updateAuth,
+    EosTxActionAck_EosActionDeleteAuth? deleteAuth,
+    EosTxActionAck_EosActionLinkAuth? linkAuth,
+    EosTxActionAck_EosActionUnlinkAuth? unlinkAuth,
+    EosTxActionAck_EosActionNewAccount? newAccount,
+    EosTxActionAck_EosActionUnknown? unknown,
+  }) {
+    final $result = create();
+    if (common != null) {
+      $result.common = common;
+    }
+    if (transfer != null) {
+      $result.transfer = transfer;
+    }
+    if (delegate != null) {
+      $result.delegate = delegate;
+    }
+    if (undelegate != null) {
+      $result.undelegate = undelegate;
+    }
+    if (refund != null) {
+      $result.refund = refund;
+    }
+    if (buyRam != null) {
+      $result.buyRam = buyRam;
+    }
+    if (buyRamBytes != null) {
+      $result.buyRamBytes = buyRamBytes;
+    }
+    if (sellRam != null) {
+      $result.sellRam = sellRam;
+    }
+    if (voteProducer != null) {
+      $result.voteProducer = voteProducer;
+    }
+    if (updateAuth != null) {
+      $result.updateAuth = updateAuth;
+    }
+    if (deleteAuth != null) {
+      $result.deleteAuth = deleteAuth;
+    }
+    if (linkAuth != null) {
+      $result.linkAuth = linkAuth;
+    }
+    if (unlinkAuth != null) {
+      $result.unlinkAuth = unlinkAuth;
+    }
+    if (newAccount != null) {
+      $result.newAccount = newAccount;
+    }
+    if (unknown != null) {
+      $result.unknown = unknown;
+    }
+    return $result;
+  }
+  EosTxActionAck._() : super();
+  factory EosTxActionAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosTxActionAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosTxActionAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..aQM<EosTxActionAck_EosActionCommon>(1, _omitFieldNames ? '' : 'common', subBuilder: EosTxActionAck_EosActionCommon.create)
+    ..aOM<EosTxActionAck_EosActionTransfer>(2, _omitFieldNames ? '' : 'transfer', subBuilder: EosTxActionAck_EosActionTransfer.create)
+    ..aOM<EosTxActionAck_EosActionDelegate>(3, _omitFieldNames ? '' : 'delegate', subBuilder: EosTxActionAck_EosActionDelegate.create)
+    ..aOM<EosTxActionAck_EosActionUndelegate>(4, _omitFieldNames ? '' : 'undelegate', subBuilder: EosTxActionAck_EosActionUndelegate.create)
+    ..aOM<EosTxActionAck_EosActionRefund>(5, _omitFieldNames ? '' : 'refund', subBuilder: EosTxActionAck_EosActionRefund.create)
+    ..aOM<EosTxActionAck_EosActionBuyRam>(6, _omitFieldNames ? '' : 'buyRam', subBuilder: EosTxActionAck_EosActionBuyRam.create)
+    ..aOM<EosTxActionAck_EosActionBuyRamBytes>(7, _omitFieldNames ? '' : 'buyRamBytes', subBuilder: EosTxActionAck_EosActionBuyRamBytes.create)
+    ..aOM<EosTxActionAck_EosActionSellRam>(8, _omitFieldNames ? '' : 'sellRam', subBuilder: EosTxActionAck_EosActionSellRam.create)
+    ..aOM<EosTxActionAck_EosActionVoteProducer>(9, _omitFieldNames ? '' : 'voteProducer', subBuilder: EosTxActionAck_EosActionVoteProducer.create)
+    ..aOM<EosTxActionAck_EosActionUpdateAuth>(10, _omitFieldNames ? '' : 'updateAuth', subBuilder: EosTxActionAck_EosActionUpdateAuth.create)
+    ..aOM<EosTxActionAck_EosActionDeleteAuth>(11, _omitFieldNames ? '' : 'deleteAuth', subBuilder: EosTxActionAck_EosActionDeleteAuth.create)
+    ..aOM<EosTxActionAck_EosActionLinkAuth>(12, _omitFieldNames ? '' : 'linkAuth', subBuilder: EosTxActionAck_EosActionLinkAuth.create)
+    ..aOM<EosTxActionAck_EosActionUnlinkAuth>(13, _omitFieldNames ? '' : 'unlinkAuth', subBuilder: EosTxActionAck_EosActionUnlinkAuth.create)
+    ..aOM<EosTxActionAck_EosActionNewAccount>(14, _omitFieldNames ? '' : 'newAccount', subBuilder: EosTxActionAck_EosActionNewAccount.create)
+    ..aOM<EosTxActionAck_EosActionUnknown>(15, _omitFieldNames ? '' : 'unknown', subBuilder: EosTxActionAck_EosActionUnknown.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck clone() => EosTxActionAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosTxActionAck copyWith(void Function(EosTxActionAck) updates) => super.copyWith((message) => updates(message as EosTxActionAck)) as EosTxActionAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck create() => EosTxActionAck._();
+  EosTxActionAck createEmptyInstance() => create();
+  static $pb.PbList<EosTxActionAck> createRepeated() => $pb.PbList<EosTxActionAck>();
+  @$core.pragma('dart2js:noInline')
+  static EosTxActionAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosTxActionAck>(create);
+  static EosTxActionAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  EosTxActionAck_EosActionCommon get common => $_getN(0);
+  @$pb.TagNumber(1)
+  set common(EosTxActionAck_EosActionCommon v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasCommon() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCommon() => clearField(1);
+  @$pb.TagNumber(1)
+  EosTxActionAck_EosActionCommon ensureCommon() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  EosTxActionAck_EosActionTransfer get transfer => $_getN(1);
+  @$pb.TagNumber(2)
+  set transfer(EosTxActionAck_EosActionTransfer v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTransfer() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTransfer() => clearField(2);
+  @$pb.TagNumber(2)
+  EosTxActionAck_EosActionTransfer ensureTransfer() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  EosTxActionAck_EosActionDelegate get delegate => $_getN(2);
+  @$pb.TagNumber(3)
+  set delegate(EosTxActionAck_EosActionDelegate v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasDelegate() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearDelegate() => clearField(3);
+  @$pb.TagNumber(3)
+  EosTxActionAck_EosActionDelegate ensureDelegate() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  EosTxActionAck_EosActionUndelegate get undelegate => $_getN(3);
+  @$pb.TagNumber(4)
+  set undelegate(EosTxActionAck_EosActionUndelegate v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasUndelegate() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearUndelegate() => clearField(4);
+  @$pb.TagNumber(4)
+  EosTxActionAck_EosActionUndelegate ensureUndelegate() => $_ensure(3);
+
+  @$pb.TagNumber(5)
+  EosTxActionAck_EosActionRefund get refund => $_getN(4);
+  @$pb.TagNumber(5)
+  set refund(EosTxActionAck_EosActionRefund v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasRefund() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearRefund() => clearField(5);
+  @$pb.TagNumber(5)
+  EosTxActionAck_EosActionRefund ensureRefund() => $_ensure(4);
+
+  @$pb.TagNumber(6)
+  EosTxActionAck_EosActionBuyRam get buyRam => $_getN(5);
+  @$pb.TagNumber(6)
+  set buyRam(EosTxActionAck_EosActionBuyRam v) { setField(6, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasBuyRam() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearBuyRam() => clearField(6);
+  @$pb.TagNumber(6)
+  EosTxActionAck_EosActionBuyRam ensureBuyRam() => $_ensure(5);
+
+  @$pb.TagNumber(7)
+  EosTxActionAck_EosActionBuyRamBytes get buyRamBytes => $_getN(6);
+  @$pb.TagNumber(7)
+  set buyRamBytes(EosTxActionAck_EosActionBuyRamBytes v) { setField(7, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasBuyRamBytes() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearBuyRamBytes() => clearField(7);
+  @$pb.TagNumber(7)
+  EosTxActionAck_EosActionBuyRamBytes ensureBuyRamBytes() => $_ensure(6);
+
+  @$pb.TagNumber(8)
+  EosTxActionAck_EosActionSellRam get sellRam => $_getN(7);
+  @$pb.TagNumber(8)
+  set sellRam(EosTxActionAck_EosActionSellRam v) { setField(8, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasSellRam() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearSellRam() => clearField(8);
+  @$pb.TagNumber(8)
+  EosTxActionAck_EosActionSellRam ensureSellRam() => $_ensure(7);
+
+  @$pb.TagNumber(9)
+  EosTxActionAck_EosActionVoteProducer get voteProducer => $_getN(8);
+  @$pb.TagNumber(9)
+  set voteProducer(EosTxActionAck_EosActionVoteProducer v) { setField(9, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasVoteProducer() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearVoteProducer() => clearField(9);
+  @$pb.TagNumber(9)
+  EosTxActionAck_EosActionVoteProducer ensureVoteProducer() => $_ensure(8);
+
+  @$pb.TagNumber(10)
+  EosTxActionAck_EosActionUpdateAuth get updateAuth => $_getN(9);
+  @$pb.TagNumber(10)
+  set updateAuth(EosTxActionAck_EosActionUpdateAuth v) { setField(10, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasUpdateAuth() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearUpdateAuth() => clearField(10);
+  @$pb.TagNumber(10)
+  EosTxActionAck_EosActionUpdateAuth ensureUpdateAuth() => $_ensure(9);
+
+  @$pb.TagNumber(11)
+  EosTxActionAck_EosActionDeleteAuth get deleteAuth => $_getN(10);
+  @$pb.TagNumber(11)
+  set deleteAuth(EosTxActionAck_EosActionDeleteAuth v) { setField(11, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasDeleteAuth() => $_has(10);
+  @$pb.TagNumber(11)
+  void clearDeleteAuth() => clearField(11);
+  @$pb.TagNumber(11)
+  EosTxActionAck_EosActionDeleteAuth ensureDeleteAuth() => $_ensure(10);
+
+  @$pb.TagNumber(12)
+  EosTxActionAck_EosActionLinkAuth get linkAuth => $_getN(11);
+  @$pb.TagNumber(12)
+  set linkAuth(EosTxActionAck_EosActionLinkAuth v) { setField(12, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasLinkAuth() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearLinkAuth() => clearField(12);
+  @$pb.TagNumber(12)
+  EosTxActionAck_EosActionLinkAuth ensureLinkAuth() => $_ensure(11);
+
+  @$pb.TagNumber(13)
+  EosTxActionAck_EosActionUnlinkAuth get unlinkAuth => $_getN(12);
+  @$pb.TagNumber(13)
+  set unlinkAuth(EosTxActionAck_EosActionUnlinkAuth v) { setField(13, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasUnlinkAuth() => $_has(12);
+  @$pb.TagNumber(13)
+  void clearUnlinkAuth() => clearField(13);
+  @$pb.TagNumber(13)
+  EosTxActionAck_EosActionUnlinkAuth ensureUnlinkAuth() => $_ensure(12);
+
+  @$pb.TagNumber(14)
+  EosTxActionAck_EosActionNewAccount get newAccount => $_getN(13);
+  @$pb.TagNumber(14)
+  set newAccount(EosTxActionAck_EosActionNewAccount v) { setField(14, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasNewAccount() => $_has(13);
+  @$pb.TagNumber(14)
+  void clearNewAccount() => clearField(14);
+  @$pb.TagNumber(14)
+  EosTxActionAck_EosActionNewAccount ensureNewAccount() => $_ensure(13);
+
+  @$pb.TagNumber(15)
+  EosTxActionAck_EosActionUnknown get unknown => $_getN(14);
+  @$pb.TagNumber(15)
+  set unknown(EosTxActionAck_EosActionUnknown v) { setField(15, v); }
+  @$pb.TagNumber(15)
+  $core.bool hasUnknown() => $_has(14);
+  @$pb.TagNumber(15)
+  void clearUnknown() => clearField(15);
+  @$pb.TagNumber(15)
+  EosTxActionAck_EosActionUnknown ensureUnknown() => $_ensure(14);
+}
+
+/// *
+///  Response: Device returns the signature.
+///  The signature_* fields contain the computed transaction signature. All three fields will be present.
+///  @end
+class EosSignedTx extends $pb.GeneratedMessage {
+  factory EosSignedTx({
+    $core.String? signature,
+  }) {
+    final $result = create();
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    return $result;
+  }
+  EosSignedTx._() : super();
+  factory EosSignedTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EosSignedTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EosSignedTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.eos'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'signature')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EosSignedTx clone() => EosSignedTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EosSignedTx copyWith(void Function(EosSignedTx) updates) => super.copyWith((message) => updates(message as EosSignedTx)) as EosSignedTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EosSignedTx create() => EosSignedTx._();
+  EosSignedTx createEmptyInstance() => create();
+  static $pb.PbList<EosSignedTx> createRepeated() => $pb.PbList<EosSignedTx>();
+  @$core.pragma('dart2js:noInline')
+  static EosSignedTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EosSignedTx>(create);
+  static EosSignedTx? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get signature => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set signature($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSignature() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSignature() => clearField(1);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-eos.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-eos.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-eos.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-eos.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-eos.pbjson.dart
@@ -1,0 +1,417 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-eos.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use eosGetPublicKeyDescriptor instead')
+const EosGetPublicKey$json = {
+  '1': 'EosGetPublicKey',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'show_display', '3': 2, '4': 1, '5': 8, '10': 'showDisplay'},
+    {'1': 'chunkify', '3': 3, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `EosGetPublicKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List eosGetPublicKeyDescriptor = $convert.base64Decode(
+    'Cg9Fb3NHZXRQdWJsaWNLZXkSGwoJYWRkcmVzc19uGAEgAygNUghhZGRyZXNzThIhCgxzaG93X2'
+    'Rpc3BsYXkYAiABKAhSC3Nob3dEaXNwbGF5EhoKCGNodW5raWZ5GAMgASgIUghjaHVua2lmeQ==');
+
+@$core.Deprecated('Use eosPublicKeyDescriptor instead')
+const EosPublicKey$json = {
+  '1': 'EosPublicKey',
+  '2': [
+    {'1': 'wif_public_key', '3': 1, '4': 2, '5': 9, '10': 'wifPublicKey'},
+    {'1': 'raw_public_key', '3': 2, '4': 2, '5': 12, '10': 'rawPublicKey'},
+  ],
+};
+
+/// Descriptor for `EosPublicKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List eosPublicKeyDescriptor = $convert.base64Decode(
+    'CgxFb3NQdWJsaWNLZXkSJAoOd2lmX3B1YmxpY19rZXkYASACKAlSDHdpZlB1YmxpY0tleRIkCg'
+    '5yYXdfcHVibGljX2tleRgCIAIoDFIMcmF3UHVibGljS2V5');
+
+@$core.Deprecated('Use eosSignTxDescriptor instead')
+const EosSignTx$json = {
+  '1': 'EosSignTx',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'chain_id', '3': 2, '4': 2, '5': 12, '10': 'chainId'},
+    {'1': 'header', '3': 3, '4': 2, '5': 11, '6': '.hw.trezor.messages.eos.EosSignTx.EosTxHeader', '10': 'header'},
+    {'1': 'num_actions', '3': 4, '4': 2, '5': 13, '10': 'numActions'},
+    {'1': 'chunkify', '3': 5, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+  '3': [EosSignTx_EosTxHeader$json],
+};
+
+@$core.Deprecated('Use eosSignTxDescriptor instead')
+const EosSignTx_EosTxHeader$json = {
+  '1': 'EosTxHeader',
+  '2': [
+    {'1': 'expiration', '3': 1, '4': 2, '5': 13, '10': 'expiration'},
+    {'1': 'ref_block_num', '3': 2, '4': 2, '5': 13, '10': 'refBlockNum'},
+    {'1': 'ref_block_prefix', '3': 3, '4': 2, '5': 13, '10': 'refBlockPrefix'},
+    {'1': 'max_net_usage_words', '3': 4, '4': 2, '5': 13, '10': 'maxNetUsageWords'},
+    {'1': 'max_cpu_usage_ms', '3': 5, '4': 2, '5': 13, '10': 'maxCpuUsageMs'},
+    {'1': 'delay_sec', '3': 6, '4': 2, '5': 13, '10': 'delaySec'},
+  ],
+};
+
+/// Descriptor for `EosSignTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List eosSignTxDescriptor = $convert.base64Decode(
+    'CglFb3NTaWduVHgSGwoJYWRkcmVzc19uGAEgAygNUghhZGRyZXNzThIZCghjaGFpbl9pZBgCIA'
+    'IoDFIHY2hhaW5JZBJFCgZoZWFkZXIYAyACKAsyLS5ody50cmV6b3IubWVzc2FnZXMuZW9zLkVv'
+    'c1NpZ25UeC5Fb3NUeEhlYWRlclIGaGVhZGVyEh8KC251bV9hY3Rpb25zGAQgAigNUgpudW1BY3'
+    'Rpb25zEhoKCGNodW5raWZ5GAUgASgIUghjaHVua2lmeRrwAQoLRW9zVHhIZWFkZXISHgoKZXhw'
+    'aXJhdGlvbhgBIAIoDVIKZXhwaXJhdGlvbhIiCg1yZWZfYmxvY2tfbnVtGAIgAigNUgtyZWZCbG'
+    '9ja051bRIoChByZWZfYmxvY2tfcHJlZml4GAMgAigNUg5yZWZCbG9ja1ByZWZpeBItChNtYXhf'
+    'bmV0X3VzYWdlX3dvcmRzGAQgAigNUhBtYXhOZXRVc2FnZVdvcmRzEicKEG1heF9jcHVfdXNhZ2'
+    'VfbXMYBSACKA1SDW1heENwdVVzYWdlTXMSGwoJZGVsYXlfc2VjGAYgAigNUghkZWxheVNlYw==');
+
+@$core.Deprecated('Use eosTxActionRequestDescriptor instead')
+const EosTxActionRequest$json = {
+  '1': 'EosTxActionRequest',
+  '2': [
+    {'1': 'data_size', '3': 1, '4': 1, '5': 13, '10': 'dataSize'},
+  ],
+};
+
+/// Descriptor for `EosTxActionRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List eosTxActionRequestDescriptor = $convert.base64Decode(
+    'ChJFb3NUeEFjdGlvblJlcXVlc3QSGwoJZGF0YV9zaXplGAEgASgNUghkYXRhU2l6ZQ==');
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck$json = {
+  '1': 'EosTxActionAck',
+  '2': [
+    {'1': 'common', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosActionCommon', '10': 'common'},
+    {'1': 'transfer', '3': 2, '4': 1, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosActionTransfer', '10': 'transfer'},
+    {'1': 'delegate', '3': 3, '4': 1, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosActionDelegate', '10': 'delegate'},
+    {'1': 'undelegate', '3': 4, '4': 1, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosActionUndelegate', '10': 'undelegate'},
+    {'1': 'refund', '3': 5, '4': 1, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosActionRefund', '10': 'refund'},
+    {'1': 'buy_ram', '3': 6, '4': 1, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosActionBuyRam', '10': 'buyRam'},
+    {'1': 'buy_ram_bytes', '3': 7, '4': 1, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosActionBuyRamBytes', '10': 'buyRamBytes'},
+    {'1': 'sell_ram', '3': 8, '4': 1, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosActionSellRam', '10': 'sellRam'},
+    {'1': 'vote_producer', '3': 9, '4': 1, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosActionVoteProducer', '10': 'voteProducer'},
+    {'1': 'update_auth', '3': 10, '4': 1, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosActionUpdateAuth', '10': 'updateAuth'},
+    {'1': 'delete_auth', '3': 11, '4': 1, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosActionDeleteAuth', '10': 'deleteAuth'},
+    {'1': 'link_auth', '3': 12, '4': 1, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosActionLinkAuth', '10': 'linkAuth'},
+    {'1': 'unlink_auth', '3': 13, '4': 1, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosActionUnlinkAuth', '10': 'unlinkAuth'},
+    {'1': 'new_account', '3': 14, '4': 1, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosActionNewAccount', '10': 'newAccount'},
+    {'1': 'unknown', '3': 15, '4': 1, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosActionUnknown', '10': 'unknown'},
+  ],
+  '3': [EosTxActionAck_EosAsset$json, EosTxActionAck_EosPermissionLevel$json, EosTxActionAck_EosAuthorizationKey$json, EosTxActionAck_EosAuthorizationAccount$json, EosTxActionAck_EosAuthorizationWait$json, EosTxActionAck_EosAuthorization$json, EosTxActionAck_EosActionCommon$json, EosTxActionAck_EosActionTransfer$json, EosTxActionAck_EosActionDelegate$json, EosTxActionAck_EosActionUndelegate$json, EosTxActionAck_EosActionRefund$json, EosTxActionAck_EosActionBuyRam$json, EosTxActionAck_EosActionBuyRamBytes$json, EosTxActionAck_EosActionSellRam$json, EosTxActionAck_EosActionVoteProducer$json, EosTxActionAck_EosActionUpdateAuth$json, EosTxActionAck_EosActionDeleteAuth$json, EosTxActionAck_EosActionLinkAuth$json, EosTxActionAck_EosActionUnlinkAuth$json, EosTxActionAck_EosActionNewAccount$json, EosTxActionAck_EosActionUnknown$json],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosAsset$json = {
+  '1': 'EosAsset',
+  '2': [
+    {'1': 'amount', '3': 1, '4': 2, '5': 18, '10': 'amount'},
+    {'1': 'symbol', '3': 2, '4': 2, '5': 4, '10': 'symbol'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosPermissionLevel$json = {
+  '1': 'EosPermissionLevel',
+  '2': [
+    {'1': 'actor', '3': 1, '4': 2, '5': 4, '10': 'actor'},
+    {'1': 'permission', '3': 2, '4': 2, '5': 4, '10': 'permission'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosAuthorizationKey$json = {
+  '1': 'EosAuthorizationKey',
+  '2': [
+    {'1': 'type', '3': 1, '4': 2, '5': 13, '10': 'type'},
+    {'1': 'key', '3': 2, '4': 1, '5': 12, '10': 'key'},
+    {'1': 'address_n', '3': 3, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'weight', '3': 4, '4': 2, '5': 13, '10': 'weight'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosAuthorizationAccount$json = {
+  '1': 'EosAuthorizationAccount',
+  '2': [
+    {'1': 'account', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosPermissionLevel', '10': 'account'},
+    {'1': 'weight', '3': 2, '4': 2, '5': 13, '10': 'weight'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosAuthorizationWait$json = {
+  '1': 'EosAuthorizationWait',
+  '2': [
+    {'1': 'wait_sec', '3': 1, '4': 2, '5': 13, '10': 'waitSec'},
+    {'1': 'weight', '3': 2, '4': 2, '5': 13, '10': 'weight'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosAuthorization$json = {
+  '1': 'EosAuthorization',
+  '2': [
+    {'1': 'threshold', '3': 1, '4': 2, '5': 13, '10': 'threshold'},
+    {'1': 'keys', '3': 2, '4': 3, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosAuthorizationKey', '10': 'keys'},
+    {'1': 'accounts', '3': 3, '4': 3, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosAuthorizationAccount', '10': 'accounts'},
+    {'1': 'waits', '3': 4, '4': 3, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosAuthorizationWait', '10': 'waits'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosActionCommon$json = {
+  '1': 'EosActionCommon',
+  '2': [
+    {'1': 'account', '3': 1, '4': 2, '5': 4, '10': 'account'},
+    {'1': 'name', '3': 2, '4': 2, '5': 4, '10': 'name'},
+    {'1': 'authorization', '3': 3, '4': 3, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosPermissionLevel', '10': 'authorization'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosActionTransfer$json = {
+  '1': 'EosActionTransfer',
+  '2': [
+    {'1': 'sender', '3': 1, '4': 2, '5': 4, '10': 'sender'},
+    {'1': 'receiver', '3': 2, '4': 2, '5': 4, '10': 'receiver'},
+    {'1': 'quantity', '3': 3, '4': 2, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosAsset', '10': 'quantity'},
+    {'1': 'memo', '3': 4, '4': 2, '5': 9, '10': 'memo'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosActionDelegate$json = {
+  '1': 'EosActionDelegate',
+  '2': [
+    {'1': 'sender', '3': 1, '4': 2, '5': 4, '10': 'sender'},
+    {'1': 'receiver', '3': 2, '4': 2, '5': 4, '10': 'receiver'},
+    {'1': 'net_quantity', '3': 3, '4': 2, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosAsset', '10': 'netQuantity'},
+    {'1': 'cpu_quantity', '3': 4, '4': 2, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosAsset', '10': 'cpuQuantity'},
+    {'1': 'transfer', '3': 5, '4': 2, '5': 8, '10': 'transfer'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosActionUndelegate$json = {
+  '1': 'EosActionUndelegate',
+  '2': [
+    {'1': 'sender', '3': 1, '4': 2, '5': 4, '10': 'sender'},
+    {'1': 'receiver', '3': 2, '4': 2, '5': 4, '10': 'receiver'},
+    {'1': 'net_quantity', '3': 3, '4': 2, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosAsset', '10': 'netQuantity'},
+    {'1': 'cpu_quantity', '3': 4, '4': 2, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosAsset', '10': 'cpuQuantity'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosActionRefund$json = {
+  '1': 'EosActionRefund',
+  '2': [
+    {'1': 'owner', '3': 1, '4': 2, '5': 4, '10': 'owner'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosActionBuyRam$json = {
+  '1': 'EosActionBuyRam',
+  '2': [
+    {'1': 'payer', '3': 1, '4': 2, '5': 4, '10': 'payer'},
+    {'1': 'receiver', '3': 2, '4': 2, '5': 4, '10': 'receiver'},
+    {'1': 'quantity', '3': 3, '4': 2, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosAsset', '10': 'quantity'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosActionBuyRamBytes$json = {
+  '1': 'EosActionBuyRamBytes',
+  '2': [
+    {'1': 'payer', '3': 1, '4': 2, '5': 4, '10': 'payer'},
+    {'1': 'receiver', '3': 2, '4': 2, '5': 4, '10': 'receiver'},
+    {'1': 'bytes', '3': 3, '4': 2, '5': 13, '10': 'bytes'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosActionSellRam$json = {
+  '1': 'EosActionSellRam',
+  '2': [
+    {'1': 'account', '3': 1, '4': 2, '5': 4, '10': 'account'},
+    {'1': 'bytes', '3': 2, '4': 2, '5': 4, '10': 'bytes'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosActionVoteProducer$json = {
+  '1': 'EosActionVoteProducer',
+  '2': [
+    {'1': 'voter', '3': 1, '4': 2, '5': 4, '10': 'voter'},
+    {'1': 'proxy', '3': 2, '4': 2, '5': 4, '10': 'proxy'},
+    {'1': 'producers', '3': 3, '4': 3, '5': 4, '10': 'producers'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosActionUpdateAuth$json = {
+  '1': 'EosActionUpdateAuth',
+  '2': [
+    {'1': 'account', '3': 1, '4': 2, '5': 4, '10': 'account'},
+    {'1': 'permission', '3': 2, '4': 2, '5': 4, '10': 'permission'},
+    {'1': 'parent', '3': 3, '4': 2, '5': 4, '10': 'parent'},
+    {'1': 'auth', '3': 4, '4': 2, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosAuthorization', '10': 'auth'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosActionDeleteAuth$json = {
+  '1': 'EosActionDeleteAuth',
+  '2': [
+    {'1': 'account', '3': 1, '4': 2, '5': 4, '10': 'account'},
+    {'1': 'permission', '3': 2, '4': 2, '5': 4, '10': 'permission'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosActionLinkAuth$json = {
+  '1': 'EosActionLinkAuth',
+  '2': [
+    {'1': 'account', '3': 1, '4': 2, '5': 4, '10': 'account'},
+    {'1': 'code', '3': 2, '4': 2, '5': 4, '10': 'code'},
+    {'1': 'type', '3': 3, '4': 2, '5': 4, '10': 'type'},
+    {'1': 'requirement', '3': 4, '4': 2, '5': 4, '10': 'requirement'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosActionUnlinkAuth$json = {
+  '1': 'EosActionUnlinkAuth',
+  '2': [
+    {'1': 'account', '3': 1, '4': 2, '5': 4, '10': 'account'},
+    {'1': 'code', '3': 2, '4': 2, '5': 4, '10': 'code'},
+    {'1': 'type', '3': 3, '4': 2, '5': 4, '10': 'type'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosActionNewAccount$json = {
+  '1': 'EosActionNewAccount',
+  '2': [
+    {'1': 'creator', '3': 1, '4': 2, '5': 4, '10': 'creator'},
+    {'1': 'name', '3': 2, '4': 2, '5': 4, '10': 'name'},
+    {'1': 'owner', '3': 3, '4': 2, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosAuthorization', '10': 'owner'},
+    {'1': 'active', '3': 4, '4': 2, '5': 11, '6': '.hw.trezor.messages.eos.EosTxActionAck.EosAuthorization', '10': 'active'},
+  ],
+};
+
+@$core.Deprecated('Use eosTxActionAckDescriptor instead')
+const EosTxActionAck_EosActionUnknown$json = {
+  '1': 'EosActionUnknown',
+  '2': [
+    {'1': 'data_size', '3': 1, '4': 2, '5': 13, '10': 'dataSize'},
+    {'1': 'data_chunk', '3': 2, '4': 2, '5': 12, '10': 'dataChunk'},
+  ],
+};
+
+/// Descriptor for `EosTxActionAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List eosTxActionAckDescriptor = $convert.base64Decode(
+    'Cg5Fb3NUeEFjdGlvbkFjaxJOCgZjb21tb24YASACKAsyNi5ody50cmV6b3IubWVzc2FnZXMuZW'
+    '9zLkVvc1R4QWN0aW9uQWNrLkVvc0FjdGlvbkNvbW1vblIGY29tbW9uElQKCHRyYW5zZmVyGAIg'
+    'ASgLMjguaHcudHJlem9yLm1lc3NhZ2VzLmVvcy5Fb3NUeEFjdGlvbkFjay5Fb3NBY3Rpb25Ucm'
+    'Fuc2ZlclIIdHJhbnNmZXISVAoIZGVsZWdhdGUYAyABKAsyOC5ody50cmV6b3IubWVzc2FnZXMu'
+    'ZW9zLkVvc1R4QWN0aW9uQWNrLkVvc0FjdGlvbkRlbGVnYXRlUghkZWxlZ2F0ZRJaCgp1bmRlbG'
+    'VnYXRlGAQgASgLMjouaHcudHJlem9yLm1lc3NhZ2VzLmVvcy5Fb3NUeEFjdGlvbkFjay5Fb3NB'
+    'Y3Rpb25VbmRlbGVnYXRlUgp1bmRlbGVnYXRlEk4KBnJlZnVuZBgFIAEoCzI2Lmh3LnRyZXpvci'
+    '5tZXNzYWdlcy5lb3MuRW9zVHhBY3Rpb25BY2suRW9zQWN0aW9uUmVmdW5kUgZyZWZ1bmQSTwoH'
+    'YnV5X3JhbRgGIAEoCzI2Lmh3LnRyZXpvci5tZXNzYWdlcy5lb3MuRW9zVHhBY3Rpb25BY2suRW'
+    '9zQWN0aW9uQnV5UmFtUgZidXlSYW0SXwoNYnV5X3JhbV9ieXRlcxgHIAEoCzI7Lmh3LnRyZXpv'
+    'ci5tZXNzYWdlcy5lb3MuRW9zVHhBY3Rpb25BY2suRW9zQWN0aW9uQnV5UmFtQnl0ZXNSC2J1eV'
+    'JhbUJ5dGVzElIKCHNlbGxfcmFtGAggASgLMjcuaHcudHJlem9yLm1lc3NhZ2VzLmVvcy5Fb3NU'
+    'eEFjdGlvbkFjay5Fb3NBY3Rpb25TZWxsUmFtUgdzZWxsUmFtEmEKDXZvdGVfcHJvZHVjZXIYCS'
+    'ABKAsyPC5ody50cmV6b3IubWVzc2FnZXMuZW9zLkVvc1R4QWN0aW9uQWNrLkVvc0FjdGlvblZv'
+    'dGVQcm9kdWNlclIMdm90ZVByb2R1Y2VyElsKC3VwZGF0ZV9hdXRoGAogASgLMjouaHcudHJlem'
+    '9yLm1lc3NhZ2VzLmVvcy5Fb3NUeEFjdGlvbkFjay5Fb3NBY3Rpb25VcGRhdGVBdXRoUgp1cGRh'
+    'dGVBdXRoElsKC2RlbGV0ZV9hdXRoGAsgASgLMjouaHcudHJlem9yLm1lc3NhZ2VzLmVvcy5Fb3'
+    'NUeEFjdGlvbkFjay5Fb3NBY3Rpb25EZWxldGVBdXRoUgpkZWxldGVBdXRoElUKCWxpbmtfYXV0'
+    'aBgMIAEoCzI4Lmh3LnRyZXpvci5tZXNzYWdlcy5lb3MuRW9zVHhBY3Rpb25BY2suRW9zQWN0aW'
+    '9uTGlua0F1dGhSCGxpbmtBdXRoElsKC3VubGlua19hdXRoGA0gASgLMjouaHcudHJlem9yLm1l'
+    'c3NhZ2VzLmVvcy5Fb3NUeEFjdGlvbkFjay5Fb3NBY3Rpb25VbmxpbmtBdXRoUgp1bmxpbmtBdX'
+    'RoElsKC25ld19hY2NvdW50GA4gASgLMjouaHcudHJlem9yLm1lc3NhZ2VzLmVvcy5Fb3NUeEFj'
+    'dGlvbkFjay5Fb3NBY3Rpb25OZXdBY2NvdW50UgpuZXdBY2NvdW50ElEKB3Vua25vd24YDyABKA'
+    'syNy5ody50cmV6b3IubWVzc2FnZXMuZW9zLkVvc1R4QWN0aW9uQWNrLkVvc0FjdGlvblVua25v'
+    'd25SB3Vua25vd24aOgoIRW9zQXNzZXQSFgoGYW1vdW50GAEgAigSUgZhbW91bnQSFgoGc3ltYm'
+    '9sGAIgAigEUgZzeW1ib2waSgoSRW9zUGVybWlzc2lvbkxldmVsEhQKBWFjdG9yGAEgAigEUgVh'
+    'Y3RvchIeCgpwZXJtaXNzaW9uGAIgAigEUgpwZXJtaXNzaW9uGnAKE0Vvc0F1dGhvcml6YXRpb2'
+    '5LZXkSEgoEdHlwZRgBIAIoDVIEdHlwZRIQCgNrZXkYAiABKAxSA2tleRIbCglhZGRyZXNzX24Y'
+    'AyADKA1SCGFkZHJlc3NOEhYKBndlaWdodBgEIAIoDVIGd2VpZ2h0GoYBChdFb3NBdXRob3Jpem'
+    'F0aW9uQWNjb3VudBJTCgdhY2NvdW50GAEgAigLMjkuaHcudHJlem9yLm1lc3NhZ2VzLmVvcy5F'
+    'b3NUeEFjdGlvbkFjay5Fb3NQZXJtaXNzaW9uTGV2ZWxSB2FjY291bnQSFgoGd2VpZ2h0GAIgAi'
+    'gNUgZ3ZWlnaHQaSQoURW9zQXV0aG9yaXphdGlvbldhaXQSGQoId2FpdF9zZWMYASACKA1SB3dh'
+    'aXRTZWMSFgoGd2VpZ2h0GAIgAigNUgZ3ZWlnaHQarwIKEEVvc0F1dGhvcml6YXRpb24SHAoJdG'
+    'hyZXNob2xkGAEgAigNUgl0aHJlc2hvbGQSTgoEa2V5cxgCIAMoCzI6Lmh3LnRyZXpvci5tZXNz'
+    'YWdlcy5lb3MuRW9zVHhBY3Rpb25BY2suRW9zQXV0aG9yaXphdGlvbktleVIEa2V5cxJaCghhY2'
+    'NvdW50cxgDIAMoCzI+Lmh3LnRyZXpvci5tZXNzYWdlcy5lb3MuRW9zVHhBY3Rpb25BY2suRW9z'
+    'QXV0aG9yaXphdGlvbkFjY291bnRSCGFjY291bnRzElEKBXdhaXRzGAQgAygLMjsuaHcudHJlem'
+    '9yLm1lc3NhZ2VzLmVvcy5Fb3NUeEFjdGlvbkFjay5Fb3NBdXRob3JpemF0aW9uV2FpdFIFd2Fp'
+    'dHMaoAEKD0Vvc0FjdGlvbkNvbW1vbhIYCgdhY2NvdW50GAEgAigEUgdhY2NvdW50EhIKBG5hbW'
+    'UYAiACKARSBG5hbWUSXwoNYXV0aG9yaXphdGlvbhgDIAMoCzI5Lmh3LnRyZXpvci5tZXNzYWdl'
+    'cy5lb3MuRW9zVHhBY3Rpb25BY2suRW9zUGVybWlzc2lvbkxldmVsUg1hdXRob3JpemF0aW9uGq'
+    'gBChFFb3NBY3Rpb25UcmFuc2ZlchIWCgZzZW5kZXIYASACKARSBnNlbmRlchIaCghyZWNlaXZl'
+    'chgCIAIoBFIIcmVjZWl2ZXISSwoIcXVhbnRpdHkYAyACKAsyLy5ody50cmV6b3IubWVzc2FnZX'
+    'MuZW9zLkVvc1R4QWN0aW9uQWNrLkVvc0Fzc2V0UghxdWFudGl0eRISCgRtZW1vGAQgAigJUgRt'
+    'ZW1vGosCChFFb3NBY3Rpb25EZWxlZ2F0ZRIWCgZzZW5kZXIYASACKARSBnNlbmRlchIaCghyZW'
+    'NlaXZlchgCIAIoBFIIcmVjZWl2ZXISUgoMbmV0X3F1YW50aXR5GAMgAigLMi8uaHcudHJlem9y'
+    'Lm1lc3NhZ2VzLmVvcy5Fb3NUeEFjdGlvbkFjay5Fb3NBc3NldFILbmV0UXVhbnRpdHkSUgoMY3'
+    'B1X3F1YW50aXR5GAQgAigLMi8uaHcudHJlem9yLm1lc3NhZ2VzLmVvcy5Fb3NUeEFjdGlvbkFj'
+    'ay5Fb3NBc3NldFILY3B1UXVhbnRpdHkSGgoIdHJhbnNmZXIYBSACKAhSCHRyYW5zZmVyGvEBCh'
+    'NFb3NBY3Rpb25VbmRlbGVnYXRlEhYKBnNlbmRlchgBIAIoBFIGc2VuZGVyEhoKCHJlY2VpdmVy'
+    'GAIgAigEUghyZWNlaXZlchJSCgxuZXRfcXVhbnRpdHkYAyACKAsyLy5ody50cmV6b3IubWVzc2'
+    'FnZXMuZW9zLkVvc1R4QWN0aW9uQWNrLkVvc0Fzc2V0UgtuZXRRdWFudGl0eRJSCgxjcHVfcXVh'
+    'bnRpdHkYBCACKAsyLy5ody50cmV6b3IubWVzc2FnZXMuZW9zLkVvc1R4QWN0aW9uQWNrLkVvc0'
+    'Fzc2V0UgtjcHVRdWFudGl0eRonCg9Fb3NBY3Rpb25SZWZ1bmQSFAoFb3duZXIYASACKARSBW93'
+    'bmVyGpABCg9Fb3NBY3Rpb25CdXlSYW0SFAoFcGF5ZXIYASACKARSBXBheWVyEhoKCHJlY2Vpdm'
+    'VyGAIgAigEUghyZWNlaXZlchJLCghxdWFudGl0eRgDIAIoCzIvLmh3LnRyZXpvci5tZXNzYWdl'
+    'cy5lb3MuRW9zVHhBY3Rpb25BY2suRW9zQXNzZXRSCHF1YW50aXR5Gl4KFEVvc0FjdGlvbkJ1eV'
+    'JhbUJ5dGVzEhQKBXBheWVyGAEgAigEUgVwYXllchIaCghyZWNlaXZlchgCIAIoBFIIcmVjZWl2'
+    'ZXISFAoFYnl0ZXMYAyACKA1SBWJ5dGVzGkIKEEVvc0FjdGlvblNlbGxSYW0SGAoHYWNjb3VudB'
+    'gBIAIoBFIHYWNjb3VudBIUCgVieXRlcxgCIAIoBFIFYnl0ZXMaYQoVRW9zQWN0aW9uVm90ZVBy'
+    'b2R1Y2VyEhQKBXZvdGVyGAEgAigEUgV2b3RlchIUCgVwcm94eRgCIAIoBFIFcHJveHkSHAoJcH'
+    'JvZHVjZXJzGAMgAygEUglwcm9kdWNlcnMatAEKE0Vvc0FjdGlvblVwZGF0ZUF1dGgSGAoHYWNj'
+    'b3VudBgBIAIoBFIHYWNjb3VudBIeCgpwZXJtaXNzaW9uGAIgAigEUgpwZXJtaXNzaW9uEhYKBn'
+    'BhcmVudBgDIAIoBFIGcGFyZW50EksKBGF1dGgYBCACKAsyNy5ody50cmV6b3IubWVzc2FnZXMu'
+    'ZW9zLkVvc1R4QWN0aW9uQWNrLkVvc0F1dGhvcml6YXRpb25SBGF1dGgaTwoTRW9zQWN0aW9uRG'
+    'VsZXRlQXV0aBIYCgdhY2NvdW50GAEgAigEUgdhY2NvdW50Eh4KCnBlcm1pc3Npb24YAiACKARS'
+    'CnBlcm1pc3Npb24adwoRRW9zQWN0aW9uTGlua0F1dGgSGAoHYWNjb3VudBgBIAIoBFIHYWNjb3'
+    'VudBISCgRjb2RlGAIgAigEUgRjb2RlEhIKBHR5cGUYAyACKARSBHR5cGUSIAoLcmVxdWlyZW1l'
+    'bnQYBCACKARSC3JlcXVpcmVtZW50GlcKE0Vvc0FjdGlvblVubGlua0F1dGgSGAoHYWNjb3VudB'
+    'gBIAIoBFIHYWNjb3VudBISCgRjb2RlGAIgAigEUgRjb2RlEhIKBHR5cGUYAyACKARSBHR5cGUa'
+    '4wEKE0Vvc0FjdGlvbk5ld0FjY291bnQSGAoHY3JlYXRvchgBIAIoBFIHY3JlYXRvchISCgRuYW'
+    '1lGAIgAigEUgRuYW1lEk0KBW93bmVyGAMgAigLMjcuaHcudHJlem9yLm1lc3NhZ2VzLmVvcy5F'
+    'b3NUeEFjdGlvbkFjay5Fb3NBdXRob3JpemF0aW9uUgVvd25lchJPCgZhY3RpdmUYBCACKAsyNy'
+    '5ody50cmV6b3IubWVzc2FnZXMuZW9zLkVvc1R4QWN0aW9uQWNrLkVvc0F1dGhvcml6YXRpb25S'
+    'BmFjdGl2ZRpOChBFb3NBY3Rpb25Vbmtub3duEhsKCWRhdGFfc2l6ZRgBIAIoDVIIZGF0YVNpem'
+    'USHQoKZGF0YV9jaHVuaxgCIAIoDFIJZGF0YUNodW5r');
+
+@$core.Deprecated('Use eosSignedTxDescriptor instead')
+const EosSignedTx$json = {
+  '1': 'EosSignedTx',
+  '2': [
+    {'1': 'signature', '3': 1, '4': 2, '5': 9, '10': 'signature'},
+  ],
+};
+
+/// Descriptor for `EosSignedTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List eosSignedTxDescriptor = $convert.base64Decode(
+    'CgtFb3NTaWduZWRUeBIcCglzaWduYXR1cmUYASACKAlSCXNpZ25hdHVyZQ==');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-eos.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-eos.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-eos.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-eos.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-definitions.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-definitions.pb.dart
@@ -1,0 +1,302 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ethereum-definitions.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+export 'messages-ethereum-definitions.pbenum.dart';
+
+/// *
+///  Ethereum network definition. Used to (de)serialize the definition.
+///
+///  Definition types should not be cross-parseable, i.e., it should not be possible to
+///  incorrectly parse network info as token info or vice versa.
+///  To achieve that, the first field is wire type varint while the second field is wire type
+///  length-delimited. Both are a mismatch for the token definition.
+///
+///  @embed
+class EthereumNetworkInfo extends $pb.GeneratedMessage {
+  factory EthereumNetworkInfo({
+    $fixnum.Int64? chainId,
+    $core.String? symbol,
+    $core.int? slip44,
+    $core.String? name,
+  }) {
+    final $result = create();
+    if (chainId != null) {
+      $result.chainId = chainId;
+    }
+    if (symbol != null) {
+      $result.symbol = symbol;
+    }
+    if (slip44 != null) {
+      $result.slip44 = slip44;
+    }
+    if (name != null) {
+      $result.name = name;
+    }
+    return $result;
+  }
+  EthereumNetworkInfo._() : super();
+  factory EthereumNetworkInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumNetworkInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumNetworkInfo', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum_definitions'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'chainId', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aQS(2, _omitFieldNames ? '' : 'symbol')
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'slip44', $pb.PbFieldType.QU3)
+    ..aQS(4, _omitFieldNames ? '' : 'name')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumNetworkInfo clone() => EthereumNetworkInfo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumNetworkInfo copyWith(void Function(EthereumNetworkInfo) updates) => super.copyWith((message) => updates(message as EthereumNetworkInfo)) as EthereumNetworkInfo;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumNetworkInfo create() => EthereumNetworkInfo._();
+  EthereumNetworkInfo createEmptyInstance() => create();
+  static $pb.PbList<EthereumNetworkInfo> createRepeated() => $pb.PbList<EthereumNetworkInfo>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumNetworkInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumNetworkInfo>(create);
+  static EthereumNetworkInfo? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get chainId => $_getI64(0);
+  @$pb.TagNumber(1)
+  set chainId($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasChainId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearChainId() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get symbol => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set symbol($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSymbol() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSymbol() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get slip44 => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set slip44($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSlip44() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSlip44() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get name => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set name($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasName() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearName() => clearField(4);
+}
+
+/// *
+///  Ethereum token definition. Used to (de)serialize the definition.
+///
+///  Definition types should not be cross-parseable, i.e., it should not be possible to
+///  incorrectly parse network info as token info or vice versa.
+///  To achieve that, the first field is wire type length-delimited while the second field
+///  is wire type varint. Both are a mismatch for the network definition.
+///
+///  @embed
+class EthereumTokenInfo extends $pb.GeneratedMessage {
+  factory EthereumTokenInfo({
+    $core.List<$core.int>? address,
+    $fixnum.Int64? chainId,
+    $core.String? symbol,
+    $core.int? decimals,
+    $core.String? name,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    if (chainId != null) {
+      $result.chainId = chainId;
+    }
+    if (symbol != null) {
+      $result.symbol = symbol;
+    }
+    if (decimals != null) {
+      $result.decimals = decimals;
+    }
+    if (name != null) {
+      $result.name = name;
+    }
+    return $result;
+  }
+  EthereumTokenInfo._() : super();
+  factory EthereumTokenInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumTokenInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumTokenInfo', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum_definitions'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'address', $pb.PbFieldType.QY)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'chainId', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aQS(3, _omitFieldNames ? '' : 'symbol')
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'decimals', $pb.PbFieldType.QU3)
+    ..aQS(5, _omitFieldNames ? '' : 'name')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumTokenInfo clone() => EthereumTokenInfo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumTokenInfo copyWith(void Function(EthereumTokenInfo) updates) => super.copyWith((message) => updates(message as EthereumTokenInfo)) as EthereumTokenInfo;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumTokenInfo create() => EthereumTokenInfo._();
+  EthereumTokenInfo createEmptyInstance() => create();
+  static $pb.PbList<EthereumTokenInfo> createRepeated() => $pb.PbList<EthereumTokenInfo>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumTokenInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumTokenInfo>(create);
+  static EthereumTokenInfo? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get address => $_getN(0);
+  @$pb.TagNumber(1)
+  set address($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get chainId => $_getI64(1);
+  @$pb.TagNumber(2)
+  set chainId($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasChainId() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearChainId() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get symbol => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set symbol($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSymbol() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSymbol() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get decimals => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set decimals($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasDecimals() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearDecimals() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.String get name => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set name($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasName() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearName() => clearField(5);
+}
+
+/// *
+///  Contains an encoded Ethereum network and/or token definition. See ethereum-definitions.md for details.
+///  @embed
+class EthereumDefinitions extends $pb.GeneratedMessage {
+  factory EthereumDefinitions({
+    $core.List<$core.int>? encodedNetwork,
+    $core.List<$core.int>? encodedToken,
+  }) {
+    final $result = create();
+    if (encodedNetwork != null) {
+      $result.encodedNetwork = encodedNetwork;
+    }
+    if (encodedToken != null) {
+      $result.encodedToken = encodedToken;
+    }
+    return $result;
+  }
+  EthereumDefinitions._() : super();
+  factory EthereumDefinitions.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumDefinitions.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumDefinitions', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum_definitions'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'encodedNetwork', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'encodedToken', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumDefinitions clone() => EthereumDefinitions()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumDefinitions copyWith(void Function(EthereumDefinitions) updates) => super.copyWith((message) => updates(message as EthereumDefinitions)) as EthereumDefinitions;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumDefinitions create() => EthereumDefinitions._();
+  EthereumDefinitions createEmptyInstance() => create();
+  static $pb.PbList<EthereumDefinitions> createRepeated() => $pb.PbList<EthereumDefinitions>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumDefinitions getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumDefinitions>(create);
+  static EthereumDefinitions? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get encodedNetwork => $_getN(0);
+  @$pb.TagNumber(1)
+  set encodedNetwork($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasEncodedNetwork() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearEncodedNetwork() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get encodedToken => $_getN(1);
+  @$pb.TagNumber(2)
+  set encodedToken($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasEncodedToken() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearEncodedToken() => clearField(2);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-definitions.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-definitions.pbenum.dart
@@ -1,0 +1,35 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ethereum-definitions.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+/// *
+///  Ethereum definitions type enum.
+///  Used to check the encoded EthereumNetworkInfo or EthereumTokenInfo message.
+class EthereumDefinitionType extends $pb.ProtobufEnum {
+  static const EthereumDefinitionType NETWORK = EthereumDefinitionType._(0, _omitEnumNames ? '' : 'NETWORK');
+  static const EthereumDefinitionType TOKEN = EthereumDefinitionType._(1, _omitEnumNames ? '' : 'TOKEN');
+
+  static const $core.List<EthereumDefinitionType> values = <EthereumDefinitionType> [
+    NETWORK,
+    TOKEN,
+  ];
+
+  static final $core.Map<$core.int, EthereumDefinitionType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static EthereumDefinitionType? valueOf($core.int value) => _byValue[value];
+
+  const EthereumDefinitionType._($core.int v, $core.String n) : super(v, n);
+}
+
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-definitions.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-definitions.pbjson.dart
@@ -1,0 +1,77 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ethereum-definitions.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use ethereumDefinitionTypeDescriptor instead')
+const EthereumDefinitionType$json = {
+  '1': 'EthereumDefinitionType',
+  '2': [
+    {'1': 'NETWORK', '2': 0},
+    {'1': 'TOKEN', '2': 1},
+  ],
+};
+
+/// Descriptor for `EthereumDefinitionType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List ethereumDefinitionTypeDescriptor = $convert.base64Decode(
+    'ChZFdGhlcmV1bURlZmluaXRpb25UeXBlEgsKB05FVFdPUksQABIJCgVUT0tFThAB');
+
+@$core.Deprecated('Use ethereumNetworkInfoDescriptor instead')
+const EthereumNetworkInfo$json = {
+  '1': 'EthereumNetworkInfo',
+  '2': [
+    {'1': 'chain_id', '3': 1, '4': 2, '5': 4, '10': 'chainId'},
+    {'1': 'symbol', '3': 2, '4': 2, '5': 9, '10': 'symbol'},
+    {'1': 'slip44', '3': 3, '4': 2, '5': 13, '10': 'slip44'},
+    {'1': 'name', '3': 4, '4': 2, '5': 9, '10': 'name'},
+  ],
+};
+
+/// Descriptor for `EthereumNetworkInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumNetworkInfoDescriptor = $convert.base64Decode(
+    'ChNFdGhlcmV1bU5ldHdvcmtJbmZvEhkKCGNoYWluX2lkGAEgAigEUgdjaGFpbklkEhYKBnN5bW'
+    'JvbBgCIAIoCVIGc3ltYm9sEhYKBnNsaXA0NBgDIAIoDVIGc2xpcDQ0EhIKBG5hbWUYBCACKAlS'
+    'BG5hbWU=');
+
+@$core.Deprecated('Use ethereumTokenInfoDescriptor instead')
+const EthereumTokenInfo$json = {
+  '1': 'EthereumTokenInfo',
+  '2': [
+    {'1': 'address', '3': 1, '4': 2, '5': 12, '10': 'address'},
+    {'1': 'chain_id', '3': 2, '4': 2, '5': 4, '10': 'chainId'},
+    {'1': 'symbol', '3': 3, '4': 2, '5': 9, '10': 'symbol'},
+    {'1': 'decimals', '3': 4, '4': 2, '5': 13, '10': 'decimals'},
+    {'1': 'name', '3': 5, '4': 2, '5': 9, '10': 'name'},
+  ],
+};
+
+/// Descriptor for `EthereumTokenInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumTokenInfoDescriptor = $convert.base64Decode(
+    'ChFFdGhlcmV1bVRva2VuSW5mbxIYCgdhZGRyZXNzGAEgAigMUgdhZGRyZXNzEhkKCGNoYWluX2'
+    'lkGAIgAigEUgdjaGFpbklkEhYKBnN5bWJvbBgDIAIoCVIGc3ltYm9sEhoKCGRlY2ltYWxzGAQg'
+    'AigNUghkZWNpbWFscxISCgRuYW1lGAUgAigJUgRuYW1l');
+
+@$core.Deprecated('Use ethereumDefinitionsDescriptor instead')
+const EthereumDefinitions$json = {
+  '1': 'EthereumDefinitions',
+  '2': [
+    {'1': 'encoded_network', '3': 1, '4': 1, '5': 12, '10': 'encodedNetwork'},
+    {'1': 'encoded_token', '3': 2, '4': 1, '5': 12, '10': 'encodedToken'},
+  ],
+};
+
+/// Descriptor for `EthereumDefinitions`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumDefinitionsDescriptor = $convert.base64Decode(
+    'ChNFdGhlcmV1bURlZmluaXRpb25zEicKD2VuY29kZWRfbmV0d29yaxgBIAEoDFIOZW5jb2RlZE'
+    '5ldHdvcmsSIwoNZW5jb2RlZF90b2tlbhgCIAEoDFIMZW5jb2RlZFRva2Vu');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-definitions.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-definitions.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ethereum-definitions.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-ethereum-definitions.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-eip712.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-eip712.pb.dart
@@ -1,0 +1,476 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ethereum-eip712.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'messages-ethereum-definitions.pb.dart' as $0;
+import 'messages-ethereum-eip712.pbenum.dart';
+
+export 'messages-ethereum-eip712.pbenum.dart';
+
+/// *
+///  Request: Ask device to sign typed data
+///  @start
+///  @next EthereumTypedDataStructRequest
+///  @next EthereumTypedDataValueRequest
+///  @next EthereumTypedDataSignature
+///  @next Failure
+class EthereumSignTypedData extends $pb.GeneratedMessage {
+  factory EthereumSignTypedData({
+    $core.Iterable<$core.int>? addressN,
+    $core.String? primaryType,
+    $core.bool? metamaskV4Compat,
+    $0.EthereumDefinitions? definitions,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (primaryType != null) {
+      $result.primaryType = primaryType;
+    }
+    if (metamaskV4Compat != null) {
+      $result.metamaskV4Compat = metamaskV4Compat;
+    }
+    if (definitions != null) {
+      $result.definitions = definitions;
+    }
+    return $result;
+  }
+  EthereumSignTypedData._() : super();
+  factory EthereumSignTypedData.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumSignTypedData.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumSignTypedData', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum_eip712'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aQS(2, _omitFieldNames ? '' : 'primaryType')
+    ..a<$core.bool>(3, _omitFieldNames ? '' : 'metamaskV4Compat', $pb.PbFieldType.OB, defaultOrMaker: true)
+    ..aOM<$0.EthereumDefinitions>(4, _omitFieldNames ? '' : 'definitions', subBuilder: $0.EthereumDefinitions.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumSignTypedData clone() => EthereumSignTypedData()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumSignTypedData copyWith(void Function(EthereumSignTypedData) updates) => super.copyWith((message) => updates(message as EthereumSignTypedData)) as EthereumSignTypedData;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumSignTypedData create() => EthereumSignTypedData._();
+  EthereumSignTypedData createEmptyInstance() => create();
+  static $pb.PbList<EthereumSignTypedData> createRepeated() => $pb.PbList<EthereumSignTypedData>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumSignTypedData getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumSignTypedData>(create);
+  static EthereumSignTypedData? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.String get primaryType => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set primaryType($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPrimaryType() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPrimaryType() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get metamaskV4Compat => $_getB(2, true);
+  @$pb.TagNumber(3)
+  set metamaskV4Compat($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasMetamaskV4Compat() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearMetamaskV4Compat() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $0.EthereumDefinitions get definitions => $_getN(3);
+  @$pb.TagNumber(4)
+  set definitions($0.EthereumDefinitions v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasDefinitions() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearDefinitions() => clearField(4);
+  @$pb.TagNumber(4)
+  $0.EthereumDefinitions ensureDefinitions() => $_ensure(3);
+}
+
+/// *
+///  Response: Device asks for type information about a struct.
+///  @next EthereumTypedDataStructAck
+class EthereumTypedDataStructRequest extends $pb.GeneratedMessage {
+  factory EthereumTypedDataStructRequest({
+    $core.String? name,
+  }) {
+    final $result = create();
+    if (name != null) {
+      $result.name = name;
+    }
+    return $result;
+  }
+  EthereumTypedDataStructRequest._() : super();
+  factory EthereumTypedDataStructRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumTypedDataStructRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumTypedDataStructRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum_eip712'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'name')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumTypedDataStructRequest clone() => EthereumTypedDataStructRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumTypedDataStructRequest copyWith(void Function(EthereumTypedDataStructRequest) updates) => super.copyWith((message) => updates(message as EthereumTypedDataStructRequest)) as EthereumTypedDataStructRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumTypedDataStructRequest create() => EthereumTypedDataStructRequest._();
+  EthereumTypedDataStructRequest createEmptyInstance() => create();
+  static $pb.PbList<EthereumTypedDataStructRequest> createRepeated() => $pb.PbList<EthereumTypedDataStructRequest>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumTypedDataStructRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumTypedDataStructRequest>(create);
+  static EthereumTypedDataStructRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => clearField(1);
+}
+
+class EthereumTypedDataStructAck_EthereumStructMember extends $pb.GeneratedMessage {
+  factory EthereumTypedDataStructAck_EthereumStructMember({
+    EthereumTypedDataStructAck_EthereumFieldType? type,
+    $core.String? name,
+  }) {
+    final $result = create();
+    if (type != null) {
+      $result.type = type;
+    }
+    if (name != null) {
+      $result.name = name;
+    }
+    return $result;
+  }
+  EthereumTypedDataStructAck_EthereumStructMember._() : super();
+  factory EthereumTypedDataStructAck_EthereumStructMember.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumTypedDataStructAck_EthereumStructMember.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumTypedDataStructAck.EthereumStructMember', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum_eip712'), createEmptyInstance: create)
+    ..aQM<EthereumTypedDataStructAck_EthereumFieldType>(1, _omitFieldNames ? '' : 'type', subBuilder: EthereumTypedDataStructAck_EthereumFieldType.create)
+    ..aQS(2, _omitFieldNames ? '' : 'name')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumTypedDataStructAck_EthereumStructMember clone() => EthereumTypedDataStructAck_EthereumStructMember()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumTypedDataStructAck_EthereumStructMember copyWith(void Function(EthereumTypedDataStructAck_EthereumStructMember) updates) => super.copyWith((message) => updates(message as EthereumTypedDataStructAck_EthereumStructMember)) as EthereumTypedDataStructAck_EthereumStructMember;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumTypedDataStructAck_EthereumStructMember create() => EthereumTypedDataStructAck_EthereumStructMember._();
+  EthereumTypedDataStructAck_EthereumStructMember createEmptyInstance() => create();
+  static $pb.PbList<EthereumTypedDataStructAck_EthereumStructMember> createRepeated() => $pb.PbList<EthereumTypedDataStructAck_EthereumStructMember>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumTypedDataStructAck_EthereumStructMember getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumTypedDataStructAck_EthereumStructMember>(create);
+  static EthereumTypedDataStructAck_EthereumStructMember? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  EthereumTypedDataStructAck_EthereumFieldType get type => $_getN(0);
+  @$pb.TagNumber(1)
+  set type(EthereumTypedDataStructAck_EthereumFieldType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearType() => clearField(1);
+  @$pb.TagNumber(1)
+  EthereumTypedDataStructAck_EthereumFieldType ensureType() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $core.String get name => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set name($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasName() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearName() => clearField(2);
+}
+
+class EthereumTypedDataStructAck_EthereumFieldType extends $pb.GeneratedMessage {
+  factory EthereumTypedDataStructAck_EthereumFieldType({
+    EthereumTypedDataStructAck_EthereumDataType? dataType,
+    $core.int? size,
+    EthereumTypedDataStructAck_EthereumFieldType? entryType,
+    $core.String? structName,
+  }) {
+    final $result = create();
+    if (dataType != null) {
+      $result.dataType = dataType;
+    }
+    if (size != null) {
+      $result.size = size;
+    }
+    if (entryType != null) {
+      $result.entryType = entryType;
+    }
+    if (structName != null) {
+      $result.structName = structName;
+    }
+    return $result;
+  }
+  EthereumTypedDataStructAck_EthereumFieldType._() : super();
+  factory EthereumTypedDataStructAck_EthereumFieldType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumTypedDataStructAck_EthereumFieldType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumTypedDataStructAck.EthereumFieldType', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum_eip712'), createEmptyInstance: create)
+    ..e<EthereumTypedDataStructAck_EthereumDataType>(1, _omitFieldNames ? '' : 'dataType', $pb.PbFieldType.QE, defaultOrMaker: EthereumTypedDataStructAck_EthereumDataType.UINT, valueOf: EthereumTypedDataStructAck_EthereumDataType.valueOf, enumValues: EthereumTypedDataStructAck_EthereumDataType.values)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'size', $pb.PbFieldType.OU3)
+    ..aOM<EthereumTypedDataStructAck_EthereumFieldType>(3, _omitFieldNames ? '' : 'entryType', subBuilder: EthereumTypedDataStructAck_EthereumFieldType.create)
+    ..aOS(4, _omitFieldNames ? '' : 'structName')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumTypedDataStructAck_EthereumFieldType clone() => EthereumTypedDataStructAck_EthereumFieldType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumTypedDataStructAck_EthereumFieldType copyWith(void Function(EthereumTypedDataStructAck_EthereumFieldType) updates) => super.copyWith((message) => updates(message as EthereumTypedDataStructAck_EthereumFieldType)) as EthereumTypedDataStructAck_EthereumFieldType;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumTypedDataStructAck_EthereumFieldType create() => EthereumTypedDataStructAck_EthereumFieldType._();
+  EthereumTypedDataStructAck_EthereumFieldType createEmptyInstance() => create();
+  static $pb.PbList<EthereumTypedDataStructAck_EthereumFieldType> createRepeated() => $pb.PbList<EthereumTypedDataStructAck_EthereumFieldType>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumTypedDataStructAck_EthereumFieldType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumTypedDataStructAck_EthereumFieldType>(create);
+  static EthereumTypedDataStructAck_EthereumFieldType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  EthereumTypedDataStructAck_EthereumDataType get dataType => $_getN(0);
+  @$pb.TagNumber(1)
+  set dataType(EthereumTypedDataStructAck_EthereumDataType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDataType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDataType() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get size => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set size($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSize() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSize() => clearField(2);
+
+  /// for bytes types: size in bytes, or unset for dynamic
+  /// for arrays: size in elements, or unset for dynamic
+  /// for structs: number of members
+  /// for string, bool and address: unset
+  @$pb.TagNumber(3)
+  EthereumTypedDataStructAck_EthereumFieldType get entryType => $_getN(2);
+  @$pb.TagNumber(3)
+  set entryType(EthereumTypedDataStructAck_EthereumFieldType v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasEntryType() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearEntryType() => clearField(3);
+  @$pb.TagNumber(3)
+  EthereumTypedDataStructAck_EthereumFieldType ensureEntryType() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  $core.String get structName => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set structName($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasStructName() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearStructName() => clearField(4);
+}
+
+/// *
+///  Request: Type information about a struct.
+///  @next EthereumTypedDataStructRequest
+class EthereumTypedDataStructAck extends $pb.GeneratedMessage {
+  factory EthereumTypedDataStructAck({
+    $core.Iterable<EthereumTypedDataStructAck_EthereumStructMember>? members,
+  }) {
+    final $result = create();
+    if (members != null) {
+      $result.members.addAll(members);
+    }
+    return $result;
+  }
+  EthereumTypedDataStructAck._() : super();
+  factory EthereumTypedDataStructAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumTypedDataStructAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumTypedDataStructAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum_eip712'), createEmptyInstance: create)
+    ..pc<EthereumTypedDataStructAck_EthereumStructMember>(1, _omitFieldNames ? '' : 'members', $pb.PbFieldType.PM, subBuilder: EthereumTypedDataStructAck_EthereumStructMember.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumTypedDataStructAck clone() => EthereumTypedDataStructAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumTypedDataStructAck copyWith(void Function(EthereumTypedDataStructAck) updates) => super.copyWith((message) => updates(message as EthereumTypedDataStructAck)) as EthereumTypedDataStructAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumTypedDataStructAck create() => EthereumTypedDataStructAck._();
+  EthereumTypedDataStructAck createEmptyInstance() => create();
+  static $pb.PbList<EthereumTypedDataStructAck> createRepeated() => $pb.PbList<EthereumTypedDataStructAck>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumTypedDataStructAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumTypedDataStructAck>(create);
+  static EthereumTypedDataStructAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<EthereumTypedDataStructAck_EthereumStructMember> get members => $_getList(0);
+}
+
+/// *
+///  Response: Device asks for data at the specific member path.
+///  @next EthereumTypedDataValueAck
+class EthereumTypedDataValueRequest extends $pb.GeneratedMessage {
+  factory EthereumTypedDataValueRequest({
+    $core.Iterable<$core.int>? memberPath,
+  }) {
+    final $result = create();
+    if (memberPath != null) {
+      $result.memberPath.addAll(memberPath);
+    }
+    return $result;
+  }
+  EthereumTypedDataValueRequest._() : super();
+  factory EthereumTypedDataValueRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumTypedDataValueRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumTypedDataValueRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum_eip712'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'memberPath', $pb.PbFieldType.PU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumTypedDataValueRequest clone() => EthereumTypedDataValueRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumTypedDataValueRequest copyWith(void Function(EthereumTypedDataValueRequest) updates) => super.copyWith((message) => updates(message as EthereumTypedDataValueRequest)) as EthereumTypedDataValueRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumTypedDataValueRequest create() => EthereumTypedDataValueRequest._();
+  EthereumTypedDataValueRequest createEmptyInstance() => create();
+  static $pb.PbList<EthereumTypedDataValueRequest> createRepeated() => $pb.PbList<EthereumTypedDataValueRequest>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumTypedDataValueRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumTypedDataValueRequest>(create);
+  static EthereumTypedDataValueRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get memberPath => $_getList(0);
+}
+
+/// *
+///  Request: Single value of a specific atomic field.
+///  @next EthereumTypedDataValueRequest
+class EthereumTypedDataValueAck extends $pb.GeneratedMessage {
+  factory EthereumTypedDataValueAck({
+    $core.List<$core.int>? value,
+  }) {
+    final $result = create();
+    if (value != null) {
+      $result.value = value;
+    }
+    return $result;
+  }
+  EthereumTypedDataValueAck._() : super();
+  factory EthereumTypedDataValueAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumTypedDataValueAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumTypedDataValueAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum_eip712'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumTypedDataValueAck clone() => EthereumTypedDataValueAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumTypedDataValueAck copyWith(void Function(EthereumTypedDataValueAck) updates) => super.copyWith((message) => updates(message as EthereumTypedDataValueAck)) as EthereumTypedDataValueAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumTypedDataValueAck create() => EthereumTypedDataValueAck._();
+  EthereumTypedDataValueAck createEmptyInstance() => create();
+  static $pb.PbList<EthereumTypedDataValueAck> createRepeated() => $pb.PbList<EthereumTypedDataValueAck>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumTypedDataValueAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumTypedDataValueAck>(create);
+  static EthereumTypedDataValueAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get value => $_getN(0);
+  @$pb.TagNumber(1)
+  set value($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasValue() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearValue() => clearField(1);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-eip712.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-eip712.pbenum.dart
@@ -1,0 +1,44 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ethereum-eip712.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+class EthereumTypedDataStructAck_EthereumDataType extends $pb.ProtobufEnum {
+  static const EthereumTypedDataStructAck_EthereumDataType UINT = EthereumTypedDataStructAck_EthereumDataType._(1, _omitEnumNames ? '' : 'UINT');
+  static const EthereumTypedDataStructAck_EthereumDataType INT = EthereumTypedDataStructAck_EthereumDataType._(2, _omitEnumNames ? '' : 'INT');
+  static const EthereumTypedDataStructAck_EthereumDataType BYTES = EthereumTypedDataStructAck_EthereumDataType._(3, _omitEnumNames ? '' : 'BYTES');
+  static const EthereumTypedDataStructAck_EthereumDataType STRING = EthereumTypedDataStructAck_EthereumDataType._(4, _omitEnumNames ? '' : 'STRING');
+  static const EthereumTypedDataStructAck_EthereumDataType BOOL = EthereumTypedDataStructAck_EthereumDataType._(5, _omitEnumNames ? '' : 'BOOL');
+  static const EthereumTypedDataStructAck_EthereumDataType ADDRESS = EthereumTypedDataStructAck_EthereumDataType._(6, _omitEnumNames ? '' : 'ADDRESS');
+  static const EthereumTypedDataStructAck_EthereumDataType ARRAY = EthereumTypedDataStructAck_EthereumDataType._(7, _omitEnumNames ? '' : 'ARRAY');
+  static const EthereumTypedDataStructAck_EthereumDataType STRUCT = EthereumTypedDataStructAck_EthereumDataType._(8, _omitEnumNames ? '' : 'STRUCT');
+
+  static const $core.List<EthereumTypedDataStructAck_EthereumDataType> values = <EthereumTypedDataStructAck_EthereumDataType> [
+    UINT,
+    INT,
+    BYTES,
+    STRING,
+    BOOL,
+    ADDRESS,
+    ARRAY,
+    STRUCT,
+  ];
+
+  static final $core.Map<$core.int, EthereumTypedDataStructAck_EthereumDataType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static EthereumTypedDataStructAck_EthereumDataType? valueOf($core.int value) => _byValue[value];
+
+  const EthereumTypedDataStructAck_EthereumDataType._($core.int v, $core.String n) : super(v, n);
+}
+
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-eip712.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-eip712.pbjson.dart
@@ -1,0 +1,132 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ethereum-eip712.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use ethereumSignTypedDataDescriptor instead')
+const EthereumSignTypedData$json = {
+  '1': 'EthereumSignTypedData',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'primary_type', '3': 2, '4': 2, '5': 9, '10': 'primaryType'},
+    {'1': 'metamask_v4_compat', '3': 3, '4': 1, '5': 8, '7': 'true', '10': 'metamaskV4Compat'},
+    {'1': 'definitions', '3': 4, '4': 1, '5': 11, '6': '.hw.trezor.messages.ethereum_definitions.EthereumDefinitions', '10': 'definitions'},
+  ],
+};
+
+/// Descriptor for `EthereumSignTypedData`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumSignTypedDataDescriptor = $convert.base64Decode(
+    'ChVFdGhlcmV1bVNpZ25UeXBlZERhdGESGwoJYWRkcmVzc19uGAEgAygNUghhZGRyZXNzThIhCg'
+    'xwcmltYXJ5X3R5cGUYAiACKAlSC3ByaW1hcnlUeXBlEjIKEm1ldGFtYXNrX3Y0X2NvbXBhdBgD'
+    'IAEoCDoEdHJ1ZVIQbWV0YW1hc2tWNENvbXBhdBJeCgtkZWZpbml0aW9ucxgEIAEoCzI8Lmh3Ln'
+    'RyZXpvci5tZXNzYWdlcy5ldGhlcmV1bV9kZWZpbml0aW9ucy5FdGhlcmV1bURlZmluaXRpb25z'
+    'UgtkZWZpbml0aW9ucw==');
+
+@$core.Deprecated('Use ethereumTypedDataStructRequestDescriptor instead')
+const EthereumTypedDataStructRequest$json = {
+  '1': 'EthereumTypedDataStructRequest',
+  '2': [
+    {'1': 'name', '3': 1, '4': 2, '5': 9, '10': 'name'},
+  ],
+};
+
+/// Descriptor for `EthereumTypedDataStructRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumTypedDataStructRequestDescriptor = $convert.base64Decode(
+    'Ch5FdGhlcmV1bVR5cGVkRGF0YVN0cnVjdFJlcXVlc3QSEgoEbmFtZRgBIAIoCVIEbmFtZQ==');
+
+@$core.Deprecated('Use ethereumTypedDataStructAckDescriptor instead')
+const EthereumTypedDataStructAck$json = {
+  '1': 'EthereumTypedDataStructAck',
+  '2': [
+    {'1': 'members', '3': 1, '4': 3, '5': 11, '6': '.hw.trezor.messages.ethereum_eip712.EthereumTypedDataStructAck.EthereumStructMember', '10': 'members'},
+  ],
+  '3': [EthereumTypedDataStructAck_EthereumStructMember$json, EthereumTypedDataStructAck_EthereumFieldType$json],
+  '4': [EthereumTypedDataStructAck_EthereumDataType$json],
+};
+
+@$core.Deprecated('Use ethereumTypedDataStructAckDescriptor instead')
+const EthereumTypedDataStructAck_EthereumStructMember$json = {
+  '1': 'EthereumStructMember',
+  '2': [
+    {'1': 'type', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.ethereum_eip712.EthereumTypedDataStructAck.EthereumFieldType', '10': 'type'},
+    {'1': 'name', '3': 2, '4': 2, '5': 9, '10': 'name'},
+  ],
+};
+
+@$core.Deprecated('Use ethereumTypedDataStructAckDescriptor instead')
+const EthereumTypedDataStructAck_EthereumFieldType$json = {
+  '1': 'EthereumFieldType',
+  '2': [
+    {'1': 'data_type', '3': 1, '4': 2, '5': 14, '6': '.hw.trezor.messages.ethereum_eip712.EthereumTypedDataStructAck.EthereumDataType', '10': 'dataType'},
+    {'1': 'size', '3': 2, '4': 1, '5': 13, '10': 'size'},
+    {'1': 'entry_type', '3': 3, '4': 1, '5': 11, '6': '.hw.trezor.messages.ethereum_eip712.EthereumTypedDataStructAck.EthereumFieldType', '10': 'entryType'},
+    {'1': 'struct_name', '3': 4, '4': 1, '5': 9, '10': 'structName'},
+  ],
+};
+
+@$core.Deprecated('Use ethereumTypedDataStructAckDescriptor instead')
+const EthereumTypedDataStructAck_EthereumDataType$json = {
+  '1': 'EthereumDataType',
+  '2': [
+    {'1': 'UINT', '2': 1},
+    {'1': 'INT', '2': 2},
+    {'1': 'BYTES', '2': 3},
+    {'1': 'STRING', '2': 4},
+    {'1': 'BOOL', '2': 5},
+    {'1': 'ADDRESS', '2': 6},
+    {'1': 'ARRAY', '2': 7},
+    {'1': 'STRUCT', '2': 8},
+  ],
+};
+
+/// Descriptor for `EthereumTypedDataStructAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumTypedDataStructAckDescriptor = $convert.base64Decode(
+    'ChpFdGhlcmV1bVR5cGVkRGF0YVN0cnVjdEFjaxJtCgdtZW1iZXJzGAEgAygLMlMuaHcudHJlem'
+    '9yLm1lc3NhZ2VzLmV0aGVyZXVtX2VpcDcxMi5FdGhlcmV1bVR5cGVkRGF0YVN0cnVjdEFjay5F'
+    'dGhlcmV1bVN0cnVjdE1lbWJlclIHbWVtYmVycxqQAQoURXRoZXJldW1TdHJ1Y3RNZW1iZXISZA'
+    'oEdHlwZRgBIAIoCzJQLmh3LnRyZXpvci5tZXNzYWdlcy5ldGhlcmV1bV9laXA3MTIuRXRoZXJl'
+    'dW1UeXBlZERhdGFTdHJ1Y3RBY2suRXRoZXJldW1GaWVsZFR5cGVSBHR5cGUSEgoEbmFtZRgCIA'
+    'IoCVIEbmFtZRqnAgoRRXRoZXJldW1GaWVsZFR5cGUSbAoJZGF0YV90eXBlGAEgAigOMk8uaHcu'
+    'dHJlem9yLm1lc3NhZ2VzLmV0aGVyZXVtX2VpcDcxMi5FdGhlcmV1bVR5cGVkRGF0YVN0cnVjdE'
+    'Fjay5FdGhlcmV1bURhdGFUeXBlUghkYXRhVHlwZRISCgRzaXplGAIgASgNUgRzaXplEm8KCmVu'
+    'dHJ5X3R5cGUYAyABKAsyUC5ody50cmV6b3IubWVzc2FnZXMuZXRoZXJldW1fZWlwNzEyLkV0aG'
+    'VyZXVtVHlwZWREYXRhU3RydWN0QWNrLkV0aGVyZXVtRmllbGRUeXBlUgllbnRyeVR5cGUSHwoL'
+    'c3RydWN0X25hbWUYBCABKAlSCnN0cnVjdE5hbWUiagoQRXRoZXJldW1EYXRhVHlwZRIICgRVSU'
+    '5UEAESBwoDSU5UEAISCQoFQllURVMQAxIKCgZTVFJJTkcQBBIICgRCT09MEAUSCwoHQUREUkVT'
+    'UxAGEgkKBUFSUkFZEAcSCgoGU1RSVUNUEAg=');
+
+@$core.Deprecated('Use ethereumTypedDataValueRequestDescriptor instead')
+const EthereumTypedDataValueRequest$json = {
+  '1': 'EthereumTypedDataValueRequest',
+  '2': [
+    {'1': 'member_path', '3': 1, '4': 3, '5': 13, '10': 'memberPath'},
+  ],
+};
+
+/// Descriptor for `EthereumTypedDataValueRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumTypedDataValueRequestDescriptor = $convert.base64Decode(
+    'Ch1FdGhlcmV1bVR5cGVkRGF0YVZhbHVlUmVxdWVzdBIfCgttZW1iZXJfcGF0aBgBIAMoDVIKbW'
+    'VtYmVyUGF0aA==');
+
+@$core.Deprecated('Use ethereumTypedDataValueAckDescriptor instead')
+const EthereumTypedDataValueAck$json = {
+  '1': 'EthereumTypedDataValueAck',
+  '2': [
+    {'1': 'value', '3': 1, '4': 2, '5': 12, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `EthereumTypedDataValueAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumTypedDataValueAckDescriptor = $convert.base64Decode(
+    'ChlFdGhlcmV1bVR5cGVkRGF0YVZhbHVlQWNrEhQKBXZhbHVlGAEgAigMUgV2YWx1ZQ==');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-eip712.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-eip712.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ethereum-eip712.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-ethereum-eip712.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum.pb.dart
@@ -1,0 +1,1352 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ethereum.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'messages-common.pb.dart' as $0;
+import 'messages-ethereum-definitions.pb.dart' as $1;
+
+/// *
+///  Request: Ask device for public key corresponding to address_n path
+///  @start
+///  @next EthereumPublicKey
+///  @next Failure
+class EthereumGetPublicKey extends $pb.GeneratedMessage {
+  factory EthereumGetPublicKey({
+    $core.Iterable<$core.int>? addressN,
+    $core.bool? showDisplay,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    return $result;
+  }
+  EthereumGetPublicKey._() : super();
+  factory EthereumGetPublicKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumGetPublicKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumGetPublicKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aOB(2, _omitFieldNames ? '' : 'showDisplay')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumGetPublicKey clone() => EthereumGetPublicKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumGetPublicKey copyWith(void Function(EthereumGetPublicKey) updates) => super.copyWith((message) => updates(message as EthereumGetPublicKey)) as EthereumGetPublicKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumGetPublicKey create() => EthereumGetPublicKey._();
+  EthereumGetPublicKey createEmptyInstance() => create();
+  static $pb.PbList<EthereumGetPublicKey> createRepeated() => $pb.PbList<EthereumGetPublicKey>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumGetPublicKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumGetPublicKey>(create);
+  static EthereumGetPublicKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.bool get showDisplay => $_getBF(1);
+  @$pb.TagNumber(2)
+  set showDisplay($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasShowDisplay() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearShowDisplay() => clearField(2);
+}
+
+/// *
+///  Response: Contains public key derived from device private seed
+///  @end
+class EthereumPublicKey extends $pb.GeneratedMessage {
+  factory EthereumPublicKey({
+    $0.HDNodeType? node,
+    $core.String? xpub,
+  }) {
+    final $result = create();
+    if (node != null) {
+      $result.node = node;
+    }
+    if (xpub != null) {
+      $result.xpub = xpub;
+    }
+    return $result;
+  }
+  EthereumPublicKey._() : super();
+  factory EthereumPublicKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumPublicKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumPublicKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum'), createEmptyInstance: create)
+    ..aQM<$0.HDNodeType>(1, _omitFieldNames ? '' : 'node', subBuilder: $0.HDNodeType.create)
+    ..aQS(2, _omitFieldNames ? '' : 'xpub')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumPublicKey clone() => EthereumPublicKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumPublicKey copyWith(void Function(EthereumPublicKey) updates) => super.copyWith((message) => updates(message as EthereumPublicKey)) as EthereumPublicKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumPublicKey create() => EthereumPublicKey._();
+  EthereumPublicKey createEmptyInstance() => create();
+  static $pb.PbList<EthereumPublicKey> createRepeated() => $pb.PbList<EthereumPublicKey>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumPublicKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumPublicKey>(create);
+  static EthereumPublicKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $0.HDNodeType get node => $_getN(0);
+  @$pb.TagNumber(1)
+  set node($0.HDNodeType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasNode() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearNode() => clearField(1);
+  @$pb.TagNumber(1)
+  $0.HDNodeType ensureNode() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $core.String get xpub => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set xpub($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasXpub() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearXpub() => clearField(2);
+}
+
+/// *
+///  Request: Ask device for Ethereum address corresponding to address_n path
+///  @start
+///  @next EthereumAddress
+///  @next Failure
+class EthereumGetAddress extends $pb.GeneratedMessage {
+  factory EthereumGetAddress({
+    $core.Iterable<$core.int>? addressN,
+    $core.bool? showDisplay,
+    $core.List<$core.int>? encodedNetwork,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    if (encodedNetwork != null) {
+      $result.encodedNetwork = encodedNetwork;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  EthereumGetAddress._() : super();
+  factory EthereumGetAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumGetAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumGetAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aOB(2, _omitFieldNames ? '' : 'showDisplay')
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'encodedNetwork', $pb.PbFieldType.OY)
+    ..aOB(4, _omitFieldNames ? '' : 'chunkify')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumGetAddress clone() => EthereumGetAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumGetAddress copyWith(void Function(EthereumGetAddress) updates) => super.copyWith((message) => updates(message as EthereumGetAddress)) as EthereumGetAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumGetAddress create() => EthereumGetAddress._();
+  EthereumGetAddress createEmptyInstance() => create();
+  static $pb.PbList<EthereumGetAddress> createRepeated() => $pb.PbList<EthereumGetAddress>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumGetAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumGetAddress>(create);
+  static EthereumGetAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.bool get showDisplay => $_getBF(1);
+  @$pb.TagNumber(2)
+  set showDisplay($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasShowDisplay() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearShowDisplay() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get encodedNetwork => $_getN(2);
+  @$pb.TagNumber(3)
+  set encodedNetwork($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasEncodedNetwork() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearEncodedNetwork() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.bool get chunkify => $_getBF(3);
+  @$pb.TagNumber(4)
+  set chunkify($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasChunkify() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearChunkify() => clearField(4);
+}
+
+/// *
+///  Response: Contains an Ethereum address derived from device private seed
+///  @end
+class EthereumAddress extends $pb.GeneratedMessage {
+  factory EthereumAddress({
+  @$core.Deprecated('This field is deprecated.')
+    $core.List<$core.int>? oldAddress,
+    $core.String? address,
+  }) {
+    final $result = create();
+    if (oldAddress != null) {
+      // ignore: deprecated_member_use_from_same_package
+      $result.oldAddress = oldAddress;
+    }
+    if (address != null) {
+      $result.address = address;
+    }
+    return $result;
+  }
+  EthereumAddress._() : super();
+  factory EthereumAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'OldAddress', $pb.PbFieldType.OY)
+    ..aOS(2, _omitFieldNames ? '' : 'address')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumAddress clone() => EthereumAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumAddress copyWith(void Function(EthereumAddress) updates) => super.copyWith((message) => updates(message as EthereumAddress)) as EthereumAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumAddress create() => EthereumAddress._();
+  EthereumAddress createEmptyInstance() => create();
+  static $pb.PbList<EthereumAddress> createRepeated() => $pb.PbList<EthereumAddress>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumAddress>(create);
+  static EthereumAddress? _defaultInstance;
+
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get oldAddress => $_getN(0);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(1)
+  set oldAddress($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(1)
+  $core.bool hasOldAddress() => $_has(0);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(1)
+  void clearOldAddress() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get address => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set address($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAddress() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAddress() => clearField(2);
+}
+
+/// *
+///  Request: Ask device to sign transaction
+///  gas_price, gas_limit and chain_id must be provided and non-zero.
+///  All other fields are optional and default to value `0` if missing.
+///  Note: the first at most 1024 bytes of data MUST be transmitted as part of this message.
+///  @start
+///  @next EthereumTxRequest
+///  @next Failure
+class EthereumSignTx extends $pb.GeneratedMessage {
+  factory EthereumSignTx({
+    $core.Iterable<$core.int>? addressN,
+    $core.List<$core.int>? nonce,
+    $core.List<$core.int>? gasPrice,
+    $core.List<$core.int>? gasLimit,
+    $core.List<$core.int>? value,
+    $core.List<$core.int>? dataInitialChunk,
+    $core.int? dataLength,
+    $fixnum.Int64? chainId,
+    $core.int? txType,
+    $core.String? to,
+    $1.EthereumDefinitions? definitions,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (nonce != null) {
+      $result.nonce = nonce;
+    }
+    if (gasPrice != null) {
+      $result.gasPrice = gasPrice;
+    }
+    if (gasLimit != null) {
+      $result.gasLimit = gasLimit;
+    }
+    if (value != null) {
+      $result.value = value;
+    }
+    if (dataInitialChunk != null) {
+      $result.dataInitialChunk = dataInitialChunk;
+    }
+    if (dataLength != null) {
+      $result.dataLength = dataLength;
+    }
+    if (chainId != null) {
+      $result.chainId = chainId;
+    }
+    if (txType != null) {
+      $result.txType = txType;
+    }
+    if (to != null) {
+      $result.to = to;
+    }
+    if (definitions != null) {
+      $result.definitions = definitions;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  EthereumSignTx._() : super();
+  factory EthereumSignTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumSignTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumSignTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'nonce', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'gasPrice', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'gasLimit', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(7, _omitFieldNames ? '' : 'dataInitialChunk', $pb.PbFieldType.OY)
+    ..a<$core.int>(8, _omitFieldNames ? '' : 'dataLength', $pb.PbFieldType.OU3)
+    ..a<$fixnum.Int64>(9, _omitFieldNames ? '' : 'chainId', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(10, _omitFieldNames ? '' : 'txType', $pb.PbFieldType.OU3)
+    ..aOS(11, _omitFieldNames ? '' : 'to')
+    ..aOM<$1.EthereumDefinitions>(12, _omitFieldNames ? '' : 'definitions', subBuilder: $1.EthereumDefinitions.create)
+    ..aOB(13, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumSignTx clone() => EthereumSignTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumSignTx copyWith(void Function(EthereumSignTx) updates) => super.copyWith((message) => updates(message as EthereumSignTx)) as EthereumSignTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumSignTx create() => EthereumSignTx._();
+  EthereumSignTx createEmptyInstance() => create();
+  static $pb.PbList<EthereumSignTx> createRepeated() => $pb.PbList<EthereumSignTx>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumSignTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumSignTx>(create);
+  static EthereumSignTx? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get nonce => $_getN(1);
+  @$pb.TagNumber(2)
+  set nonce($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasNonce() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNonce() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get gasPrice => $_getN(2);
+  @$pb.TagNumber(3)
+  set gasPrice($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasGasPrice() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearGasPrice() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get gasLimit => $_getN(3);
+  @$pb.TagNumber(4)
+  set gasLimit($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasGasLimit() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearGasLimit() => clearField(4);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get value => $_getN(4);
+  @$pb.TagNumber(6)
+  set value($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasValue() => $_has(4);
+  @$pb.TagNumber(6)
+  void clearValue() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.List<$core.int> get dataInitialChunk => $_getN(5);
+  @$pb.TagNumber(7)
+  set dataInitialChunk($core.List<$core.int> v) { $_setBytes(5, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasDataInitialChunk() => $_has(5);
+  @$pb.TagNumber(7)
+  void clearDataInitialChunk() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.int get dataLength => $_getIZ(6);
+  @$pb.TagNumber(8)
+  set dataLength($core.int v) { $_setUnsignedInt32(6, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasDataLength() => $_has(6);
+  @$pb.TagNumber(8)
+  void clearDataLength() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $fixnum.Int64 get chainId => $_getI64(7);
+  @$pb.TagNumber(9)
+  set chainId($fixnum.Int64 v) { $_setInt64(7, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasChainId() => $_has(7);
+  @$pb.TagNumber(9)
+  void clearChainId() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.int get txType => $_getIZ(8);
+  @$pb.TagNumber(10)
+  set txType($core.int v) { $_setUnsignedInt32(8, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasTxType() => $_has(8);
+  @$pb.TagNumber(10)
+  void clearTxType() => clearField(10);
+
+  @$pb.TagNumber(11)
+  $core.String get to => $_getSZ(9);
+  @$pb.TagNumber(11)
+  set to($core.String v) { $_setString(9, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasTo() => $_has(9);
+  @$pb.TagNumber(11)
+  void clearTo() => clearField(11);
+
+  @$pb.TagNumber(12)
+  $1.EthereumDefinitions get definitions => $_getN(10);
+  @$pb.TagNumber(12)
+  set definitions($1.EthereumDefinitions v) { setField(12, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasDefinitions() => $_has(10);
+  @$pb.TagNumber(12)
+  void clearDefinitions() => clearField(12);
+  @$pb.TagNumber(12)
+  $1.EthereumDefinitions ensureDefinitions() => $_ensure(10);
+
+  @$pb.TagNumber(13)
+  $core.bool get chunkify => $_getBF(11);
+  @$pb.TagNumber(13)
+  set chunkify($core.bool v) { $_setBool(11, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasChunkify() => $_has(11);
+  @$pb.TagNumber(13)
+  void clearChunkify() => clearField(13);
+}
+
+class EthereumSignTxEIP1559_EthereumAccessList extends $pb.GeneratedMessage {
+  factory EthereumSignTxEIP1559_EthereumAccessList({
+    $core.String? address,
+    $core.Iterable<$core.List<$core.int>>? storageKeys,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    if (storageKeys != null) {
+      $result.storageKeys.addAll(storageKeys);
+    }
+    return $result;
+  }
+  EthereumSignTxEIP1559_EthereumAccessList._() : super();
+  factory EthereumSignTxEIP1559_EthereumAccessList.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumSignTxEIP1559_EthereumAccessList.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumSignTxEIP1559.EthereumAccessList', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'address')
+    ..p<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'storageKeys', $pb.PbFieldType.PY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumSignTxEIP1559_EthereumAccessList clone() => EthereumSignTxEIP1559_EthereumAccessList()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumSignTxEIP1559_EthereumAccessList copyWith(void Function(EthereumSignTxEIP1559_EthereumAccessList) updates) => super.copyWith((message) => updates(message as EthereumSignTxEIP1559_EthereumAccessList)) as EthereumSignTxEIP1559_EthereumAccessList;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumSignTxEIP1559_EthereumAccessList create() => EthereumSignTxEIP1559_EthereumAccessList._();
+  EthereumSignTxEIP1559_EthereumAccessList createEmptyInstance() => create();
+  static $pb.PbList<EthereumSignTxEIP1559_EthereumAccessList> createRepeated() => $pb.PbList<EthereumSignTxEIP1559_EthereumAccessList>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumSignTxEIP1559_EthereumAccessList getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumSignTxEIP1559_EthereumAccessList>(create);
+  static EthereumSignTxEIP1559_EthereumAccessList? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.List<$core.int>> get storageKeys => $_getList(1);
+}
+
+/// *
+///  Request: Ask device to sign EIP1559 transaction
+///  Note: the first at most 1024 bytes of data MUST be transmitted as part of this message.
+///  @start
+///  @next EthereumTxRequest
+///  @next Failure
+class EthereumSignTxEIP1559 extends $pb.GeneratedMessage {
+  factory EthereumSignTxEIP1559({
+    $core.Iterable<$core.int>? addressN,
+    $core.List<$core.int>? nonce,
+    $core.List<$core.int>? maxGasFee,
+    $core.List<$core.int>? maxPriorityFee,
+    $core.List<$core.int>? gasLimit,
+    $core.String? to,
+    $core.List<$core.int>? value,
+    $core.List<$core.int>? dataInitialChunk,
+    $core.int? dataLength,
+    $fixnum.Int64? chainId,
+    $core.Iterable<EthereumSignTxEIP1559_EthereumAccessList>? accessList,
+    $1.EthereumDefinitions? definitions,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (nonce != null) {
+      $result.nonce = nonce;
+    }
+    if (maxGasFee != null) {
+      $result.maxGasFee = maxGasFee;
+    }
+    if (maxPriorityFee != null) {
+      $result.maxPriorityFee = maxPriorityFee;
+    }
+    if (gasLimit != null) {
+      $result.gasLimit = gasLimit;
+    }
+    if (to != null) {
+      $result.to = to;
+    }
+    if (value != null) {
+      $result.value = value;
+    }
+    if (dataInitialChunk != null) {
+      $result.dataInitialChunk = dataInitialChunk;
+    }
+    if (dataLength != null) {
+      $result.dataLength = dataLength;
+    }
+    if (chainId != null) {
+      $result.chainId = chainId;
+    }
+    if (accessList != null) {
+      $result.accessList.addAll(accessList);
+    }
+    if (definitions != null) {
+      $result.definitions = definitions;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  EthereumSignTxEIP1559._() : super();
+  factory EthereumSignTxEIP1559.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumSignTxEIP1559.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumSignTxEIP1559', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'nonce', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'maxGasFee', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'maxPriorityFee', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'gasLimit', $pb.PbFieldType.QY)
+    ..aOS(6, _omitFieldNames ? '' : 'to')
+    ..a<$core.List<$core.int>>(7, _omitFieldNames ? '' : 'value', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(8, _omitFieldNames ? '' : 'dataInitialChunk', $pb.PbFieldType.OY)
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'dataLength', $pb.PbFieldType.QU3)
+    ..a<$fixnum.Int64>(10, _omitFieldNames ? '' : 'chainId', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..pc<EthereumSignTxEIP1559_EthereumAccessList>(11, _omitFieldNames ? '' : 'accessList', $pb.PbFieldType.PM, subBuilder: EthereumSignTxEIP1559_EthereumAccessList.create)
+    ..aOM<$1.EthereumDefinitions>(12, _omitFieldNames ? '' : 'definitions', subBuilder: $1.EthereumDefinitions.create)
+    ..aOB(13, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumSignTxEIP1559 clone() => EthereumSignTxEIP1559()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumSignTxEIP1559 copyWith(void Function(EthereumSignTxEIP1559) updates) => super.copyWith((message) => updates(message as EthereumSignTxEIP1559)) as EthereumSignTxEIP1559;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumSignTxEIP1559 create() => EthereumSignTxEIP1559._();
+  EthereumSignTxEIP1559 createEmptyInstance() => create();
+  static $pb.PbList<EthereumSignTxEIP1559> createRepeated() => $pb.PbList<EthereumSignTxEIP1559>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumSignTxEIP1559 getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumSignTxEIP1559>(create);
+  static EthereumSignTxEIP1559? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get nonce => $_getN(1);
+  @$pb.TagNumber(2)
+  set nonce($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasNonce() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNonce() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get maxGasFee => $_getN(2);
+  @$pb.TagNumber(3)
+  set maxGasFee($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasMaxGasFee() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearMaxGasFee() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get maxPriorityFee => $_getN(3);
+  @$pb.TagNumber(4)
+  set maxPriorityFee($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasMaxPriorityFee() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMaxPriorityFee() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get gasLimit => $_getN(4);
+  @$pb.TagNumber(5)
+  set gasLimit($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasGasLimit() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearGasLimit() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.String get to => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set to($core.String v) { $_setString(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasTo() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearTo() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.List<$core.int> get value => $_getN(6);
+  @$pb.TagNumber(7)
+  set value($core.List<$core.int> v) { $_setBytes(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasValue() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearValue() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.List<$core.int> get dataInitialChunk => $_getN(7);
+  @$pb.TagNumber(8)
+  set dataInitialChunk($core.List<$core.int> v) { $_setBytes(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasDataInitialChunk() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearDataInitialChunk() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.int get dataLength => $_getIZ(8);
+  @$pb.TagNumber(9)
+  set dataLength($core.int v) { $_setUnsignedInt32(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasDataLength() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearDataLength() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $fixnum.Int64 get chainId => $_getI64(9);
+  @$pb.TagNumber(10)
+  set chainId($fixnum.Int64 v) { $_setInt64(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasChainId() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearChainId() => clearField(10);
+
+  @$pb.TagNumber(11)
+  $core.List<EthereumSignTxEIP1559_EthereumAccessList> get accessList => $_getList(10);
+
+  @$pb.TagNumber(12)
+  $1.EthereumDefinitions get definitions => $_getN(11);
+  @$pb.TagNumber(12)
+  set definitions($1.EthereumDefinitions v) { setField(12, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasDefinitions() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearDefinitions() => clearField(12);
+  @$pb.TagNumber(12)
+  $1.EthereumDefinitions ensureDefinitions() => $_ensure(11);
+
+  @$pb.TagNumber(13)
+  $core.bool get chunkify => $_getBF(12);
+  @$pb.TagNumber(13)
+  set chunkify($core.bool v) { $_setBool(12, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasChunkify() => $_has(12);
+  @$pb.TagNumber(13)
+  void clearChunkify() => clearField(13);
+}
+
+/// *
+///  Response: Device asks for more data from transaction payload, or returns the signature.
+///  If data_length is set, device awaits that many more bytes of payload.
+///  Otherwise, the signature_* fields contain the computed transaction signature. All three fields will be present.
+///  @end
+///  @next EthereumTxAck
+class EthereumTxRequest extends $pb.GeneratedMessage {
+  factory EthereumTxRequest({
+    $core.int? dataLength,
+    $core.int? signatureV,
+    $core.List<$core.int>? signatureR,
+    $core.List<$core.int>? signatureS,
+  }) {
+    final $result = create();
+    if (dataLength != null) {
+      $result.dataLength = dataLength;
+    }
+    if (signatureV != null) {
+      $result.signatureV = signatureV;
+    }
+    if (signatureR != null) {
+      $result.signatureR = signatureR;
+    }
+    if (signatureS != null) {
+      $result.signatureS = signatureS;
+    }
+    return $result;
+  }
+  EthereumTxRequest._() : super();
+  factory EthereumTxRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumTxRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumTxRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'dataLength', $pb.PbFieldType.OU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'signatureV', $pb.PbFieldType.OU3)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'signatureR', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'signatureS', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumTxRequest clone() => EthereumTxRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumTxRequest copyWith(void Function(EthereumTxRequest) updates) => super.copyWith((message) => updates(message as EthereumTxRequest)) as EthereumTxRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumTxRequest create() => EthereumTxRequest._();
+  EthereumTxRequest createEmptyInstance() => create();
+  static $pb.PbList<EthereumTxRequest> createRepeated() => $pb.PbList<EthereumTxRequest>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumTxRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumTxRequest>(create);
+  static EthereumTxRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get dataLength => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set dataLength($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDataLength() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDataLength() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get signatureV => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set signatureV($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSignatureV() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSignatureV() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get signatureR => $_getN(2);
+  @$pb.TagNumber(3)
+  set signatureR($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSignatureR() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSignatureR() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get signatureS => $_getN(3);
+  @$pb.TagNumber(4)
+  set signatureS($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasSignatureS() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearSignatureS() => clearField(4);
+}
+
+/// *
+///  Request: Transaction payload data.
+///  @next EthereumTxRequest
+class EthereumTxAck extends $pb.GeneratedMessage {
+  factory EthereumTxAck({
+    $core.List<$core.int>? dataChunk,
+  }) {
+    final $result = create();
+    if (dataChunk != null) {
+      $result.dataChunk = dataChunk;
+    }
+    return $result;
+  }
+  EthereumTxAck._() : super();
+  factory EthereumTxAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumTxAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumTxAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'dataChunk', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumTxAck clone() => EthereumTxAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumTxAck copyWith(void Function(EthereumTxAck) updates) => super.copyWith((message) => updates(message as EthereumTxAck)) as EthereumTxAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumTxAck create() => EthereumTxAck._();
+  EthereumTxAck createEmptyInstance() => create();
+  static $pb.PbList<EthereumTxAck> createRepeated() => $pb.PbList<EthereumTxAck>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumTxAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumTxAck>(create);
+  static EthereumTxAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get dataChunk => $_getN(0);
+  @$pb.TagNumber(1)
+  set dataChunk($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDataChunk() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDataChunk() => clearField(1);
+}
+
+/// *
+///  Request: Ask device to sign message
+///  @start
+///  @next EthereumMessageSignature
+///  @next Failure
+class EthereumSignMessage extends $pb.GeneratedMessage {
+  factory EthereumSignMessage({
+    $core.Iterable<$core.int>? addressN,
+    $core.List<$core.int>? message,
+    $core.List<$core.int>? encodedNetwork,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (message != null) {
+      $result.message = message;
+    }
+    if (encodedNetwork != null) {
+      $result.encodedNetwork = encodedNetwork;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  EthereumSignMessage._() : super();
+  factory EthereumSignMessage.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumSignMessage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumSignMessage', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'message', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'encodedNetwork', $pb.PbFieldType.OY)
+    ..aOB(4, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumSignMessage clone() => EthereumSignMessage()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumSignMessage copyWith(void Function(EthereumSignMessage) updates) => super.copyWith((message) => updates(message as EthereumSignMessage)) as EthereumSignMessage;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumSignMessage create() => EthereumSignMessage._();
+  EthereumSignMessage createEmptyInstance() => create();
+  static $pb.PbList<EthereumSignMessage> createRepeated() => $pb.PbList<EthereumSignMessage>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumSignMessage getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumSignMessage>(create);
+  static EthereumSignMessage? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get message => $_getN(1);
+  @$pb.TagNumber(2)
+  set message($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMessage() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMessage() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get encodedNetwork => $_getN(2);
+  @$pb.TagNumber(3)
+  set encodedNetwork($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasEncodedNetwork() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearEncodedNetwork() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.bool get chunkify => $_getBF(3);
+  @$pb.TagNumber(4)
+  set chunkify($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasChunkify() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearChunkify() => clearField(4);
+}
+
+/// *
+///  Response: Signed message
+///  @end
+class EthereumMessageSignature extends $pb.GeneratedMessage {
+  factory EthereumMessageSignature({
+    $core.List<$core.int>? signature,
+    $core.String? address,
+  }) {
+    final $result = create();
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    if (address != null) {
+      $result.address = address;
+    }
+    return $result;
+  }
+  EthereumMessageSignature._() : super();
+  factory EthereumMessageSignature.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumMessageSignature.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumMessageSignature', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+    ..aQS(3, _omitFieldNames ? '' : 'address')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumMessageSignature clone() => EthereumMessageSignature()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumMessageSignature copyWith(void Function(EthereumMessageSignature) updates) => super.copyWith((message) => updates(message as EthereumMessageSignature)) as EthereumMessageSignature;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumMessageSignature create() => EthereumMessageSignature._();
+  EthereumMessageSignature createEmptyInstance() => create();
+  static $pb.PbList<EthereumMessageSignature> createRepeated() => $pb.PbList<EthereumMessageSignature>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumMessageSignature getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumMessageSignature>(create);
+  static EthereumMessageSignature? _defaultInstance;
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get signature => $_getN(0);
+  @$pb.TagNumber(2)
+  set signature($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSignature() => $_has(0);
+  @$pb.TagNumber(2)
+  void clearSignature() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get address => $_getSZ(1);
+  @$pb.TagNumber(3)
+  set address($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasAddress() => $_has(1);
+  @$pb.TagNumber(3)
+  void clearAddress() => clearField(3);
+}
+
+/// *
+///  Request: Ask device to verify message
+///  @start
+///  @next Success
+///  @next Failure
+class EthereumVerifyMessage extends $pb.GeneratedMessage {
+  factory EthereumVerifyMessage({
+    $core.List<$core.int>? signature,
+    $core.List<$core.int>? message,
+    $core.String? address,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    if (message != null) {
+      $result.message = message;
+    }
+    if (address != null) {
+      $result.address = address;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  EthereumVerifyMessage._() : super();
+  factory EthereumVerifyMessage.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumVerifyMessage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumVerifyMessage', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'message', $pb.PbFieldType.QY)
+    ..aQS(4, _omitFieldNames ? '' : 'address')
+    ..aOB(5, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumVerifyMessage clone() => EthereumVerifyMessage()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumVerifyMessage copyWith(void Function(EthereumVerifyMessage) updates) => super.copyWith((message) => updates(message as EthereumVerifyMessage)) as EthereumVerifyMessage;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumVerifyMessage create() => EthereumVerifyMessage._();
+  EthereumVerifyMessage createEmptyInstance() => create();
+  static $pb.PbList<EthereumVerifyMessage> createRepeated() => $pb.PbList<EthereumVerifyMessage>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumVerifyMessage getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumVerifyMessage>(create);
+  static EthereumVerifyMessage? _defaultInstance;
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get signature => $_getN(0);
+  @$pb.TagNumber(2)
+  set signature($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSignature() => $_has(0);
+  @$pb.TagNumber(2)
+  void clearSignature() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get message => $_getN(1);
+  @$pb.TagNumber(3)
+  set message($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasMessage() => $_has(1);
+  @$pb.TagNumber(3)
+  void clearMessage() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get address => $_getSZ(2);
+  @$pb.TagNumber(4)
+  set address($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasAddress() => $_has(2);
+  @$pb.TagNumber(4)
+  void clearAddress() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.bool get chunkify => $_getBF(3);
+  @$pb.TagNumber(5)
+  set chunkify($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasChunkify() => $_has(3);
+  @$pb.TagNumber(5)
+  void clearChunkify() => clearField(5);
+}
+
+/// *
+///  Request: Ask device to sign hash of typed data
+///  @start
+///  @next EthereumTypedDataSignature
+///  @next Failure
+class EthereumSignTypedHash extends $pb.GeneratedMessage {
+  factory EthereumSignTypedHash({
+    $core.Iterable<$core.int>? addressN,
+    $core.List<$core.int>? domainSeparatorHash,
+    $core.List<$core.int>? messageHash,
+    $core.List<$core.int>? encodedNetwork,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (domainSeparatorHash != null) {
+      $result.domainSeparatorHash = domainSeparatorHash;
+    }
+    if (messageHash != null) {
+      $result.messageHash = messageHash;
+    }
+    if (encodedNetwork != null) {
+      $result.encodedNetwork = encodedNetwork;
+    }
+    return $result;
+  }
+  EthereumSignTypedHash._() : super();
+  factory EthereumSignTypedHash.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumSignTypedHash.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumSignTypedHash', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'domainSeparatorHash', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'messageHash', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'encodedNetwork', $pb.PbFieldType.OY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumSignTypedHash clone() => EthereumSignTypedHash()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumSignTypedHash copyWith(void Function(EthereumSignTypedHash) updates) => super.copyWith((message) => updates(message as EthereumSignTypedHash)) as EthereumSignTypedHash;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumSignTypedHash create() => EthereumSignTypedHash._();
+  EthereumSignTypedHash createEmptyInstance() => create();
+  static $pb.PbList<EthereumSignTypedHash> createRepeated() => $pb.PbList<EthereumSignTypedHash>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumSignTypedHash getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumSignTypedHash>(create);
+  static EthereumSignTypedHash? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get domainSeparatorHash => $_getN(1);
+  @$pb.TagNumber(2)
+  set domainSeparatorHash($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasDomainSeparatorHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearDomainSeparatorHash() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get messageHash => $_getN(2);
+  @$pb.TagNumber(3)
+  set messageHash($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasMessageHash() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearMessageHash() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get encodedNetwork => $_getN(3);
+  @$pb.TagNumber(4)
+  set encodedNetwork($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasEncodedNetwork() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearEncodedNetwork() => clearField(4);
+}
+
+/// *
+///  Response: Signed typed data
+///  @end
+class EthereumTypedDataSignature extends $pb.GeneratedMessage {
+  factory EthereumTypedDataSignature({
+    $core.List<$core.int>? signature,
+    $core.String? address,
+  }) {
+    final $result = create();
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    if (address != null) {
+      $result.address = address;
+    }
+    return $result;
+  }
+  EthereumTypedDataSignature._() : super();
+  factory EthereumTypedDataSignature.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EthereumTypedDataSignature.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EthereumTypedDataSignature', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ethereum'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+    ..aQS(2, _omitFieldNames ? '' : 'address')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EthereumTypedDataSignature clone() => EthereumTypedDataSignature()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EthereumTypedDataSignature copyWith(void Function(EthereumTypedDataSignature) updates) => super.copyWith((message) => updates(message as EthereumTypedDataSignature)) as EthereumTypedDataSignature;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EthereumTypedDataSignature create() => EthereumTypedDataSignature._();
+  EthereumTypedDataSignature createEmptyInstance() => create();
+  static $pb.PbList<EthereumTypedDataSignature> createRepeated() => $pb.PbList<EthereumTypedDataSignature>();
+  @$core.pragma('dart2js:noInline')
+  static EthereumTypedDataSignature getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EthereumTypedDataSignature>(create);
+  static EthereumTypedDataSignature? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get signature => $_getN(0);
+  @$pb.TagNumber(1)
+  set signature($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSignature() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSignature() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get address => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set address($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAddress() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAddress() => clearField(2);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ethereum.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum.pbjson.dart
@@ -1,0 +1,265 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ethereum.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use ethereumGetPublicKeyDescriptor instead')
+const EthereumGetPublicKey$json = {
+  '1': 'EthereumGetPublicKey',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'show_display', '3': 2, '4': 1, '5': 8, '10': 'showDisplay'},
+  ],
+};
+
+/// Descriptor for `EthereumGetPublicKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumGetPublicKeyDescriptor = $convert.base64Decode(
+    'ChRFdGhlcmV1bUdldFB1YmxpY0tleRIbCglhZGRyZXNzX24YASADKA1SCGFkZHJlc3NOEiEKDH'
+    'Nob3dfZGlzcGxheRgCIAEoCFILc2hvd0Rpc3BsYXk=');
+
+@$core.Deprecated('Use ethereumPublicKeyDescriptor instead')
+const EthereumPublicKey$json = {
+  '1': 'EthereumPublicKey',
+  '2': [
+    {'1': 'node', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.common.HDNodeType', '10': 'node'},
+    {'1': 'xpub', '3': 2, '4': 2, '5': 9, '10': 'xpub'},
+  ],
+};
+
+/// Descriptor for `EthereumPublicKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumPublicKeyDescriptor = $convert.base64Decode(
+    'ChFFdGhlcmV1bVB1YmxpY0tleRI5CgRub2RlGAEgAigLMiUuaHcudHJlem9yLm1lc3NhZ2VzLm'
+    'NvbW1vbi5IRE5vZGVUeXBlUgRub2RlEhIKBHhwdWIYAiACKAlSBHhwdWI=');
+
+@$core.Deprecated('Use ethereumGetAddressDescriptor instead')
+const EthereumGetAddress$json = {
+  '1': 'EthereumGetAddress',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'show_display', '3': 2, '4': 1, '5': 8, '10': 'showDisplay'},
+    {'1': 'encoded_network', '3': 3, '4': 1, '5': 12, '10': 'encodedNetwork'},
+    {'1': 'chunkify', '3': 4, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `EthereumGetAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumGetAddressDescriptor = $convert.base64Decode(
+    'ChJFdGhlcmV1bUdldEFkZHJlc3MSGwoJYWRkcmVzc19uGAEgAygNUghhZGRyZXNzThIhCgxzaG'
+    '93X2Rpc3BsYXkYAiABKAhSC3Nob3dEaXNwbGF5EicKD2VuY29kZWRfbmV0d29yaxgDIAEoDFIO'
+    'ZW5jb2RlZE5ldHdvcmsSGgoIY2h1bmtpZnkYBCABKAhSCGNodW5raWZ5');
+
+@$core.Deprecated('Use ethereumAddressDescriptor instead')
+const EthereumAddress$json = {
+  '1': 'EthereumAddress',
+  '2': [
+    {
+      '1': '_old_address',
+      '3': 1,
+      '4': 1,
+      '5': 12,
+      '8': {'3': true},
+      '10': 'OldAddress',
+    },
+    {'1': 'address', '3': 2, '4': 1, '5': 9, '10': 'address'},
+  ],
+};
+
+/// Descriptor for `EthereumAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumAddressDescriptor = $convert.base64Decode(
+    'Cg9FdGhlcmV1bUFkZHJlc3MSJAoMX29sZF9hZGRyZXNzGAEgASgMQgIYAVIKT2xkQWRkcmVzcx'
+    'IYCgdhZGRyZXNzGAIgASgJUgdhZGRyZXNz');
+
+@$core.Deprecated('Use ethereumSignTxDescriptor instead')
+const EthereumSignTx$json = {
+  '1': 'EthereumSignTx',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'nonce', '3': 2, '4': 1, '5': 12, '7': '', '10': 'nonce'},
+    {'1': 'gas_price', '3': 3, '4': 2, '5': 12, '10': 'gasPrice'},
+    {'1': 'gas_limit', '3': 4, '4': 2, '5': 12, '10': 'gasLimit'},
+    {'1': 'to', '3': 11, '4': 1, '5': 9, '7': '', '10': 'to'},
+    {'1': 'value', '3': 6, '4': 1, '5': 12, '7': '', '10': 'value'},
+    {'1': 'data_initial_chunk', '3': 7, '4': 1, '5': 12, '7': '', '10': 'dataInitialChunk'},
+    {'1': 'data_length', '3': 8, '4': 1, '5': 13, '7': '0', '10': 'dataLength'},
+    {'1': 'chain_id', '3': 9, '4': 2, '5': 4, '10': 'chainId'},
+    {'1': 'tx_type', '3': 10, '4': 1, '5': 13, '10': 'txType'},
+    {'1': 'definitions', '3': 12, '4': 1, '5': 11, '6': '.hw.trezor.messages.ethereum_definitions.EthereumDefinitions', '10': 'definitions'},
+    {'1': 'chunkify', '3': 13, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `EthereumSignTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumSignTxDescriptor = $convert.base64Decode(
+    'Cg5FdGhlcmV1bVNpZ25UeBIbCglhZGRyZXNzX24YASADKA1SCGFkZHJlc3NOEhYKBW5vbmNlGA'
+    'IgASgMOgBSBW5vbmNlEhsKCWdhc19wcmljZRgDIAIoDFIIZ2FzUHJpY2USGwoJZ2FzX2xpbWl0'
+    'GAQgAigMUghnYXNMaW1pdBIQCgJ0bxgLIAEoCToAUgJ0bxIWCgV2YWx1ZRgGIAEoDDoAUgV2YW'
+    'x1ZRIuChJkYXRhX2luaXRpYWxfY2h1bmsYByABKAw6AFIQZGF0YUluaXRpYWxDaHVuaxIiCgtk'
+    'YXRhX2xlbmd0aBgIIAEoDToBMFIKZGF0YUxlbmd0aBIZCghjaGFpbl9pZBgJIAIoBFIHY2hhaW'
+    '5JZBIXCgd0eF90eXBlGAogASgNUgZ0eFR5cGUSXgoLZGVmaW5pdGlvbnMYDCABKAsyPC5ody50'
+    'cmV6b3IubWVzc2FnZXMuZXRoZXJldW1fZGVmaW5pdGlvbnMuRXRoZXJldW1EZWZpbml0aW9uc1'
+    'ILZGVmaW5pdGlvbnMSGgoIY2h1bmtpZnkYDSABKAhSCGNodW5raWZ5');
+
+@$core.Deprecated('Use ethereumSignTxEIP1559Descriptor instead')
+const EthereumSignTxEIP1559$json = {
+  '1': 'EthereumSignTxEIP1559',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'nonce', '3': 2, '4': 2, '5': 12, '10': 'nonce'},
+    {'1': 'max_gas_fee', '3': 3, '4': 2, '5': 12, '10': 'maxGasFee'},
+    {'1': 'max_priority_fee', '3': 4, '4': 2, '5': 12, '10': 'maxPriorityFee'},
+    {'1': 'gas_limit', '3': 5, '4': 2, '5': 12, '10': 'gasLimit'},
+    {'1': 'to', '3': 6, '4': 1, '5': 9, '7': '', '10': 'to'},
+    {'1': 'value', '3': 7, '4': 2, '5': 12, '10': 'value'},
+    {'1': 'data_initial_chunk', '3': 8, '4': 1, '5': 12, '7': '', '10': 'dataInitialChunk'},
+    {'1': 'data_length', '3': 9, '4': 2, '5': 13, '10': 'dataLength'},
+    {'1': 'chain_id', '3': 10, '4': 2, '5': 4, '10': 'chainId'},
+    {'1': 'access_list', '3': 11, '4': 3, '5': 11, '6': '.hw.trezor.messages.ethereum.EthereumSignTxEIP1559.EthereumAccessList', '10': 'accessList'},
+    {'1': 'definitions', '3': 12, '4': 1, '5': 11, '6': '.hw.trezor.messages.ethereum_definitions.EthereumDefinitions', '10': 'definitions'},
+    {'1': 'chunkify', '3': 13, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+  '3': [EthereumSignTxEIP1559_EthereumAccessList$json],
+};
+
+@$core.Deprecated('Use ethereumSignTxEIP1559Descriptor instead')
+const EthereumSignTxEIP1559_EthereumAccessList$json = {
+  '1': 'EthereumAccessList',
+  '2': [
+    {'1': 'address', '3': 1, '4': 2, '5': 9, '10': 'address'},
+    {'1': 'storage_keys', '3': 2, '4': 3, '5': 12, '10': 'storageKeys'},
+  ],
+};
+
+/// Descriptor for `EthereumSignTxEIP1559`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumSignTxEIP1559Descriptor = $convert.base64Decode(
+    'ChVFdGhlcmV1bVNpZ25UeEVJUDE1NTkSGwoJYWRkcmVzc19uGAEgAygNUghhZGRyZXNzThIUCg'
+    'Vub25jZRgCIAIoDFIFbm9uY2USHgoLbWF4X2dhc19mZWUYAyACKAxSCW1heEdhc0ZlZRIoChBt'
+    'YXhfcHJpb3JpdHlfZmVlGAQgAigMUg5tYXhQcmlvcml0eUZlZRIbCglnYXNfbGltaXQYBSACKA'
+    'xSCGdhc0xpbWl0EhAKAnRvGAYgASgJOgBSAnRvEhQKBXZhbHVlGAcgAigMUgV2YWx1ZRIuChJk'
+    'YXRhX2luaXRpYWxfY2h1bmsYCCABKAw6AFIQZGF0YUluaXRpYWxDaHVuaxIfCgtkYXRhX2xlbm'
+    'd0aBgJIAIoDVIKZGF0YUxlbmd0aBIZCghjaGFpbl9pZBgKIAIoBFIHY2hhaW5JZBJmCgthY2Nl'
+    'c3NfbGlzdBgLIAMoCzJFLmh3LnRyZXpvci5tZXNzYWdlcy5ldGhlcmV1bS5FdGhlcmV1bVNpZ2'
+    '5UeEVJUDE1NTkuRXRoZXJldW1BY2Nlc3NMaXN0UgphY2Nlc3NMaXN0El4KC2RlZmluaXRpb25z'
+    'GAwgASgLMjwuaHcudHJlem9yLm1lc3NhZ2VzLmV0aGVyZXVtX2RlZmluaXRpb25zLkV0aGVyZX'
+    'VtRGVmaW5pdGlvbnNSC2RlZmluaXRpb25zEhoKCGNodW5raWZ5GA0gASgIUghjaHVua2lmeRpR'
+    'ChJFdGhlcmV1bUFjY2Vzc0xpc3QSGAoHYWRkcmVzcxgBIAIoCVIHYWRkcmVzcxIhCgxzdG9yYW'
+    'dlX2tleXMYAiADKAxSC3N0b3JhZ2VLZXlz');
+
+@$core.Deprecated('Use ethereumTxRequestDescriptor instead')
+const EthereumTxRequest$json = {
+  '1': 'EthereumTxRequest',
+  '2': [
+    {'1': 'data_length', '3': 1, '4': 1, '5': 13, '10': 'dataLength'},
+    {'1': 'signature_v', '3': 2, '4': 1, '5': 13, '10': 'signatureV'},
+    {'1': 'signature_r', '3': 3, '4': 1, '5': 12, '10': 'signatureR'},
+    {'1': 'signature_s', '3': 4, '4': 1, '5': 12, '10': 'signatureS'},
+  ],
+};
+
+/// Descriptor for `EthereumTxRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumTxRequestDescriptor = $convert.base64Decode(
+    'ChFFdGhlcmV1bVR4UmVxdWVzdBIfCgtkYXRhX2xlbmd0aBgBIAEoDVIKZGF0YUxlbmd0aBIfCg'
+    'tzaWduYXR1cmVfdhgCIAEoDVIKc2lnbmF0dXJlVhIfCgtzaWduYXR1cmVfchgDIAEoDFIKc2ln'
+    'bmF0dXJlUhIfCgtzaWduYXR1cmVfcxgEIAEoDFIKc2lnbmF0dXJlUw==');
+
+@$core.Deprecated('Use ethereumTxAckDescriptor instead')
+const EthereumTxAck$json = {
+  '1': 'EthereumTxAck',
+  '2': [
+    {'1': 'data_chunk', '3': 1, '4': 2, '5': 12, '10': 'dataChunk'},
+  ],
+};
+
+/// Descriptor for `EthereumTxAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumTxAckDescriptor = $convert.base64Decode(
+    'Cg1FdGhlcmV1bVR4QWNrEh0KCmRhdGFfY2h1bmsYASACKAxSCWRhdGFDaHVuaw==');
+
+@$core.Deprecated('Use ethereumSignMessageDescriptor instead')
+const EthereumSignMessage$json = {
+  '1': 'EthereumSignMessage',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'message', '3': 2, '4': 2, '5': 12, '10': 'message'},
+    {'1': 'encoded_network', '3': 3, '4': 1, '5': 12, '10': 'encodedNetwork'},
+    {'1': 'chunkify', '3': 4, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `EthereumSignMessage`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumSignMessageDescriptor = $convert.base64Decode(
+    'ChNFdGhlcmV1bVNpZ25NZXNzYWdlEhsKCWFkZHJlc3NfbhgBIAMoDVIIYWRkcmVzc04SGAoHbW'
+    'Vzc2FnZRgCIAIoDFIHbWVzc2FnZRInCg9lbmNvZGVkX25ldHdvcmsYAyABKAxSDmVuY29kZWRO'
+    'ZXR3b3JrEhoKCGNodW5raWZ5GAQgASgIUghjaHVua2lmeQ==');
+
+@$core.Deprecated('Use ethereumMessageSignatureDescriptor instead')
+const EthereumMessageSignature$json = {
+  '1': 'EthereumMessageSignature',
+  '2': [
+    {'1': 'signature', '3': 2, '4': 2, '5': 12, '10': 'signature'},
+    {'1': 'address', '3': 3, '4': 2, '5': 9, '10': 'address'},
+  ],
+};
+
+/// Descriptor for `EthereumMessageSignature`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumMessageSignatureDescriptor = $convert.base64Decode(
+    'ChhFdGhlcmV1bU1lc3NhZ2VTaWduYXR1cmUSHAoJc2lnbmF0dXJlGAIgAigMUglzaWduYXR1cm'
+    'USGAoHYWRkcmVzcxgDIAIoCVIHYWRkcmVzcw==');
+
+@$core.Deprecated('Use ethereumVerifyMessageDescriptor instead')
+const EthereumVerifyMessage$json = {
+  '1': 'EthereumVerifyMessage',
+  '2': [
+    {'1': 'signature', '3': 2, '4': 2, '5': 12, '10': 'signature'},
+    {'1': 'message', '3': 3, '4': 2, '5': 12, '10': 'message'},
+    {'1': 'address', '3': 4, '4': 2, '5': 9, '10': 'address'},
+    {'1': 'chunkify', '3': 5, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `EthereumVerifyMessage`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumVerifyMessageDescriptor = $convert.base64Decode(
+    'ChVFdGhlcmV1bVZlcmlmeU1lc3NhZ2USHAoJc2lnbmF0dXJlGAIgAigMUglzaWduYXR1cmUSGA'
+    'oHbWVzc2FnZRgDIAIoDFIHbWVzc2FnZRIYCgdhZGRyZXNzGAQgAigJUgdhZGRyZXNzEhoKCGNo'
+    'dW5raWZ5GAUgASgIUghjaHVua2lmeQ==');
+
+@$core.Deprecated('Use ethereumSignTypedHashDescriptor instead')
+const EthereumSignTypedHash$json = {
+  '1': 'EthereumSignTypedHash',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'domain_separator_hash', '3': 2, '4': 2, '5': 12, '10': 'domainSeparatorHash'},
+    {'1': 'message_hash', '3': 3, '4': 1, '5': 12, '10': 'messageHash'},
+    {'1': 'encoded_network', '3': 4, '4': 1, '5': 12, '10': 'encodedNetwork'},
+  ],
+};
+
+/// Descriptor for `EthereumSignTypedHash`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumSignTypedHashDescriptor = $convert.base64Decode(
+    'ChVFdGhlcmV1bVNpZ25UeXBlZEhhc2gSGwoJYWRkcmVzc19uGAEgAygNUghhZGRyZXNzThIyCh'
+    'Vkb21haW5fc2VwYXJhdG9yX2hhc2gYAiACKAxSE2RvbWFpblNlcGFyYXRvckhhc2gSIQoMbWVz'
+    'c2FnZV9oYXNoGAMgASgMUgttZXNzYWdlSGFzaBInCg9lbmNvZGVkX25ldHdvcmsYBCABKAxSDm'
+    'VuY29kZWROZXR3b3Jr');
+
+@$core.Deprecated('Use ethereumTypedDataSignatureDescriptor instead')
+const EthereumTypedDataSignature$json = {
+  '1': 'EthereumTypedDataSignature',
+  '2': [
+    {'1': 'signature', '3': 1, '4': 2, '5': 12, '10': 'signature'},
+    {'1': 'address', '3': 2, '4': 2, '5': 9, '10': 'address'},
+  ],
+};
+
+/// Descriptor for `EthereumTypedDataSignature`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List ethereumTypedDataSignatureDescriptor = $convert.base64Decode(
+    'ChpFdGhlcmV1bVR5cGVkRGF0YVNpZ25hdHVyZRIcCglzaWduYXR1cmUYASACKAxSCXNpZ25hdH'
+    'VyZRIYCgdhZGRyZXNzGAIgAigJUgdhZGRyZXNz');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ethereum.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-ethereum.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-management.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-management.pb.dart
@@ -1,0 +1,3452 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-management.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'messages-management.pbenum.dart';
+
+export 'messages-management.pbenum.dart';
+
+/// *
+///  Request: Reset device to default state and ask for device details
+///  @start
+///  @next Features
+class Initialize extends $pb.GeneratedMessage {
+  factory Initialize({
+    $core.List<$core.int>? sessionId,
+  @$core.Deprecated('This field is deprecated.')
+    $core.bool? skipPassphrase,
+    $core.bool? deriveCardano,
+  }) {
+    final $result = create();
+    if (sessionId != null) {
+      $result.sessionId = sessionId;
+    }
+    if (skipPassphrase != null) {
+      // ignore: deprecated_member_use_from_same_package
+      $result.skipPassphrase = skipPassphrase;
+    }
+    if (deriveCardano != null) {
+      $result.deriveCardano = deriveCardano;
+    }
+    return $result;
+  }
+  Initialize._() : super();
+  factory Initialize.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Initialize.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Initialize', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'sessionId', $pb.PbFieldType.OY)
+    ..aOB(2, _omitFieldNames ? '' : 'SkipPassphrase')
+    ..aOB(3, _omitFieldNames ? '' : 'deriveCardano')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Initialize clone() => Initialize()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Initialize copyWith(void Function(Initialize) updates) => super.copyWith((message) => updates(message as Initialize)) as Initialize;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Initialize create() => Initialize._();
+  Initialize createEmptyInstance() => create();
+  static $pb.PbList<Initialize> createRepeated() => $pb.PbList<Initialize>();
+  @$core.pragma('dart2js:noInline')
+  static Initialize getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Initialize>(create);
+  static Initialize? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get sessionId => $_getN(0);
+  @$pb.TagNumber(1)
+  set sessionId($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSessionId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSessionId() => clearField(1);
+
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(2)
+  $core.bool get skipPassphrase => $_getBF(1);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(2)
+  set skipPassphrase($core.bool v) { $_setBool(1, v); }
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(2)
+  $core.bool hasSkipPassphrase() => $_has(1);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(2)
+  void clearSkipPassphrase() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get deriveCardano => $_getBF(2);
+  @$pb.TagNumber(3)
+  set deriveCardano($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasDeriveCardano() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearDeriveCardano() => clearField(3);
+}
+
+/// *
+///  Request: Ask for device details (no device reset)
+///  @start
+///  @next Features
+class GetFeatures extends $pb.GeneratedMessage {
+  factory GetFeatures() => create();
+  GetFeatures._() : super();
+  factory GetFeatures.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetFeatures.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetFeatures', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetFeatures clone() => GetFeatures()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetFeatures copyWith(void Function(GetFeatures) updates) => super.copyWith((message) => updates(message as GetFeatures)) as GetFeatures;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetFeatures create() => GetFeatures._();
+  GetFeatures createEmptyInstance() => create();
+  static $pb.PbList<GetFeatures> createRepeated() => $pb.PbList<GetFeatures>();
+  @$core.pragma('dart2js:noInline')
+  static GetFeatures getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetFeatures>(create);
+  static GetFeatures? _defaultInstance;
+}
+
+/// *
+///  Response: Reports various information about the device
+///  @end
+class Features extends $pb.GeneratedMessage {
+  factory Features({
+    $core.String? vendor,
+    $core.int? majorVersion,
+    $core.int? minorVersion,
+    $core.int? patchVersion,
+    $core.bool? bootloaderMode,
+    $core.String? deviceId,
+    $core.bool? pinProtection,
+    $core.bool? passphraseProtection,
+    $core.String? language,
+    $core.String? label,
+    $core.bool? initialized,
+    $core.List<$core.int>? revision,
+    $core.List<$core.int>? bootloaderHash,
+    $core.bool? imported,
+    $core.bool? unlocked,
+  @$core.Deprecated('This field is deprecated.')
+    $core.bool? passphraseCached,
+    $core.bool? firmwarePresent,
+    $core.bool? needsBackup,
+    $core.int? flags,
+    $core.String? model,
+    $core.int? fwMajor,
+    $core.int? fwMinor,
+    $core.int? fwPatch,
+    $core.String? fwVendor,
+    $core.bool? unfinishedBackup,
+    $core.bool? noBackup,
+    $core.bool? recoveryMode,
+    $core.Iterable<Features_Capability>? capabilities,
+    BackupType? backupType,
+    $core.bool? sdCardPresent,
+    $core.bool? sdProtection,
+    $core.bool? wipeCodeProtection,
+    $core.List<$core.int>? sessionId,
+    $core.bool? passphraseAlwaysOnDevice,
+    SafetyCheckLevel? safetyChecks,
+    $core.int? autoLockDelayMs,
+    $core.int? displayRotation,
+    $core.bool? experimentalFeatures,
+    $core.bool? busy,
+    HomescreenFormat? homescreenFormat,
+    $core.bool? hidePassphraseFromHost,
+    $core.String? internalModel,
+    $core.int? unitColor,
+    $core.bool? unitBtconly,
+    $core.int? homescreenWidth,
+    $core.int? homescreenHeight,
+    $core.bool? bootloaderLocked,
+    $core.bool? languageVersionMatches,
+  }) {
+    final $result = create();
+    if (vendor != null) {
+      $result.vendor = vendor;
+    }
+    if (majorVersion != null) {
+      $result.majorVersion = majorVersion;
+    }
+    if (minorVersion != null) {
+      $result.minorVersion = minorVersion;
+    }
+    if (patchVersion != null) {
+      $result.patchVersion = patchVersion;
+    }
+    if (bootloaderMode != null) {
+      $result.bootloaderMode = bootloaderMode;
+    }
+    if (deviceId != null) {
+      $result.deviceId = deviceId;
+    }
+    if (pinProtection != null) {
+      $result.pinProtection = pinProtection;
+    }
+    if (passphraseProtection != null) {
+      $result.passphraseProtection = passphraseProtection;
+    }
+    if (language != null) {
+      $result.language = language;
+    }
+    if (label != null) {
+      $result.label = label;
+    }
+    if (initialized != null) {
+      $result.initialized = initialized;
+    }
+    if (revision != null) {
+      $result.revision = revision;
+    }
+    if (bootloaderHash != null) {
+      $result.bootloaderHash = bootloaderHash;
+    }
+    if (imported != null) {
+      $result.imported = imported;
+    }
+    if (unlocked != null) {
+      $result.unlocked = unlocked;
+    }
+    if (passphraseCached != null) {
+      // ignore: deprecated_member_use_from_same_package
+      $result.passphraseCached = passphraseCached;
+    }
+    if (firmwarePresent != null) {
+      $result.firmwarePresent = firmwarePresent;
+    }
+    if (needsBackup != null) {
+      $result.needsBackup = needsBackup;
+    }
+    if (flags != null) {
+      $result.flags = flags;
+    }
+    if (model != null) {
+      $result.model = model;
+    }
+    if (fwMajor != null) {
+      $result.fwMajor = fwMajor;
+    }
+    if (fwMinor != null) {
+      $result.fwMinor = fwMinor;
+    }
+    if (fwPatch != null) {
+      $result.fwPatch = fwPatch;
+    }
+    if (fwVendor != null) {
+      $result.fwVendor = fwVendor;
+    }
+    if (unfinishedBackup != null) {
+      $result.unfinishedBackup = unfinishedBackup;
+    }
+    if (noBackup != null) {
+      $result.noBackup = noBackup;
+    }
+    if (recoveryMode != null) {
+      $result.recoveryMode = recoveryMode;
+    }
+    if (capabilities != null) {
+      $result.capabilities.addAll(capabilities);
+    }
+    if (backupType != null) {
+      $result.backupType = backupType;
+    }
+    if (sdCardPresent != null) {
+      $result.sdCardPresent = sdCardPresent;
+    }
+    if (sdProtection != null) {
+      $result.sdProtection = sdProtection;
+    }
+    if (wipeCodeProtection != null) {
+      $result.wipeCodeProtection = wipeCodeProtection;
+    }
+    if (sessionId != null) {
+      $result.sessionId = sessionId;
+    }
+    if (passphraseAlwaysOnDevice != null) {
+      $result.passphraseAlwaysOnDevice = passphraseAlwaysOnDevice;
+    }
+    if (safetyChecks != null) {
+      $result.safetyChecks = safetyChecks;
+    }
+    if (autoLockDelayMs != null) {
+      $result.autoLockDelayMs = autoLockDelayMs;
+    }
+    if (displayRotation != null) {
+      $result.displayRotation = displayRotation;
+    }
+    if (experimentalFeatures != null) {
+      $result.experimentalFeatures = experimentalFeatures;
+    }
+    if (busy != null) {
+      $result.busy = busy;
+    }
+    if (homescreenFormat != null) {
+      $result.homescreenFormat = homescreenFormat;
+    }
+    if (hidePassphraseFromHost != null) {
+      $result.hidePassphraseFromHost = hidePassphraseFromHost;
+    }
+    if (internalModel != null) {
+      $result.internalModel = internalModel;
+    }
+    if (unitColor != null) {
+      $result.unitColor = unitColor;
+    }
+    if (unitBtconly != null) {
+      $result.unitBtconly = unitBtconly;
+    }
+    if (homescreenWidth != null) {
+      $result.homescreenWidth = homescreenWidth;
+    }
+    if (homescreenHeight != null) {
+      $result.homescreenHeight = homescreenHeight;
+    }
+    if (bootloaderLocked != null) {
+      $result.bootloaderLocked = bootloaderLocked;
+    }
+    if (languageVersionMatches != null) {
+      $result.languageVersionMatches = languageVersionMatches;
+    }
+    return $result;
+  }
+  Features._() : super();
+  factory Features.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Features.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Features', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'vendor')
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'majorVersion', $pb.PbFieldType.QU3)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'minorVersion', $pb.PbFieldType.QU3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'patchVersion', $pb.PbFieldType.QU3)
+    ..aOB(5, _omitFieldNames ? '' : 'bootloaderMode')
+    ..aOS(6, _omitFieldNames ? '' : 'deviceId')
+    ..aOB(7, _omitFieldNames ? '' : 'pinProtection')
+    ..aOB(8, _omitFieldNames ? '' : 'passphraseProtection')
+    ..aOS(9, _omitFieldNames ? '' : 'language')
+    ..aOS(10, _omitFieldNames ? '' : 'label')
+    ..aOB(12, _omitFieldNames ? '' : 'initialized')
+    ..a<$core.List<$core.int>>(13, _omitFieldNames ? '' : 'revision', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(14, _omitFieldNames ? '' : 'bootloaderHash', $pb.PbFieldType.OY)
+    ..aOB(15, _omitFieldNames ? '' : 'imported')
+    ..aOB(16, _omitFieldNames ? '' : 'unlocked')
+    ..aOB(17, _omitFieldNames ? '' : 'PassphraseCached')
+    ..aOB(18, _omitFieldNames ? '' : 'firmwarePresent')
+    ..aOB(19, _omitFieldNames ? '' : 'needsBackup')
+    ..a<$core.int>(20, _omitFieldNames ? '' : 'flags', $pb.PbFieldType.OU3)
+    ..aOS(21, _omitFieldNames ? '' : 'model')
+    ..a<$core.int>(22, _omitFieldNames ? '' : 'fwMajor', $pb.PbFieldType.OU3)
+    ..a<$core.int>(23, _omitFieldNames ? '' : 'fwMinor', $pb.PbFieldType.OU3)
+    ..a<$core.int>(24, _omitFieldNames ? '' : 'fwPatch', $pb.PbFieldType.OU3)
+    ..aOS(25, _omitFieldNames ? '' : 'fwVendor')
+    ..aOB(27, _omitFieldNames ? '' : 'unfinishedBackup')
+    ..aOB(28, _omitFieldNames ? '' : 'noBackup')
+    ..aOB(29, _omitFieldNames ? '' : 'recoveryMode')
+    ..pc<Features_Capability>(30, _omitFieldNames ? '' : 'capabilities', $pb.PbFieldType.PE, valueOf: Features_Capability.valueOf, enumValues: Features_Capability.values, defaultEnumValue: Features_Capability.Capability_Bitcoin)
+    ..e<BackupType>(31, _omitFieldNames ? '' : 'backupType', $pb.PbFieldType.OE, defaultOrMaker: BackupType.Bip39, valueOf: BackupType.valueOf, enumValues: BackupType.values)
+    ..aOB(32, _omitFieldNames ? '' : 'sdCardPresent')
+    ..aOB(33, _omitFieldNames ? '' : 'sdProtection')
+    ..aOB(34, _omitFieldNames ? '' : 'wipeCodeProtection')
+    ..a<$core.List<$core.int>>(35, _omitFieldNames ? '' : 'sessionId', $pb.PbFieldType.OY)
+    ..aOB(36, _omitFieldNames ? '' : 'passphraseAlwaysOnDevice')
+    ..e<SafetyCheckLevel>(37, _omitFieldNames ? '' : 'safetyChecks', $pb.PbFieldType.OE, defaultOrMaker: SafetyCheckLevel.Strict, valueOf: SafetyCheckLevel.valueOf, enumValues: SafetyCheckLevel.values)
+    ..a<$core.int>(38, _omitFieldNames ? '' : 'autoLockDelayMs', $pb.PbFieldType.OU3)
+    ..a<$core.int>(39, _omitFieldNames ? '' : 'displayRotation', $pb.PbFieldType.OU3)
+    ..aOB(40, _omitFieldNames ? '' : 'experimentalFeatures')
+    ..aOB(41, _omitFieldNames ? '' : 'busy')
+    ..e<HomescreenFormat>(42, _omitFieldNames ? '' : 'homescreenFormat', $pb.PbFieldType.OE, defaultOrMaker: HomescreenFormat.Toif, valueOf: HomescreenFormat.valueOf, enumValues: HomescreenFormat.values)
+    ..aOB(43, _omitFieldNames ? '' : 'hidePassphraseFromHost')
+    ..aOS(44, _omitFieldNames ? '' : 'internalModel')
+    ..a<$core.int>(45, _omitFieldNames ? '' : 'unitColor', $pb.PbFieldType.OU3)
+    ..aOB(46, _omitFieldNames ? '' : 'unitBtconly')
+    ..a<$core.int>(47, _omitFieldNames ? '' : 'homescreenWidth', $pb.PbFieldType.OU3)
+    ..a<$core.int>(48, _omitFieldNames ? '' : 'homescreenHeight', $pb.PbFieldType.OU3)
+    ..aOB(49, _omitFieldNames ? '' : 'bootloaderLocked')
+    ..a<$core.bool>(50, _omitFieldNames ? '' : 'languageVersionMatches', $pb.PbFieldType.OB, defaultOrMaker: true)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Features clone() => Features()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Features copyWith(void Function(Features) updates) => super.copyWith((message) => updates(message as Features)) as Features;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Features create() => Features._();
+  Features createEmptyInstance() => create();
+  static $pb.PbList<Features> createRepeated() => $pb.PbList<Features>();
+  @$core.pragma('dart2js:noInline')
+  static Features getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Features>(create);
+  static Features? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get vendor => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set vendor($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasVendor() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearVendor() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get majorVersion => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set majorVersion($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMajorVersion() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMajorVersion() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get minorVersion => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set minorVersion($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasMinorVersion() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearMinorVersion() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get patchVersion => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set patchVersion($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasPatchVersion() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearPatchVersion() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.bool get bootloaderMode => $_getBF(4);
+  @$pb.TagNumber(5)
+  set bootloaderMode($core.bool v) { $_setBool(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasBootloaderMode() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearBootloaderMode() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.String get deviceId => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set deviceId($core.String v) { $_setString(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasDeviceId() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearDeviceId() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.bool get pinProtection => $_getBF(6);
+  @$pb.TagNumber(7)
+  set pinProtection($core.bool v) { $_setBool(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasPinProtection() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearPinProtection() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.bool get passphraseProtection => $_getBF(7);
+  @$pb.TagNumber(8)
+  set passphraseProtection($core.bool v) { $_setBool(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasPassphraseProtection() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearPassphraseProtection() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.String get language => $_getSZ(8);
+  @$pb.TagNumber(9)
+  set language($core.String v) { $_setString(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasLanguage() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearLanguage() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.String get label => $_getSZ(9);
+  @$pb.TagNumber(10)
+  set label($core.String v) { $_setString(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasLabel() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearLabel() => clearField(10);
+
+  @$pb.TagNumber(12)
+  $core.bool get initialized => $_getBF(10);
+  @$pb.TagNumber(12)
+  set initialized($core.bool v) { $_setBool(10, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasInitialized() => $_has(10);
+  @$pb.TagNumber(12)
+  void clearInitialized() => clearField(12);
+
+  @$pb.TagNumber(13)
+  $core.List<$core.int> get revision => $_getN(11);
+  @$pb.TagNumber(13)
+  set revision($core.List<$core.int> v) { $_setBytes(11, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasRevision() => $_has(11);
+  @$pb.TagNumber(13)
+  void clearRevision() => clearField(13);
+
+  @$pb.TagNumber(14)
+  $core.List<$core.int> get bootloaderHash => $_getN(12);
+  @$pb.TagNumber(14)
+  set bootloaderHash($core.List<$core.int> v) { $_setBytes(12, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasBootloaderHash() => $_has(12);
+  @$pb.TagNumber(14)
+  void clearBootloaderHash() => clearField(14);
+
+  @$pb.TagNumber(15)
+  $core.bool get imported => $_getBF(13);
+  @$pb.TagNumber(15)
+  set imported($core.bool v) { $_setBool(13, v); }
+  @$pb.TagNumber(15)
+  $core.bool hasImported() => $_has(13);
+  @$pb.TagNumber(15)
+  void clearImported() => clearField(15);
+
+  @$pb.TagNumber(16)
+  $core.bool get unlocked => $_getBF(14);
+  @$pb.TagNumber(16)
+  set unlocked($core.bool v) { $_setBool(14, v); }
+  @$pb.TagNumber(16)
+  $core.bool hasUnlocked() => $_has(14);
+  @$pb.TagNumber(16)
+  void clearUnlocked() => clearField(16);
+
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(17)
+  $core.bool get passphraseCached => $_getBF(15);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(17)
+  set passphraseCached($core.bool v) { $_setBool(15, v); }
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(17)
+  $core.bool hasPassphraseCached() => $_has(15);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(17)
+  void clearPassphraseCached() => clearField(17);
+
+  @$pb.TagNumber(18)
+  $core.bool get firmwarePresent => $_getBF(16);
+  @$pb.TagNumber(18)
+  set firmwarePresent($core.bool v) { $_setBool(16, v); }
+  @$pb.TagNumber(18)
+  $core.bool hasFirmwarePresent() => $_has(16);
+  @$pb.TagNumber(18)
+  void clearFirmwarePresent() => clearField(18);
+
+  @$pb.TagNumber(19)
+  $core.bool get needsBackup => $_getBF(17);
+  @$pb.TagNumber(19)
+  set needsBackup($core.bool v) { $_setBool(17, v); }
+  @$pb.TagNumber(19)
+  $core.bool hasNeedsBackup() => $_has(17);
+  @$pb.TagNumber(19)
+  void clearNeedsBackup() => clearField(19);
+
+  @$pb.TagNumber(20)
+  $core.int get flags => $_getIZ(18);
+  @$pb.TagNumber(20)
+  set flags($core.int v) { $_setUnsignedInt32(18, v); }
+  @$pb.TagNumber(20)
+  $core.bool hasFlags() => $_has(18);
+  @$pb.TagNumber(20)
+  void clearFlags() => clearField(20);
+
+  @$pb.TagNumber(21)
+  $core.String get model => $_getSZ(19);
+  @$pb.TagNumber(21)
+  set model($core.String v) { $_setString(19, v); }
+  @$pb.TagNumber(21)
+  $core.bool hasModel() => $_has(19);
+  @$pb.TagNumber(21)
+  void clearModel() => clearField(21);
+
+  @$pb.TagNumber(22)
+  $core.int get fwMajor => $_getIZ(20);
+  @$pb.TagNumber(22)
+  set fwMajor($core.int v) { $_setUnsignedInt32(20, v); }
+  @$pb.TagNumber(22)
+  $core.bool hasFwMajor() => $_has(20);
+  @$pb.TagNumber(22)
+  void clearFwMajor() => clearField(22);
+
+  @$pb.TagNumber(23)
+  $core.int get fwMinor => $_getIZ(21);
+  @$pb.TagNumber(23)
+  set fwMinor($core.int v) { $_setUnsignedInt32(21, v); }
+  @$pb.TagNumber(23)
+  $core.bool hasFwMinor() => $_has(21);
+  @$pb.TagNumber(23)
+  void clearFwMinor() => clearField(23);
+
+  @$pb.TagNumber(24)
+  $core.int get fwPatch => $_getIZ(22);
+  @$pb.TagNumber(24)
+  set fwPatch($core.int v) { $_setUnsignedInt32(22, v); }
+  @$pb.TagNumber(24)
+  $core.bool hasFwPatch() => $_has(22);
+  @$pb.TagNumber(24)
+  void clearFwPatch() => clearField(24);
+
+  @$pb.TagNumber(25)
+  $core.String get fwVendor => $_getSZ(23);
+  @$pb.TagNumber(25)
+  set fwVendor($core.String v) { $_setString(23, v); }
+  @$pb.TagNumber(25)
+  $core.bool hasFwVendor() => $_has(23);
+  @$pb.TagNumber(25)
+  void clearFwVendor() => clearField(25);
+
+  /// optional bytes fw_vendor_keys = 26;      // obsoleted, use fw_vendor
+  @$pb.TagNumber(27)
+  $core.bool get unfinishedBackup => $_getBF(24);
+  @$pb.TagNumber(27)
+  set unfinishedBackup($core.bool v) { $_setBool(24, v); }
+  @$pb.TagNumber(27)
+  $core.bool hasUnfinishedBackup() => $_has(24);
+  @$pb.TagNumber(27)
+  void clearUnfinishedBackup() => clearField(27);
+
+  @$pb.TagNumber(28)
+  $core.bool get noBackup => $_getBF(25);
+  @$pb.TagNumber(28)
+  set noBackup($core.bool v) { $_setBool(25, v); }
+  @$pb.TagNumber(28)
+  $core.bool hasNoBackup() => $_has(25);
+  @$pb.TagNumber(28)
+  void clearNoBackup() => clearField(28);
+
+  @$pb.TagNumber(29)
+  $core.bool get recoveryMode => $_getBF(26);
+  @$pb.TagNumber(29)
+  set recoveryMode($core.bool v) { $_setBool(26, v); }
+  @$pb.TagNumber(29)
+  $core.bool hasRecoveryMode() => $_has(26);
+  @$pb.TagNumber(29)
+  void clearRecoveryMode() => clearField(29);
+
+  @$pb.TagNumber(30)
+  $core.List<Features_Capability> get capabilities => $_getList(27);
+
+  @$pb.TagNumber(31)
+  BackupType get backupType => $_getN(28);
+  @$pb.TagNumber(31)
+  set backupType(BackupType v) { setField(31, v); }
+  @$pb.TagNumber(31)
+  $core.bool hasBackupType() => $_has(28);
+  @$pb.TagNumber(31)
+  void clearBackupType() => clearField(31);
+
+  @$pb.TagNumber(32)
+  $core.bool get sdCardPresent => $_getBF(29);
+  @$pb.TagNumber(32)
+  set sdCardPresent($core.bool v) { $_setBool(29, v); }
+  @$pb.TagNumber(32)
+  $core.bool hasSdCardPresent() => $_has(29);
+  @$pb.TagNumber(32)
+  void clearSdCardPresent() => clearField(32);
+
+  @$pb.TagNumber(33)
+  $core.bool get sdProtection => $_getBF(30);
+  @$pb.TagNumber(33)
+  set sdProtection($core.bool v) { $_setBool(30, v); }
+  @$pb.TagNumber(33)
+  $core.bool hasSdProtection() => $_has(30);
+  @$pb.TagNumber(33)
+  void clearSdProtection() => clearField(33);
+
+  @$pb.TagNumber(34)
+  $core.bool get wipeCodeProtection => $_getBF(31);
+  @$pb.TagNumber(34)
+  set wipeCodeProtection($core.bool v) { $_setBool(31, v); }
+  @$pb.TagNumber(34)
+  $core.bool hasWipeCodeProtection() => $_has(31);
+  @$pb.TagNumber(34)
+  void clearWipeCodeProtection() => clearField(34);
+
+  @$pb.TagNumber(35)
+  $core.List<$core.int> get sessionId => $_getN(32);
+  @$pb.TagNumber(35)
+  set sessionId($core.List<$core.int> v) { $_setBytes(32, v); }
+  @$pb.TagNumber(35)
+  $core.bool hasSessionId() => $_has(32);
+  @$pb.TagNumber(35)
+  void clearSessionId() => clearField(35);
+
+  @$pb.TagNumber(36)
+  $core.bool get passphraseAlwaysOnDevice => $_getBF(33);
+  @$pb.TagNumber(36)
+  set passphraseAlwaysOnDevice($core.bool v) { $_setBool(33, v); }
+  @$pb.TagNumber(36)
+  $core.bool hasPassphraseAlwaysOnDevice() => $_has(33);
+  @$pb.TagNumber(36)
+  void clearPassphraseAlwaysOnDevice() => clearField(36);
+
+  @$pb.TagNumber(37)
+  SafetyCheckLevel get safetyChecks => $_getN(34);
+  @$pb.TagNumber(37)
+  set safetyChecks(SafetyCheckLevel v) { setField(37, v); }
+  @$pb.TagNumber(37)
+  $core.bool hasSafetyChecks() => $_has(34);
+  @$pb.TagNumber(37)
+  void clearSafetyChecks() => clearField(37);
+
+  @$pb.TagNumber(38)
+  $core.int get autoLockDelayMs => $_getIZ(35);
+  @$pb.TagNumber(38)
+  set autoLockDelayMs($core.int v) { $_setUnsignedInt32(35, v); }
+  @$pb.TagNumber(38)
+  $core.bool hasAutoLockDelayMs() => $_has(35);
+  @$pb.TagNumber(38)
+  void clearAutoLockDelayMs() => clearField(38);
+
+  @$pb.TagNumber(39)
+  $core.int get displayRotation => $_getIZ(36);
+  @$pb.TagNumber(39)
+  set displayRotation($core.int v) { $_setUnsignedInt32(36, v); }
+  @$pb.TagNumber(39)
+  $core.bool hasDisplayRotation() => $_has(36);
+  @$pb.TagNumber(39)
+  void clearDisplayRotation() => clearField(39);
+
+  @$pb.TagNumber(40)
+  $core.bool get experimentalFeatures => $_getBF(37);
+  @$pb.TagNumber(40)
+  set experimentalFeatures($core.bool v) { $_setBool(37, v); }
+  @$pb.TagNumber(40)
+  $core.bool hasExperimentalFeatures() => $_has(37);
+  @$pb.TagNumber(40)
+  void clearExperimentalFeatures() => clearField(40);
+
+  @$pb.TagNumber(41)
+  $core.bool get busy => $_getBF(38);
+  @$pb.TagNumber(41)
+  set busy($core.bool v) { $_setBool(38, v); }
+  @$pb.TagNumber(41)
+  $core.bool hasBusy() => $_has(38);
+  @$pb.TagNumber(41)
+  void clearBusy() => clearField(41);
+
+  @$pb.TagNumber(42)
+  HomescreenFormat get homescreenFormat => $_getN(39);
+  @$pb.TagNumber(42)
+  set homescreenFormat(HomescreenFormat v) { setField(42, v); }
+  @$pb.TagNumber(42)
+  $core.bool hasHomescreenFormat() => $_has(39);
+  @$pb.TagNumber(42)
+  void clearHomescreenFormat() => clearField(42);
+
+  @$pb.TagNumber(43)
+  $core.bool get hidePassphraseFromHost => $_getBF(40);
+  @$pb.TagNumber(43)
+  set hidePassphraseFromHost($core.bool v) { $_setBool(40, v); }
+  @$pb.TagNumber(43)
+  $core.bool hasHidePassphraseFromHost() => $_has(40);
+  @$pb.TagNumber(43)
+  void clearHidePassphraseFromHost() => clearField(43);
+
+  @$pb.TagNumber(44)
+  $core.String get internalModel => $_getSZ(41);
+  @$pb.TagNumber(44)
+  set internalModel($core.String v) { $_setString(41, v); }
+  @$pb.TagNumber(44)
+  $core.bool hasInternalModel() => $_has(41);
+  @$pb.TagNumber(44)
+  void clearInternalModel() => clearField(44);
+
+  @$pb.TagNumber(45)
+  $core.int get unitColor => $_getIZ(42);
+  @$pb.TagNumber(45)
+  set unitColor($core.int v) { $_setUnsignedInt32(42, v); }
+  @$pb.TagNumber(45)
+  $core.bool hasUnitColor() => $_has(42);
+  @$pb.TagNumber(45)
+  void clearUnitColor() => clearField(45);
+
+  @$pb.TagNumber(46)
+  $core.bool get unitBtconly => $_getBF(43);
+  @$pb.TagNumber(46)
+  set unitBtconly($core.bool v) { $_setBool(43, v); }
+  @$pb.TagNumber(46)
+  $core.bool hasUnitBtconly() => $_has(43);
+  @$pb.TagNumber(46)
+  void clearUnitBtconly() => clearField(46);
+
+  @$pb.TagNumber(47)
+  $core.int get homescreenWidth => $_getIZ(44);
+  @$pb.TagNumber(47)
+  set homescreenWidth($core.int v) { $_setUnsignedInt32(44, v); }
+  @$pb.TagNumber(47)
+  $core.bool hasHomescreenWidth() => $_has(44);
+  @$pb.TagNumber(47)
+  void clearHomescreenWidth() => clearField(47);
+
+  @$pb.TagNumber(48)
+  $core.int get homescreenHeight => $_getIZ(45);
+  @$pb.TagNumber(48)
+  set homescreenHeight($core.int v) { $_setUnsignedInt32(45, v); }
+  @$pb.TagNumber(48)
+  $core.bool hasHomescreenHeight() => $_has(45);
+  @$pb.TagNumber(48)
+  void clearHomescreenHeight() => clearField(48);
+
+  @$pb.TagNumber(49)
+  $core.bool get bootloaderLocked => $_getBF(46);
+  @$pb.TagNumber(49)
+  set bootloaderLocked($core.bool v) { $_setBool(46, v); }
+  @$pb.TagNumber(49)
+  $core.bool hasBootloaderLocked() => $_has(46);
+  @$pb.TagNumber(49)
+  void clearBootloaderLocked() => clearField(49);
+
+  @$pb.TagNumber(50)
+  $core.bool get languageVersionMatches => $_getB(47, true);
+  @$pb.TagNumber(50)
+  set languageVersionMatches($core.bool v) { $_setBool(47, v); }
+  @$pb.TagNumber(50)
+  $core.bool hasLanguageVersionMatches() => $_has(47);
+  @$pb.TagNumber(50)
+  void clearLanguageVersionMatches() => clearField(50);
+}
+
+/// *
+///  Request: soft-lock the device. Following actions will require PIN. Passphrases remain cached.
+///  @start
+///  @next Success
+class LockDevice extends $pb.GeneratedMessage {
+  factory LockDevice() => create();
+  LockDevice._() : super();
+  factory LockDevice.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory LockDevice.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'LockDevice', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  LockDevice clone() => LockDevice()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  LockDevice copyWith(void Function(LockDevice) updates) => super.copyWith((message) => updates(message as LockDevice)) as LockDevice;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static LockDevice create() => LockDevice._();
+  LockDevice createEmptyInstance() => create();
+  static $pb.PbList<LockDevice> createRepeated() => $pb.PbList<LockDevice>();
+  @$core.pragma('dart2js:noInline')
+  static LockDevice getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LockDevice>(create);
+  static LockDevice? _defaultInstance;
+}
+
+/// *
+///  Request: Show a "Do not disconnect" dialog instead of the standard homescreen.
+///  @start
+///  @next Success
+class SetBusy extends $pb.GeneratedMessage {
+  factory SetBusy({
+    $core.int? expiryMs,
+  }) {
+    final $result = create();
+    if (expiryMs != null) {
+      $result.expiryMs = expiryMs;
+    }
+    return $result;
+  }
+  SetBusy._() : super();
+  factory SetBusy.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetBusy.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetBusy', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'expiryMs', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SetBusy clone() => SetBusy()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetBusy copyWith(void Function(SetBusy) updates) => super.copyWith((message) => updates(message as SetBusy)) as SetBusy;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SetBusy create() => SetBusy._();
+  SetBusy createEmptyInstance() => create();
+  static $pb.PbList<SetBusy> createRepeated() => $pb.PbList<SetBusy>();
+  @$core.pragma('dart2js:noInline')
+  static SetBusy getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetBusy>(create);
+  static SetBusy? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get expiryMs => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set expiryMs($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasExpiryMs() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearExpiryMs() => clearField(1);
+}
+
+/// *
+///  Request: end the current sesson. Following actions must call Initialize again.
+///  Cache for the current session is discarded, other sessions remain intact.
+///  Device is not PIN-locked.
+///  @start
+///  @next Success
+class EndSession extends $pb.GeneratedMessage {
+  factory EndSession() => create();
+  EndSession._() : super();
+  factory EndSession.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EndSession.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EndSession', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EndSession clone() => EndSession()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EndSession copyWith(void Function(EndSession) updates) => super.copyWith((message) => updates(message as EndSession)) as EndSession;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EndSession create() => EndSession._();
+  EndSession createEmptyInstance() => create();
+  static $pb.PbList<EndSession> createRepeated() => $pb.PbList<EndSession>();
+  @$core.pragma('dart2js:noInline')
+  static EndSession getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EndSession>(create);
+  static EndSession? _defaultInstance;
+}
+
+/// *
+///  Request: change some property of the device, e.g. label or homescreen
+///  @start
+///  @next Success
+///  @next Failure
+class ApplySettings extends $pb.GeneratedMessage {
+  factory ApplySettings({
+  @$core.Deprecated('This field is deprecated.')
+    $core.String? language,
+    $core.String? label,
+    $core.bool? usePassphrase,
+    $core.List<$core.int>? homescreen,
+  @$core.Deprecated('This field is deprecated.')
+    $core.int? passphraseSource,
+    $core.int? autoLockDelayMs,
+    $core.int? displayRotation,
+    $core.bool? passphraseAlwaysOnDevice,
+    SafetyCheckLevel? safetyChecks,
+    $core.bool? experimentalFeatures,
+    $core.bool? hidePassphraseFromHost,
+  }) {
+    final $result = create();
+    if (language != null) {
+      // ignore: deprecated_member_use_from_same_package
+      $result.language = language;
+    }
+    if (label != null) {
+      $result.label = label;
+    }
+    if (usePassphrase != null) {
+      $result.usePassphrase = usePassphrase;
+    }
+    if (homescreen != null) {
+      $result.homescreen = homescreen;
+    }
+    if (passphraseSource != null) {
+      // ignore: deprecated_member_use_from_same_package
+      $result.passphraseSource = passphraseSource;
+    }
+    if (autoLockDelayMs != null) {
+      $result.autoLockDelayMs = autoLockDelayMs;
+    }
+    if (displayRotation != null) {
+      $result.displayRotation = displayRotation;
+    }
+    if (passphraseAlwaysOnDevice != null) {
+      $result.passphraseAlwaysOnDevice = passphraseAlwaysOnDevice;
+    }
+    if (safetyChecks != null) {
+      $result.safetyChecks = safetyChecks;
+    }
+    if (experimentalFeatures != null) {
+      $result.experimentalFeatures = experimentalFeatures;
+    }
+    if (hidePassphraseFromHost != null) {
+      $result.hidePassphraseFromHost = hidePassphraseFromHost;
+    }
+    return $result;
+  }
+  ApplySettings._() : super();
+  factory ApplySettings.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ApplySettings.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ApplySettings', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'language')
+    ..aOS(2, _omitFieldNames ? '' : 'label')
+    ..aOB(3, _omitFieldNames ? '' : 'usePassphrase')
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'homescreen', $pb.PbFieldType.OY)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'PassphraseSource', $pb.PbFieldType.OU3)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'autoLockDelayMs', $pb.PbFieldType.OU3)
+    ..a<$core.int>(7, _omitFieldNames ? '' : 'displayRotation', $pb.PbFieldType.OU3)
+    ..aOB(8, _omitFieldNames ? '' : 'passphraseAlwaysOnDevice')
+    ..e<SafetyCheckLevel>(9, _omitFieldNames ? '' : 'safetyChecks', $pb.PbFieldType.OE, defaultOrMaker: SafetyCheckLevel.Strict, valueOf: SafetyCheckLevel.valueOf, enumValues: SafetyCheckLevel.values)
+    ..aOB(10, _omitFieldNames ? '' : 'experimentalFeatures')
+    ..aOB(11, _omitFieldNames ? '' : 'hidePassphraseFromHost')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ApplySettings clone() => ApplySettings()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ApplySettings copyWith(void Function(ApplySettings) updates) => super.copyWith((message) => updates(message as ApplySettings)) as ApplySettings;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ApplySettings create() => ApplySettings._();
+  ApplySettings createEmptyInstance() => create();
+  static $pb.PbList<ApplySettings> createRepeated() => $pb.PbList<ApplySettings>();
+  @$core.pragma('dart2js:noInline')
+  static ApplySettings getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ApplySettings>(create);
+  static ApplySettings? _defaultInstance;
+
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(1)
+  $core.String get language => $_getSZ(0);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(1)
+  set language($core.String v) { $_setString(0, v); }
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(1)
+  $core.bool hasLanguage() => $_has(0);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(1)
+  void clearLanguage() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get label => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set label($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasLabel() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearLabel() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get usePassphrase => $_getBF(2);
+  @$pb.TagNumber(3)
+  set usePassphrase($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasUsePassphrase() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearUsePassphrase() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get homescreen => $_getN(3);
+  @$pb.TagNumber(4)
+  set homescreen($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasHomescreen() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearHomescreen() => clearField(4);
+
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(5)
+  $core.int get passphraseSource => $_getIZ(4);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(5)
+  set passphraseSource($core.int v) { $_setUnsignedInt32(4, v); }
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(5)
+  $core.bool hasPassphraseSource() => $_has(4);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(5)
+  void clearPassphraseSource() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.int get autoLockDelayMs => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set autoLockDelayMs($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasAutoLockDelayMs() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearAutoLockDelayMs() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.int get displayRotation => $_getIZ(6);
+  @$pb.TagNumber(7)
+  set displayRotation($core.int v) { $_setUnsignedInt32(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasDisplayRotation() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearDisplayRotation() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.bool get passphraseAlwaysOnDevice => $_getBF(7);
+  @$pb.TagNumber(8)
+  set passphraseAlwaysOnDevice($core.bool v) { $_setBool(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasPassphraseAlwaysOnDevice() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearPassphraseAlwaysOnDevice() => clearField(8);
+
+  @$pb.TagNumber(9)
+  SafetyCheckLevel get safetyChecks => $_getN(8);
+  @$pb.TagNumber(9)
+  set safetyChecks(SafetyCheckLevel v) { setField(9, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasSafetyChecks() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearSafetyChecks() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.bool get experimentalFeatures => $_getBF(9);
+  @$pb.TagNumber(10)
+  set experimentalFeatures($core.bool v) { $_setBool(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasExperimentalFeatures() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearExperimentalFeatures() => clearField(10);
+
+  @$pb.TagNumber(11)
+  $core.bool get hidePassphraseFromHost => $_getBF(10);
+  @$pb.TagNumber(11)
+  set hidePassphraseFromHost($core.bool v) { $_setBool(10, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasHidePassphraseFromHost() => $_has(10);
+  @$pb.TagNumber(11)
+  void clearHidePassphraseFromHost() => clearField(11);
+}
+
+/// *
+///  Request: change the device language via translation data.
+///  Does not send the translation data itself, as they are too large for one message.
+///  Device will request the translation data in chunks.
+///  @start
+///  @next TranslationDataRequest
+///  @next Failure
+class ChangeLanguage extends $pb.GeneratedMessage {
+  factory ChangeLanguage({
+    $core.int? dataLength,
+    $core.bool? showDisplay,
+  }) {
+    final $result = create();
+    if (dataLength != null) {
+      $result.dataLength = dataLength;
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    return $result;
+  }
+  ChangeLanguage._() : super();
+  factory ChangeLanguage.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ChangeLanguage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ChangeLanguage', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'dataLength', $pb.PbFieldType.QU3)
+    ..aOB(2, _omitFieldNames ? '' : 'showDisplay')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ChangeLanguage clone() => ChangeLanguage()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ChangeLanguage copyWith(void Function(ChangeLanguage) updates) => super.copyWith((message) => updates(message as ChangeLanguage)) as ChangeLanguage;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ChangeLanguage create() => ChangeLanguage._();
+  ChangeLanguage createEmptyInstance() => create();
+  static $pb.PbList<ChangeLanguage> createRepeated() => $pb.PbList<ChangeLanguage>();
+  @$core.pragma('dart2js:noInline')
+  static ChangeLanguage getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChangeLanguage>(create);
+  static ChangeLanguage? _defaultInstance;
+
+  /// byte length of the whole translation blob (set to 0 for default language - english)
+  @$pb.TagNumber(1)
+  $core.int get dataLength => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set dataLength($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDataLength() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDataLength() => clearField(1);
+
+  /// Prompt the user on screen.
+  /// In certain conditions (such as freshly installed device), the confirmation prompt
+  /// is not mandatory. Setting show_display=false will skip the prompt if that's
+  /// the case. If the device does not allow skipping the prompt, a request with
+  /// show_display=false will return a failure. (This way the host can safely try
+  /// to change the language without invoking a prompt.)
+  /// Setting show_display to true will always show the prompt.
+  /// Leaving the option unset will show the prompt only when necessary.
+  @$pb.TagNumber(2)
+  $core.bool get showDisplay => $_getBF(1);
+  @$pb.TagNumber(2)
+  set showDisplay($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasShowDisplay() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearShowDisplay() => clearField(2);
+}
+
+/// *
+///  Response: Device asks for more data from transaction payload.
+///  @end
+///  @next TranslationDataAck
+class TranslationDataRequest extends $pb.GeneratedMessage {
+  factory TranslationDataRequest({
+    $core.int? dataLength,
+    $core.int? dataOffset,
+  }) {
+    final $result = create();
+    if (dataLength != null) {
+      $result.dataLength = dataLength;
+    }
+    if (dataOffset != null) {
+      $result.dataOffset = dataOffset;
+    }
+    return $result;
+  }
+  TranslationDataRequest._() : super();
+  factory TranslationDataRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TranslationDataRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TranslationDataRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'dataLength', $pb.PbFieldType.QU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'dataOffset', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TranslationDataRequest clone() => TranslationDataRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TranslationDataRequest copyWith(void Function(TranslationDataRequest) updates) => super.copyWith((message) => updates(message as TranslationDataRequest)) as TranslationDataRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TranslationDataRequest create() => TranslationDataRequest._();
+  TranslationDataRequest createEmptyInstance() => create();
+  static $pb.PbList<TranslationDataRequest> createRepeated() => $pb.PbList<TranslationDataRequest>();
+  @$core.pragma('dart2js:noInline')
+  static TranslationDataRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TranslationDataRequest>(create);
+  static TranslationDataRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get dataLength => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set dataLength($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDataLength() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDataLength() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get dataOffset => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set dataOffset($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasDataOffset() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearDataOffset() => clearField(2);
+}
+
+/// *
+///  Request: Translation payload data.
+///  @next TranslationDataRequest
+///  @next Success
+class TranslationDataAck extends $pb.GeneratedMessage {
+  factory TranslationDataAck({
+    $core.List<$core.int>? dataChunk,
+  }) {
+    final $result = create();
+    if (dataChunk != null) {
+      $result.dataChunk = dataChunk;
+    }
+    return $result;
+  }
+  TranslationDataAck._() : super();
+  factory TranslationDataAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TranslationDataAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TranslationDataAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'dataChunk', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TranslationDataAck clone() => TranslationDataAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TranslationDataAck copyWith(void Function(TranslationDataAck) updates) => super.copyWith((message) => updates(message as TranslationDataAck)) as TranslationDataAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TranslationDataAck create() => TranslationDataAck._();
+  TranslationDataAck createEmptyInstance() => create();
+  static $pb.PbList<TranslationDataAck> createRepeated() => $pb.PbList<TranslationDataAck>();
+  @$core.pragma('dart2js:noInline')
+  static TranslationDataAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TranslationDataAck>(create);
+  static TranslationDataAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get dataChunk => $_getN(0);
+  @$pb.TagNumber(1)
+  set dataChunk($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDataChunk() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDataChunk() => clearField(1);
+}
+
+/// *
+///  Request: set flags of the device
+///  @start
+///  @next Success
+///  @next Failure
+class ApplyFlags extends $pb.GeneratedMessage {
+  factory ApplyFlags({
+    $core.int? flags,
+  }) {
+    final $result = create();
+    if (flags != null) {
+      $result.flags = flags;
+    }
+    return $result;
+  }
+  ApplyFlags._() : super();
+  factory ApplyFlags.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ApplyFlags.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ApplyFlags', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'flags', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ApplyFlags clone() => ApplyFlags()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ApplyFlags copyWith(void Function(ApplyFlags) updates) => super.copyWith((message) => updates(message as ApplyFlags)) as ApplyFlags;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ApplyFlags create() => ApplyFlags._();
+  ApplyFlags createEmptyInstance() => create();
+  static $pb.PbList<ApplyFlags> createRepeated() => $pb.PbList<ApplyFlags>();
+  @$core.pragma('dart2js:noInline')
+  static ApplyFlags getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ApplyFlags>(create);
+  static ApplyFlags? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get flags => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set flags($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasFlags() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearFlags() => clearField(1);
+}
+
+/// *
+///  Request: Starts workflow for setting/changing/removing the PIN
+///  @start
+///  @next Success
+///  @next Failure
+class ChangePin extends $pb.GeneratedMessage {
+  factory ChangePin({
+    $core.bool? remove,
+  }) {
+    final $result = create();
+    if (remove != null) {
+      $result.remove = remove;
+    }
+    return $result;
+  }
+  ChangePin._() : super();
+  factory ChangePin.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ChangePin.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ChangePin', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..aOB(1, _omitFieldNames ? '' : 'remove')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ChangePin clone() => ChangePin()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ChangePin copyWith(void Function(ChangePin) updates) => super.copyWith((message) => updates(message as ChangePin)) as ChangePin;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ChangePin create() => ChangePin._();
+  ChangePin createEmptyInstance() => create();
+  static $pb.PbList<ChangePin> createRepeated() => $pb.PbList<ChangePin>();
+  @$core.pragma('dart2js:noInline')
+  static ChangePin getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChangePin>(create);
+  static ChangePin? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.bool get remove => $_getBF(0);
+  @$pb.TagNumber(1)
+  set remove($core.bool v) { $_setBool(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasRemove() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRemove() => clearField(1);
+}
+
+/// *
+///  Request: Starts workflow for setting/removing the wipe code
+///  @start
+///  @next Success
+///  @next Failure
+class ChangeWipeCode extends $pb.GeneratedMessage {
+  factory ChangeWipeCode({
+    $core.bool? remove,
+  }) {
+    final $result = create();
+    if (remove != null) {
+      $result.remove = remove;
+    }
+    return $result;
+  }
+  ChangeWipeCode._() : super();
+  factory ChangeWipeCode.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ChangeWipeCode.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ChangeWipeCode', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..aOB(1, _omitFieldNames ? '' : 'remove')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ChangeWipeCode clone() => ChangeWipeCode()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ChangeWipeCode copyWith(void Function(ChangeWipeCode) updates) => super.copyWith((message) => updates(message as ChangeWipeCode)) as ChangeWipeCode;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ChangeWipeCode create() => ChangeWipeCode._();
+  ChangeWipeCode createEmptyInstance() => create();
+  static $pb.PbList<ChangeWipeCode> createRepeated() => $pb.PbList<ChangeWipeCode>();
+  @$core.pragma('dart2js:noInline')
+  static ChangeWipeCode getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChangeWipeCode>(create);
+  static ChangeWipeCode? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.bool get remove => $_getBF(0);
+  @$pb.TagNumber(1)
+  set remove($core.bool v) { $_setBool(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasRemove() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRemove() => clearField(1);
+}
+
+/// *
+///  Request: Starts workflow for enabling/regenerating/disabling SD card protection
+///  @start
+///  @next Success
+///  @next Failure
+class SdProtect extends $pb.GeneratedMessage {
+  factory SdProtect({
+    SdProtect_SdProtectOperationType? operation,
+  }) {
+    final $result = create();
+    if (operation != null) {
+      $result.operation = operation;
+    }
+    return $result;
+  }
+  SdProtect._() : super();
+  factory SdProtect.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SdProtect.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SdProtect', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..e<SdProtect_SdProtectOperationType>(1, _omitFieldNames ? '' : 'operation', $pb.PbFieldType.QE, defaultOrMaker: SdProtect_SdProtectOperationType.DISABLE, valueOf: SdProtect_SdProtectOperationType.valueOf, enumValues: SdProtect_SdProtectOperationType.values)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SdProtect clone() => SdProtect()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SdProtect copyWith(void Function(SdProtect) updates) => super.copyWith((message) => updates(message as SdProtect)) as SdProtect;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SdProtect create() => SdProtect._();
+  SdProtect createEmptyInstance() => create();
+  static $pb.PbList<SdProtect> createRepeated() => $pb.PbList<SdProtect>();
+  @$core.pragma('dart2js:noInline')
+  static SdProtect getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SdProtect>(create);
+  static SdProtect? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  SdProtect_SdProtectOperationType get operation => $_getN(0);
+  @$pb.TagNumber(1)
+  set operation(SdProtect_SdProtectOperationType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasOperation() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearOperation() => clearField(1);
+}
+
+/// *
+///  Request: Test if the device is alive, device sends back the message in Success response
+///  @start
+///  @next Success
+class Ping extends $pb.GeneratedMessage {
+  factory Ping({
+    $core.String? message,
+    $core.bool? buttonProtection,
+  }) {
+    final $result = create();
+    if (message != null) {
+      $result.message = message;
+    }
+    if (buttonProtection != null) {
+      $result.buttonProtection = buttonProtection;
+    }
+    return $result;
+  }
+  Ping._() : super();
+  factory Ping.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Ping.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Ping', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'message')
+    ..aOB(2, _omitFieldNames ? '' : 'buttonProtection')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Ping clone() => Ping()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Ping copyWith(void Function(Ping) updates) => super.copyWith((message) => updates(message as Ping)) as Ping;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Ping create() => Ping._();
+  Ping createEmptyInstance() => create();
+  static $pb.PbList<Ping> createRepeated() => $pb.PbList<Ping>();
+  @$core.pragma('dart2js:noInline')
+  static Ping getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Ping>(create);
+  static Ping? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get message => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set message($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasMessage() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearMessage() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.bool get buttonProtection => $_getBF(1);
+  @$pb.TagNumber(2)
+  set buttonProtection($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasButtonProtection() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearButtonProtection() => clearField(2);
+}
+
+/// *
+///  Request: Abort last operation that required user interaction
+///  @start
+///  @next Failure
+class Cancel extends $pb.GeneratedMessage {
+  factory Cancel() => create();
+  Cancel._() : super();
+  factory Cancel.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Cancel.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Cancel', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Cancel clone() => Cancel()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Cancel copyWith(void Function(Cancel) updates) => super.copyWith((message) => updates(message as Cancel)) as Cancel;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Cancel create() => Cancel._();
+  Cancel createEmptyInstance() => create();
+  static $pb.PbList<Cancel> createRepeated() => $pb.PbList<Cancel>();
+  @$core.pragma('dart2js:noInline')
+  static Cancel getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Cancel>(create);
+  static Cancel? _defaultInstance;
+}
+
+/// *
+///  Request: Request a sample of random data generated by hardware RNG. May be used for testing.
+///  @start
+///  @next Entropy
+///  @next Failure
+class GetEntropy extends $pb.GeneratedMessage {
+  factory GetEntropy({
+    $core.int? size,
+  }) {
+    final $result = create();
+    if (size != null) {
+      $result.size = size;
+    }
+    return $result;
+  }
+  GetEntropy._() : super();
+  factory GetEntropy.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetEntropy.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetEntropy', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'size', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetEntropy clone() => GetEntropy()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetEntropy copyWith(void Function(GetEntropy) updates) => super.copyWith((message) => updates(message as GetEntropy)) as GetEntropy;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetEntropy create() => GetEntropy._();
+  GetEntropy createEmptyInstance() => create();
+  static $pb.PbList<GetEntropy> createRepeated() => $pb.PbList<GetEntropy>();
+  @$core.pragma('dart2js:noInline')
+  static GetEntropy getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetEntropy>(create);
+  static GetEntropy? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get size => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set size($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSize() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSize() => clearField(1);
+}
+
+/// *
+///  Response: Reply with random data generated by internal RNG
+///  @end
+class Entropy extends $pb.GeneratedMessage {
+  factory Entropy({
+    $core.List<$core.int>? entropy,
+  }) {
+    final $result = create();
+    if (entropy != null) {
+      $result.entropy = entropy;
+    }
+    return $result;
+  }
+  Entropy._() : super();
+  factory Entropy.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Entropy.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Entropy', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'entropy', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Entropy clone() => Entropy()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Entropy copyWith(void Function(Entropy) updates) => super.copyWith((message) => updates(message as Entropy)) as Entropy;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Entropy create() => Entropy._();
+  Entropy createEmptyInstance() => create();
+  static $pb.PbList<Entropy> createRepeated() => $pb.PbList<Entropy>();
+  @$core.pragma('dart2js:noInline')
+  static Entropy getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Entropy>(create);
+  static Entropy? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get entropy => $_getN(0);
+  @$pb.TagNumber(1)
+  set entropy($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasEntropy() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearEntropy() => clearField(1);
+}
+
+/// *
+///  Request: Get a hash of the installed firmware combined with an optional challenge.
+///  @start
+///  @next FirmwareHash
+///  @next Failure
+class GetFirmwareHash extends $pb.GeneratedMessage {
+  factory GetFirmwareHash({
+    $core.List<$core.int>? challenge,
+  }) {
+    final $result = create();
+    if (challenge != null) {
+      $result.challenge = challenge;
+    }
+    return $result;
+  }
+  GetFirmwareHash._() : super();
+  factory GetFirmwareHash.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetFirmwareHash.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetFirmwareHash', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'challenge', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetFirmwareHash clone() => GetFirmwareHash()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetFirmwareHash copyWith(void Function(GetFirmwareHash) updates) => super.copyWith((message) => updates(message as GetFirmwareHash)) as GetFirmwareHash;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetFirmwareHash create() => GetFirmwareHash._();
+  GetFirmwareHash createEmptyInstance() => create();
+  static $pb.PbList<GetFirmwareHash> createRepeated() => $pb.PbList<GetFirmwareHash>();
+  @$core.pragma('dart2js:noInline')
+  static GetFirmwareHash getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetFirmwareHash>(create);
+  static GetFirmwareHash? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get challenge => $_getN(0);
+  @$pb.TagNumber(1)
+  set challenge($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasChallenge() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearChallenge() => clearField(1);
+}
+
+/// *
+///  Response: Hash of the installed firmware combined with the optional challenge.
+///  @end
+class FirmwareHash extends $pb.GeneratedMessage {
+  factory FirmwareHash({
+    $core.List<$core.int>? hash,
+  }) {
+    final $result = create();
+    if (hash != null) {
+      $result.hash = hash;
+    }
+    return $result;
+  }
+  FirmwareHash._() : super();
+  factory FirmwareHash.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory FirmwareHash.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'FirmwareHash', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'hash', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  FirmwareHash clone() => FirmwareHash()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  FirmwareHash copyWith(void Function(FirmwareHash) updates) => super.copyWith((message) => updates(message as FirmwareHash)) as FirmwareHash;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static FirmwareHash create() => FirmwareHash._();
+  FirmwareHash createEmptyInstance() => create();
+  static $pb.PbList<FirmwareHash> createRepeated() => $pb.PbList<FirmwareHash>();
+  @$core.pragma('dart2js:noInline')
+  static FirmwareHash getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FirmwareHash>(create);
+  static FirmwareHash? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get hash => $_getN(0);
+  @$pb.TagNumber(1)
+  set hash($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasHash() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearHash() => clearField(1);
+}
+
+/// *
+///  Request: Request a signature of the provided challenge.
+///  @start
+///  @next AuthenticityProof
+///  @next Failure
+class AuthenticateDevice extends $pb.GeneratedMessage {
+  factory AuthenticateDevice({
+    $core.List<$core.int>? challenge,
+  }) {
+    final $result = create();
+    if (challenge != null) {
+      $result.challenge = challenge;
+    }
+    return $result;
+  }
+  AuthenticateDevice._() : super();
+  factory AuthenticateDevice.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AuthenticateDevice.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AuthenticateDevice', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'challenge', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  AuthenticateDevice clone() => AuthenticateDevice()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  AuthenticateDevice copyWith(void Function(AuthenticateDevice) updates) => super.copyWith((message) => updates(message as AuthenticateDevice)) as AuthenticateDevice;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static AuthenticateDevice create() => AuthenticateDevice._();
+  AuthenticateDevice createEmptyInstance() => create();
+  static $pb.PbList<AuthenticateDevice> createRepeated() => $pb.PbList<AuthenticateDevice>();
+  @$core.pragma('dart2js:noInline')
+  static AuthenticateDevice getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AuthenticateDevice>(create);
+  static AuthenticateDevice? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get challenge => $_getN(0);
+  @$pb.TagNumber(1)
+  set challenge($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasChallenge() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearChallenge() => clearField(1);
+}
+
+/// *
+///  Response: Signature of the provided challenge along with a certificate issued by the Trezor company.
+///  @end
+class AuthenticityProof extends $pb.GeneratedMessage {
+  factory AuthenticityProof({
+    $core.Iterable<$core.List<$core.int>>? certificates,
+    $core.List<$core.int>? signature,
+  }) {
+    final $result = create();
+    if (certificates != null) {
+      $result.certificates.addAll(certificates);
+    }
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    return $result;
+  }
+  AuthenticityProof._() : super();
+  factory AuthenticityProof.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AuthenticityProof.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AuthenticityProof', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..p<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'certificates', $pb.PbFieldType.PY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  AuthenticityProof clone() => AuthenticityProof()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  AuthenticityProof copyWith(void Function(AuthenticityProof) updates) => super.copyWith((message) => updates(message as AuthenticityProof)) as AuthenticityProof;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static AuthenticityProof create() => AuthenticityProof._();
+  AuthenticityProof createEmptyInstance() => create();
+  static $pb.PbList<AuthenticityProof> createRepeated() => $pb.PbList<AuthenticityProof>();
+  @$core.pragma('dart2js:noInline')
+  static AuthenticityProof getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AuthenticityProof>(create);
+  static AuthenticityProof? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.List<$core.int>> get certificates => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get signature => $_getN(1);
+  @$pb.TagNumber(2)
+  set signature($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSignature() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSignature() => clearField(2);
+}
+
+/// *
+///  Request: Request device to wipe all sensitive data and settings
+///  @start
+///  @next Success
+///  @next Failure
+class WipeDevice extends $pb.GeneratedMessage {
+  factory WipeDevice() => create();
+  WipeDevice._() : super();
+  factory WipeDevice.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WipeDevice.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WipeDevice', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  WipeDevice clone() => WipeDevice()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WipeDevice copyWith(void Function(WipeDevice) updates) => super.copyWith((message) => updates(message as WipeDevice)) as WipeDevice;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static WipeDevice create() => WipeDevice._();
+  WipeDevice createEmptyInstance() => create();
+  static $pb.PbList<WipeDevice> createRepeated() => $pb.PbList<WipeDevice>();
+  @$core.pragma('dart2js:noInline')
+  static WipeDevice getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WipeDevice>(create);
+  static WipeDevice? _defaultInstance;
+}
+
+/// *
+///  Request: Load seed and related internal settings from the computer
+///  @start
+///  @next Success
+///  @next Failure
+class LoadDevice extends $pb.GeneratedMessage {
+  factory LoadDevice({
+    $core.Iterable<$core.String>? mnemonics,
+    $core.String? pin,
+    $core.bool? passphraseProtection,
+  @$core.Deprecated('This field is deprecated.')
+    $core.String? language,
+    $core.String? label,
+    $core.bool? skipChecksum,
+    $core.int? u2fCounter,
+    $core.bool? needsBackup,
+    $core.bool? noBackup,
+  }) {
+    final $result = create();
+    if (mnemonics != null) {
+      $result.mnemonics.addAll(mnemonics);
+    }
+    if (pin != null) {
+      $result.pin = pin;
+    }
+    if (passphraseProtection != null) {
+      $result.passphraseProtection = passphraseProtection;
+    }
+    if (language != null) {
+      // ignore: deprecated_member_use_from_same_package
+      $result.language = language;
+    }
+    if (label != null) {
+      $result.label = label;
+    }
+    if (skipChecksum != null) {
+      $result.skipChecksum = skipChecksum;
+    }
+    if (u2fCounter != null) {
+      $result.u2fCounter = u2fCounter;
+    }
+    if (needsBackup != null) {
+      $result.needsBackup = needsBackup;
+    }
+    if (noBackup != null) {
+      $result.noBackup = noBackup;
+    }
+    return $result;
+  }
+  LoadDevice._() : super();
+  factory LoadDevice.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory LoadDevice.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'LoadDevice', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..pPS(1, _omitFieldNames ? '' : 'mnemonics')
+    ..aOS(3, _omitFieldNames ? '' : 'pin')
+    ..aOB(4, _omitFieldNames ? '' : 'passphraseProtection')
+    ..aOS(5, _omitFieldNames ? '' : 'language')
+    ..aOS(6, _omitFieldNames ? '' : 'label')
+    ..aOB(7, _omitFieldNames ? '' : 'skipChecksum')
+    ..a<$core.int>(8, _omitFieldNames ? '' : 'u2fCounter', $pb.PbFieldType.OU3)
+    ..aOB(9, _omitFieldNames ? '' : 'needsBackup')
+    ..aOB(10, _omitFieldNames ? '' : 'noBackup')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  LoadDevice clone() => LoadDevice()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  LoadDevice copyWith(void Function(LoadDevice) updates) => super.copyWith((message) => updates(message as LoadDevice)) as LoadDevice;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static LoadDevice create() => LoadDevice._();
+  LoadDevice createEmptyInstance() => create();
+  static $pb.PbList<LoadDevice> createRepeated() => $pb.PbList<LoadDevice>();
+  @$core.pragma('dart2js:noInline')
+  static LoadDevice getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LoadDevice>(create);
+  static LoadDevice? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.String> get mnemonics => $_getList(0);
+
+  @$pb.TagNumber(3)
+  $core.String get pin => $_getSZ(1);
+  @$pb.TagNumber(3)
+  set pin($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasPin() => $_has(1);
+  @$pb.TagNumber(3)
+  void clearPin() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.bool get passphraseProtection => $_getBF(2);
+  @$pb.TagNumber(4)
+  set passphraseProtection($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasPassphraseProtection() => $_has(2);
+  @$pb.TagNumber(4)
+  void clearPassphraseProtection() => clearField(4);
+
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(5)
+  $core.String get language => $_getSZ(3);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(5)
+  set language($core.String v) { $_setString(3, v); }
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(5)
+  $core.bool hasLanguage() => $_has(3);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(5)
+  void clearLanguage() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.String get label => $_getSZ(4);
+  @$pb.TagNumber(6)
+  set label($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasLabel() => $_has(4);
+  @$pb.TagNumber(6)
+  void clearLabel() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.bool get skipChecksum => $_getBF(5);
+  @$pb.TagNumber(7)
+  set skipChecksum($core.bool v) { $_setBool(5, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasSkipChecksum() => $_has(5);
+  @$pb.TagNumber(7)
+  void clearSkipChecksum() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.int get u2fCounter => $_getIZ(6);
+  @$pb.TagNumber(8)
+  set u2fCounter($core.int v) { $_setUnsignedInt32(6, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasU2fCounter() => $_has(6);
+  @$pb.TagNumber(8)
+  void clearU2fCounter() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.bool get needsBackup => $_getBF(7);
+  @$pb.TagNumber(9)
+  set needsBackup($core.bool v) { $_setBool(7, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasNeedsBackup() => $_has(7);
+  @$pb.TagNumber(9)
+  void clearNeedsBackup() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.bool get noBackup => $_getBF(8);
+  @$pb.TagNumber(10)
+  set noBackup($core.bool v) { $_setBool(8, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasNoBackup() => $_has(8);
+  @$pb.TagNumber(10)
+  void clearNoBackup() => clearField(10);
+}
+
+/// *
+///  Request: Ask device to do initialization involving user interaction
+///  @start
+///  @next EntropyRequest
+///  @next Failure
+class ResetDevice extends $pb.GeneratedMessage {
+  factory ResetDevice({
+    $core.bool? displayRandom,
+    $core.int? strength,
+    $core.bool? passphraseProtection,
+    $core.bool? pinProtection,
+  @$core.Deprecated('This field is deprecated.')
+    $core.String? language,
+    $core.String? label,
+    $core.int? u2fCounter,
+    $core.bool? skipBackup,
+    $core.bool? noBackup,
+    BackupType? backupType,
+  }) {
+    final $result = create();
+    if (displayRandom != null) {
+      $result.displayRandom = displayRandom;
+    }
+    if (strength != null) {
+      $result.strength = strength;
+    }
+    if (passphraseProtection != null) {
+      $result.passphraseProtection = passphraseProtection;
+    }
+    if (pinProtection != null) {
+      $result.pinProtection = pinProtection;
+    }
+    if (language != null) {
+      // ignore: deprecated_member_use_from_same_package
+      $result.language = language;
+    }
+    if (label != null) {
+      $result.label = label;
+    }
+    if (u2fCounter != null) {
+      $result.u2fCounter = u2fCounter;
+    }
+    if (skipBackup != null) {
+      $result.skipBackup = skipBackup;
+    }
+    if (noBackup != null) {
+      $result.noBackup = noBackup;
+    }
+    if (backupType != null) {
+      $result.backupType = backupType;
+    }
+    return $result;
+  }
+  ResetDevice._() : super();
+  factory ResetDevice.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ResetDevice.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ResetDevice', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..aOB(1, _omitFieldNames ? '' : 'displayRandom')
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'strength', $pb.PbFieldType.OU3, defaultOrMaker: 256)
+    ..aOB(3, _omitFieldNames ? '' : 'passphraseProtection')
+    ..aOB(4, _omitFieldNames ? '' : 'pinProtection')
+    ..aOS(5, _omitFieldNames ? '' : 'language')
+    ..aOS(6, _omitFieldNames ? '' : 'label')
+    ..a<$core.int>(7, _omitFieldNames ? '' : 'u2fCounter', $pb.PbFieldType.OU3)
+    ..aOB(8, _omitFieldNames ? '' : 'skipBackup')
+    ..aOB(9, _omitFieldNames ? '' : 'noBackup')
+    ..e<BackupType>(10, _omitFieldNames ? '' : 'backupType', $pb.PbFieldType.OE, defaultOrMaker: BackupType.Bip39, valueOf: BackupType.valueOf, enumValues: BackupType.values)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ResetDevice clone() => ResetDevice()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ResetDevice copyWith(void Function(ResetDevice) updates) => super.copyWith((message) => updates(message as ResetDevice)) as ResetDevice;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ResetDevice create() => ResetDevice._();
+  ResetDevice createEmptyInstance() => create();
+  static $pb.PbList<ResetDevice> createRepeated() => $pb.PbList<ResetDevice>();
+  @$core.pragma('dart2js:noInline')
+  static ResetDevice getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ResetDevice>(create);
+  static ResetDevice? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.bool get displayRandom => $_getBF(0);
+  @$pb.TagNumber(1)
+  set displayRandom($core.bool v) { $_setBool(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDisplayRandom() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDisplayRandom() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get strength => $_getI(1, 256);
+  @$pb.TagNumber(2)
+  set strength($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasStrength() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearStrength() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get passphraseProtection => $_getBF(2);
+  @$pb.TagNumber(3)
+  set passphraseProtection($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasPassphraseProtection() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearPassphraseProtection() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.bool get pinProtection => $_getBF(3);
+  @$pb.TagNumber(4)
+  set pinProtection($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasPinProtection() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearPinProtection() => clearField(4);
+
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(5)
+  $core.String get language => $_getSZ(4);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(5)
+  set language($core.String v) { $_setString(4, v); }
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(5)
+  $core.bool hasLanguage() => $_has(4);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(5)
+  void clearLanguage() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.String get label => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set label($core.String v) { $_setString(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasLabel() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearLabel() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.int get u2fCounter => $_getIZ(6);
+  @$pb.TagNumber(7)
+  set u2fCounter($core.int v) { $_setUnsignedInt32(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasU2fCounter() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearU2fCounter() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.bool get skipBackup => $_getBF(7);
+  @$pb.TagNumber(8)
+  set skipBackup($core.bool v) { $_setBool(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasSkipBackup() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearSkipBackup() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.bool get noBackup => $_getBF(8);
+  @$pb.TagNumber(9)
+  set noBackup($core.bool v) { $_setBool(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasNoBackup() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearNoBackup() => clearField(9);
+
+  @$pb.TagNumber(10)
+  BackupType get backupType => $_getN(9);
+  @$pb.TagNumber(10)
+  set backupType(BackupType v) { setField(10, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasBackupType() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearBackupType() => clearField(10);
+}
+
+/// *
+///  Request: Perform backup of the device seed if not backed up using ResetDevice
+///  @start
+///  @next Success
+class BackupDevice extends $pb.GeneratedMessage {
+  factory BackupDevice() => create();
+  BackupDevice._() : super();
+  factory BackupDevice.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BackupDevice.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BackupDevice', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BackupDevice clone() => BackupDevice()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BackupDevice copyWith(void Function(BackupDevice) updates) => super.copyWith((message) => updates(message as BackupDevice)) as BackupDevice;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BackupDevice create() => BackupDevice._();
+  BackupDevice createEmptyInstance() => create();
+  static $pb.PbList<BackupDevice> createRepeated() => $pb.PbList<BackupDevice>();
+  @$core.pragma('dart2js:noInline')
+  static BackupDevice getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BackupDevice>(create);
+  static BackupDevice? _defaultInstance;
+}
+
+/// *
+///  Response: Ask for additional entropy from host computer
+///  @next EntropyAck
+class EntropyRequest extends $pb.GeneratedMessage {
+  factory EntropyRequest() => create();
+  EntropyRequest._() : super();
+  factory EntropyRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EntropyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EntropyRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EntropyRequest clone() => EntropyRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EntropyRequest copyWith(void Function(EntropyRequest) updates) => super.copyWith((message) => updates(message as EntropyRequest)) as EntropyRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EntropyRequest create() => EntropyRequest._();
+  EntropyRequest createEmptyInstance() => create();
+  static $pb.PbList<EntropyRequest> createRepeated() => $pb.PbList<EntropyRequest>();
+  @$core.pragma('dart2js:noInline')
+  static EntropyRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EntropyRequest>(create);
+  static EntropyRequest? _defaultInstance;
+}
+
+/// *
+///  Request: Provide additional entropy for seed generation function
+///  @next Success
+class EntropyAck extends $pb.GeneratedMessage {
+  factory EntropyAck({
+    $core.List<$core.int>? entropy,
+  }) {
+    final $result = create();
+    if (entropy != null) {
+      $result.entropy = entropy;
+    }
+    return $result;
+  }
+  EntropyAck._() : super();
+  factory EntropyAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EntropyAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EntropyAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'entropy', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EntropyAck clone() => EntropyAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EntropyAck copyWith(void Function(EntropyAck) updates) => super.copyWith((message) => updates(message as EntropyAck)) as EntropyAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EntropyAck create() => EntropyAck._();
+  EntropyAck createEmptyInstance() => create();
+  static $pb.PbList<EntropyAck> createRepeated() => $pb.PbList<EntropyAck>();
+  @$core.pragma('dart2js:noInline')
+  static EntropyAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EntropyAck>(create);
+  static EntropyAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get entropy => $_getN(0);
+  @$pb.TagNumber(1)
+  set entropy($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasEntropy() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearEntropy() => clearField(1);
+}
+
+/// *
+///  Request: Start recovery workflow asking user for specific words of mnemonic
+///  Used to recovery device safely even on untrusted computer.
+///  @start
+///  @next WordRequest
+class RecoveryDevice extends $pb.GeneratedMessage {
+  factory RecoveryDevice({
+    $core.int? wordCount,
+    $core.bool? passphraseProtection,
+    $core.bool? pinProtection,
+  @$core.Deprecated('This field is deprecated.')
+    $core.String? language,
+    $core.String? label,
+    $core.bool? enforceWordlist,
+    RecoveryDevice_RecoveryDeviceType? type,
+    $core.int? u2fCounter,
+    $core.bool? dryRun,
+  }) {
+    final $result = create();
+    if (wordCount != null) {
+      $result.wordCount = wordCount;
+    }
+    if (passphraseProtection != null) {
+      $result.passphraseProtection = passphraseProtection;
+    }
+    if (pinProtection != null) {
+      $result.pinProtection = pinProtection;
+    }
+    if (language != null) {
+      // ignore: deprecated_member_use_from_same_package
+      $result.language = language;
+    }
+    if (label != null) {
+      $result.label = label;
+    }
+    if (enforceWordlist != null) {
+      $result.enforceWordlist = enforceWordlist;
+    }
+    if (type != null) {
+      $result.type = type;
+    }
+    if (u2fCounter != null) {
+      $result.u2fCounter = u2fCounter;
+    }
+    if (dryRun != null) {
+      $result.dryRun = dryRun;
+    }
+    return $result;
+  }
+  RecoveryDevice._() : super();
+  factory RecoveryDevice.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RecoveryDevice.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RecoveryDevice', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'wordCount', $pb.PbFieldType.OU3)
+    ..aOB(2, _omitFieldNames ? '' : 'passphraseProtection')
+    ..aOB(3, _omitFieldNames ? '' : 'pinProtection')
+    ..aOS(4, _omitFieldNames ? '' : 'language')
+    ..aOS(5, _omitFieldNames ? '' : 'label')
+    ..aOB(6, _omitFieldNames ? '' : 'enforceWordlist')
+    ..e<RecoveryDevice_RecoveryDeviceType>(8, _omitFieldNames ? '' : 'type', $pb.PbFieldType.OE, defaultOrMaker: RecoveryDevice_RecoveryDeviceType.RecoveryDeviceType_ScrambledWords, valueOf: RecoveryDevice_RecoveryDeviceType.valueOf, enumValues: RecoveryDevice_RecoveryDeviceType.values)
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'u2fCounter', $pb.PbFieldType.OU3)
+    ..aOB(10, _omitFieldNames ? '' : 'dryRun')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  RecoveryDevice clone() => RecoveryDevice()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RecoveryDevice copyWith(void Function(RecoveryDevice) updates) => super.copyWith((message) => updates(message as RecoveryDevice)) as RecoveryDevice;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static RecoveryDevice create() => RecoveryDevice._();
+  RecoveryDevice createEmptyInstance() => create();
+  static $pb.PbList<RecoveryDevice> createRepeated() => $pb.PbList<RecoveryDevice>();
+  @$core.pragma('dart2js:noInline')
+  static RecoveryDevice getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RecoveryDevice>(create);
+  static RecoveryDevice? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get wordCount => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set wordCount($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWordCount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWordCount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.bool get passphraseProtection => $_getBF(1);
+  @$pb.TagNumber(2)
+  set passphraseProtection($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPassphraseProtection() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPassphraseProtection() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get pinProtection => $_getBF(2);
+  @$pb.TagNumber(3)
+  set pinProtection($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasPinProtection() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearPinProtection() => clearField(3);
+
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(4)
+  $core.String get language => $_getSZ(3);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(4)
+  set language($core.String v) { $_setString(3, v); }
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(4)
+  $core.bool hasLanguage() => $_has(3);
+  @$core.Deprecated('This field is deprecated.')
+  @$pb.TagNumber(4)
+  void clearLanguage() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.String get label => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set label($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasLabel() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearLabel() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.bool get enforceWordlist => $_getBF(5);
+  @$pb.TagNumber(6)
+  set enforceWordlist($core.bool v) { $_setBool(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasEnforceWordlist() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearEnforceWordlist() => clearField(6);
+
+  /// 7 reserved for unused recovery method
+  @$pb.TagNumber(8)
+  RecoveryDevice_RecoveryDeviceType get type => $_getN(6);
+  @$pb.TagNumber(8)
+  set type(RecoveryDevice_RecoveryDeviceType v) { setField(8, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasType() => $_has(6);
+  @$pb.TagNumber(8)
+  void clearType() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.int get u2fCounter => $_getIZ(7);
+  @$pb.TagNumber(9)
+  set u2fCounter($core.int v) { $_setUnsignedInt32(7, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasU2fCounter() => $_has(7);
+  @$pb.TagNumber(9)
+  void clearU2fCounter() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.bool get dryRun => $_getBF(8);
+  @$pb.TagNumber(10)
+  set dryRun($core.bool v) { $_setBool(8, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasDryRun() => $_has(8);
+  @$pb.TagNumber(10)
+  void clearDryRun() => clearField(10);
+}
+
+/// *
+///  Response: Device is waiting for user to enter word of the mnemonic
+///  Its position is shown only on device's internal display.
+///  @next WordAck
+class WordRequest extends $pb.GeneratedMessage {
+  factory WordRequest({
+    WordRequest_WordRequestType? type,
+  }) {
+    final $result = create();
+    if (type != null) {
+      $result.type = type;
+    }
+    return $result;
+  }
+  WordRequest._() : super();
+  factory WordRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WordRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WordRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..e<WordRequest_WordRequestType>(1, _omitFieldNames ? '' : 'type', $pb.PbFieldType.QE, defaultOrMaker: WordRequest_WordRequestType.WordRequestType_Plain, valueOf: WordRequest_WordRequestType.valueOf, enumValues: WordRequest_WordRequestType.values)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  WordRequest clone() => WordRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WordRequest copyWith(void Function(WordRequest) updates) => super.copyWith((message) => updates(message as WordRequest)) as WordRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static WordRequest create() => WordRequest._();
+  WordRequest createEmptyInstance() => create();
+  static $pb.PbList<WordRequest> createRepeated() => $pb.PbList<WordRequest>();
+  @$core.pragma('dart2js:noInline')
+  static WordRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WordRequest>(create);
+  static WordRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  WordRequest_WordRequestType get type => $_getN(0);
+  @$pb.TagNumber(1)
+  set type(WordRequest_WordRequestType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearType() => clearField(1);
+}
+
+/// *
+///  Request: Computer replies with word from the mnemonic
+///  @next WordRequest
+///  @next Success
+///  @next Failure
+class WordAck extends $pb.GeneratedMessage {
+  factory WordAck({
+    $core.String? word,
+  }) {
+    final $result = create();
+    if (word != null) {
+      $result.word = word;
+    }
+    return $result;
+  }
+  WordAck._() : super();
+  factory WordAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WordAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WordAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'word')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  WordAck clone() => WordAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WordAck copyWith(void Function(WordAck) updates) => super.copyWith((message) => updates(message as WordAck)) as WordAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static WordAck create() => WordAck._();
+  WordAck createEmptyInstance() => create();
+  static $pb.PbList<WordAck> createRepeated() => $pb.PbList<WordAck>();
+  @$core.pragma('dart2js:noInline')
+  static WordAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WordAck>(create);
+  static WordAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get word => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set word($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWord() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWord() => clearField(1);
+}
+
+/// *
+///  Request: Set U2F counter
+///  @start
+///  @next Success
+class SetU2FCounter extends $pb.GeneratedMessage {
+  factory SetU2FCounter({
+    $core.int? u2fCounter,
+  }) {
+    final $result = create();
+    if (u2fCounter != null) {
+      $result.u2fCounter = u2fCounter;
+    }
+    return $result;
+  }
+  SetU2FCounter._() : super();
+  factory SetU2FCounter.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetU2FCounter.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetU2FCounter', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'u2fCounter', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SetU2FCounter clone() => SetU2FCounter()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetU2FCounter copyWith(void Function(SetU2FCounter) updates) => super.copyWith((message) => updates(message as SetU2FCounter)) as SetU2FCounter;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SetU2FCounter create() => SetU2FCounter._();
+  SetU2FCounter createEmptyInstance() => create();
+  static $pb.PbList<SetU2FCounter> createRepeated() => $pb.PbList<SetU2FCounter>();
+  @$core.pragma('dart2js:noInline')
+  static SetU2FCounter getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetU2FCounter>(create);
+  static SetU2FCounter? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get u2fCounter => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set u2fCounter($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasU2fCounter() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearU2fCounter() => clearField(1);
+}
+
+/// *
+///  Request: Set U2F counter
+///  @start
+///  @next NextU2FCounter
+class GetNextU2FCounter extends $pb.GeneratedMessage {
+  factory GetNextU2FCounter() => create();
+  GetNextU2FCounter._() : super();
+  factory GetNextU2FCounter.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNextU2FCounter.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNextU2FCounter', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetNextU2FCounter clone() => GetNextU2FCounter()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNextU2FCounter copyWith(void Function(GetNextU2FCounter) updates) => super.copyWith((message) => updates(message as GetNextU2FCounter)) as GetNextU2FCounter;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetNextU2FCounter create() => GetNextU2FCounter._();
+  GetNextU2FCounter createEmptyInstance() => create();
+  static $pb.PbList<GetNextU2FCounter> createRepeated() => $pb.PbList<GetNextU2FCounter>();
+  @$core.pragma('dart2js:noInline')
+  static GetNextU2FCounter getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNextU2FCounter>(create);
+  static GetNextU2FCounter? _defaultInstance;
+}
+
+/// *
+///  Request: Set U2F counter
+///  @end
+class NextU2FCounter extends $pb.GeneratedMessage {
+  factory NextU2FCounter({
+    $core.int? u2fCounter,
+  }) {
+    final $result = create();
+    if (u2fCounter != null) {
+      $result.u2fCounter = u2fCounter;
+    }
+    return $result;
+  }
+  NextU2FCounter._() : super();
+  factory NextU2FCounter.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NextU2FCounter.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NextU2FCounter', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'u2fCounter', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NextU2FCounter clone() => NextU2FCounter()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NextU2FCounter copyWith(void Function(NextU2FCounter) updates) => super.copyWith((message) => updates(message as NextU2FCounter)) as NextU2FCounter;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NextU2FCounter create() => NextU2FCounter._();
+  NextU2FCounter createEmptyInstance() => create();
+  static $pb.PbList<NextU2FCounter> createRepeated() => $pb.PbList<NextU2FCounter>();
+  @$core.pragma('dart2js:noInline')
+  static NextU2FCounter getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NextU2FCounter>(create);
+  static NextU2FCounter? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get u2fCounter => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set u2fCounter($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasU2fCounter() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearU2fCounter() => clearField(1);
+}
+
+/// *
+///  Request: Ask device to prepare for a preauthorized operation.
+///  @start
+///  @next PreauthorizedRequest
+///  @next Failure
+class DoPreauthorized extends $pb.GeneratedMessage {
+  factory DoPreauthorized() => create();
+  DoPreauthorized._() : super();
+  factory DoPreauthorized.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DoPreauthorized.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DoPreauthorized', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DoPreauthorized clone() => DoPreauthorized()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DoPreauthorized copyWith(void Function(DoPreauthorized) updates) => super.copyWith((message) => updates(message as DoPreauthorized)) as DoPreauthorized;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DoPreauthorized create() => DoPreauthorized._();
+  DoPreauthorized createEmptyInstance() => create();
+  static $pb.PbList<DoPreauthorized> createRepeated() => $pb.PbList<DoPreauthorized>();
+  @$core.pragma('dart2js:noInline')
+  static DoPreauthorized getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DoPreauthorized>(create);
+  static DoPreauthorized? _defaultInstance;
+}
+
+/// *
+///  Request: Device awaits a preauthorized operation.
+///  @start
+///  @next SignTx
+///  @next GetOwnershipProof
+class PreauthorizedRequest extends $pb.GeneratedMessage {
+  factory PreauthorizedRequest() => create();
+  PreauthorizedRequest._() : super();
+  factory PreauthorizedRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PreauthorizedRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PreauthorizedRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PreauthorizedRequest clone() => PreauthorizedRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PreauthorizedRequest copyWith(void Function(PreauthorizedRequest) updates) => super.copyWith((message) => updates(message as PreauthorizedRequest)) as PreauthorizedRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PreauthorizedRequest create() => PreauthorizedRequest._();
+  PreauthorizedRequest createEmptyInstance() => create();
+  static $pb.PbList<PreauthorizedRequest> createRepeated() => $pb.PbList<PreauthorizedRequest>();
+  @$core.pragma('dart2js:noInline')
+  static PreauthorizedRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PreauthorizedRequest>(create);
+  static PreauthorizedRequest? _defaultInstance;
+}
+
+/// *
+///  Request: Cancel any outstanding authorization in the current session.
+///  @start
+///  @next Success
+///  @next Failure
+class CancelAuthorization extends $pb.GeneratedMessage {
+  factory CancelAuthorization() => create();
+  CancelAuthorization._() : super();
+  factory CancelAuthorization.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CancelAuthorization.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CancelAuthorization', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CancelAuthorization clone() => CancelAuthorization()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CancelAuthorization copyWith(void Function(CancelAuthorization) updates) => super.copyWith((message) => updates(message as CancelAuthorization)) as CancelAuthorization;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CancelAuthorization create() => CancelAuthorization._();
+  CancelAuthorization createEmptyInstance() => create();
+  static $pb.PbList<CancelAuthorization> createRepeated() => $pb.PbList<CancelAuthorization>();
+  @$core.pragma('dart2js:noInline')
+  static CancelAuthorization getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CancelAuthorization>(create);
+  static CancelAuthorization? _defaultInstance;
+}
+
+/// *
+///  Request: Reboot firmware to bootloader
+///  @start
+///  @next Success
+class RebootToBootloader extends $pb.GeneratedMessage {
+  factory RebootToBootloader({
+    RebootToBootloader_BootCommand? bootCommand,
+    $core.List<$core.int>? firmwareHeader,
+    $core.int? languageDataLength,
+  }) {
+    final $result = create();
+    if (bootCommand != null) {
+      $result.bootCommand = bootCommand;
+    }
+    if (firmwareHeader != null) {
+      $result.firmwareHeader = firmwareHeader;
+    }
+    if (languageDataLength != null) {
+      $result.languageDataLength = languageDataLength;
+    }
+    return $result;
+  }
+  RebootToBootloader._() : super();
+  factory RebootToBootloader.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RebootToBootloader.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RebootToBootloader', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..e<RebootToBootloader_BootCommand>(1, _omitFieldNames ? '' : 'bootCommand', $pb.PbFieldType.OE, defaultOrMaker: RebootToBootloader_BootCommand.STOP_AND_WAIT, valueOf: RebootToBootloader_BootCommand.valueOf, enumValues: RebootToBootloader_BootCommand.values)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'firmwareHeader', $pb.PbFieldType.OY)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'languageDataLength', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  RebootToBootloader clone() => RebootToBootloader()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RebootToBootloader copyWith(void Function(RebootToBootloader) updates) => super.copyWith((message) => updates(message as RebootToBootloader)) as RebootToBootloader;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static RebootToBootloader create() => RebootToBootloader._();
+  RebootToBootloader createEmptyInstance() => create();
+  static $pb.PbList<RebootToBootloader> createRepeated() => $pb.PbList<RebootToBootloader>();
+  @$core.pragma('dart2js:noInline')
+  static RebootToBootloader getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RebootToBootloader>(create);
+  static RebootToBootloader? _defaultInstance;
+
+  /// Action to be performed after rebooting to bootloader
+  @$pb.TagNumber(1)
+  RebootToBootloader_BootCommand get bootCommand => $_getN(0);
+  @$pb.TagNumber(1)
+  set bootCommand(RebootToBootloader_BootCommand v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasBootCommand() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearBootCommand() => clearField(1);
+
+  /// Firmware header to be flashed after rebooting to bootloader
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get firmwareHeader => $_getN(1);
+  @$pb.TagNumber(2)
+  set firmwareHeader($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasFirmwareHeader() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearFirmwareHeader() => clearField(2);
+
+  /// Length of language blob to be installed before upgrading firmware
+  @$pb.TagNumber(3)
+  $core.int get languageDataLength => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set languageDataLength($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasLanguageDataLength() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearLanguageDataLength() => clearField(3);
+}
+
+/// *
+///  Request: Ask device to generate a random nonce and store it in the session's cache
+///  @start
+///  @next Nonce
+class GetNonce extends $pb.GeneratedMessage {
+  factory GetNonce() => create();
+  GetNonce._() : super();
+  factory GetNonce.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNonce.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNonce', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetNonce clone() => GetNonce()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNonce copyWith(void Function(GetNonce) updates) => super.copyWith((message) => updates(message as GetNonce)) as GetNonce;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetNonce create() => GetNonce._();
+  GetNonce createEmptyInstance() => create();
+  static $pb.PbList<GetNonce> createRepeated() => $pb.PbList<GetNonce>();
+  @$core.pragma('dart2js:noInline')
+  static GetNonce getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNonce>(create);
+  static GetNonce? _defaultInstance;
+}
+
+/// *
+///  Response: Contains a random nonce
+///  @end
+class Nonce extends $pb.GeneratedMessage {
+  factory Nonce({
+    $core.List<$core.int>? nonce,
+  }) {
+    final $result = create();
+    if (nonce != null) {
+      $result.nonce = nonce;
+    }
+    return $result;
+  }
+  Nonce._() : super();
+  factory Nonce.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Nonce.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Nonce', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'nonce', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Nonce clone() => Nonce()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Nonce copyWith(void Function(Nonce) updates) => super.copyWith((message) => updates(message as Nonce)) as Nonce;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Nonce create() => Nonce._();
+  Nonce createEmptyInstance() => create();
+  static $pb.PbList<Nonce> createRepeated() => $pb.PbList<Nonce>();
+  @$core.pragma('dart2js:noInline')
+  static Nonce getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Nonce>(create);
+  static Nonce? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get nonce => $_getN(0);
+  @$pb.TagNumber(1)
+  set nonce($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasNonce() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearNonce() => clearField(1);
+}
+
+/// *
+///  Request: Ask device to unlock a subtree of the keychain.
+///  @start
+///  @next UnlockedPathRequest
+///  @next Failure
+class UnlockPath extends $pb.GeneratedMessage {
+  factory UnlockPath({
+    $core.Iterable<$core.int>? addressN,
+    $core.List<$core.int>? mac,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (mac != null) {
+      $result.mac = mac;
+    }
+    return $result;
+  }
+  UnlockPath._() : super();
+  factory UnlockPath.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UnlockPath.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UnlockPath', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'mac', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  UnlockPath clone() => UnlockPath()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UnlockPath copyWith(void Function(UnlockPath) updates) => super.copyWith((message) => updates(message as UnlockPath)) as UnlockPath;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static UnlockPath create() => UnlockPath._();
+  UnlockPath createEmptyInstance() => create();
+  static $pb.PbList<UnlockPath> createRepeated() => $pb.PbList<UnlockPath>();
+  @$core.pragma('dart2js:noInline')
+  static UnlockPath getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnlockPath>(create);
+  static UnlockPath? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get mac => $_getN(1);
+  @$pb.TagNumber(2)
+  set mac($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMac() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMac() => clearField(2);
+}
+
+/// *
+///  Request: Device awaits an operation.
+///  @start
+///  @next SignTx
+///  @next GetPublicKey
+///  @next GetAddress
+class UnlockedPathRequest extends $pb.GeneratedMessage {
+  factory UnlockedPathRequest({
+    $core.List<$core.int>? mac,
+  }) {
+    final $result = create();
+    if (mac != null) {
+      $result.mac = mac;
+    }
+    return $result;
+  }
+  UnlockedPathRequest._() : super();
+  factory UnlockedPathRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UnlockedPathRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UnlockedPathRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'mac', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  UnlockedPathRequest clone() => UnlockedPathRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UnlockedPathRequest copyWith(void Function(UnlockedPathRequest) updates) => super.copyWith((message) => updates(message as UnlockedPathRequest)) as UnlockedPathRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static UnlockedPathRequest create() => UnlockedPathRequest._();
+  UnlockedPathRequest createEmptyInstance() => create();
+  static $pb.PbList<UnlockedPathRequest> createRepeated() => $pb.PbList<UnlockedPathRequest>();
+  @$core.pragma('dart2js:noInline')
+  static UnlockedPathRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnlockedPathRequest>(create);
+  static UnlockedPathRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get mac => $_getN(0);
+  @$pb.TagNumber(1)
+  set mac($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasMac() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearMac() => clearField(1);
+}
+
+/// *
+///  Request: Show tutorial screens on the device
+///  @start
+///  @next Success
+class ShowDeviceTutorial extends $pb.GeneratedMessage {
+  factory ShowDeviceTutorial() => create();
+  ShowDeviceTutorial._() : super();
+  factory ShowDeviceTutorial.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ShowDeviceTutorial.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShowDeviceTutorial', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ShowDeviceTutorial clone() => ShowDeviceTutorial()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ShowDeviceTutorial copyWith(void Function(ShowDeviceTutorial) updates) => super.copyWith((message) => updates(message as ShowDeviceTutorial)) as ShowDeviceTutorial;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ShowDeviceTutorial create() => ShowDeviceTutorial._();
+  ShowDeviceTutorial createEmptyInstance() => create();
+  static $pb.PbList<ShowDeviceTutorial> createRepeated() => $pb.PbList<ShowDeviceTutorial>();
+  @$core.pragma('dart2js:noInline')
+  static ShowDeviceTutorial getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ShowDeviceTutorial>(create);
+  static ShowDeviceTutorial? _defaultInstance;
+}
+
+/// *
+///  Request: Unlocks bootloader, !irreversible!
+///  @start
+///  @next Success
+///  @next Failure
+class UnlockBootloader extends $pb.GeneratedMessage {
+  factory UnlockBootloader() => create();
+  UnlockBootloader._() : super();
+  factory UnlockBootloader.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UnlockBootloader.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UnlockBootloader', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.management'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  UnlockBootloader clone() => UnlockBootloader()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UnlockBootloader copyWith(void Function(UnlockBootloader) updates) => super.copyWith((message) => updates(message as UnlockBootloader)) as UnlockBootloader;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static UnlockBootloader create() => UnlockBootloader._();
+  UnlockBootloader createEmptyInstance() => create();
+  static $pb.PbList<UnlockBootloader> createRepeated() => $pb.PbList<UnlockBootloader>();
+  @$core.pragma('dart2js:noInline')
+  static UnlockBootloader getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnlockBootloader>(create);
+  static UnlockBootloader? _defaultInstance;
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-management.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-management.pbenum.dart
@@ -1,0 +1,198 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-management.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+/// *
+///  Type of the mnemonic backup given/received by the device during reset/recovery.
+class BackupType extends $pb.ProtobufEnum {
+  static const BackupType Bip39 = BackupType._(0, _omitEnumNames ? '' : 'Bip39');
+  static const BackupType Slip39_Basic = BackupType._(1, _omitEnumNames ? '' : 'Slip39_Basic');
+  static const BackupType Slip39_Advanced = BackupType._(2, _omitEnumNames ? '' : 'Slip39_Advanced');
+
+  static const $core.List<BackupType> values = <BackupType> [
+    Bip39,
+    Slip39_Basic,
+    Slip39_Advanced,
+  ];
+
+  static final $core.Map<$core.int, BackupType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static BackupType? valueOf($core.int value) => _byValue[value];
+
+  const BackupType._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Level of safety checks for unsafe actions like spending from invalid path namespace or setting high transaction fee.
+class SafetyCheckLevel extends $pb.ProtobufEnum {
+  static const SafetyCheckLevel Strict = SafetyCheckLevel._(0, _omitEnumNames ? '' : 'Strict');
+  static const SafetyCheckLevel PromptAlways = SafetyCheckLevel._(1, _omitEnumNames ? '' : 'PromptAlways');
+  static const SafetyCheckLevel PromptTemporarily = SafetyCheckLevel._(2, _omitEnumNames ? '' : 'PromptTemporarily');
+
+  static const $core.List<SafetyCheckLevel> values = <SafetyCheckLevel> [
+    Strict,
+    PromptAlways,
+    PromptTemporarily,
+  ];
+
+  static final $core.Map<$core.int, SafetyCheckLevel> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static SafetyCheckLevel? valueOf($core.int value) => _byValue[value];
+
+  const SafetyCheckLevel._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Format of the homescreen image
+class HomescreenFormat extends $pb.ProtobufEnum {
+  static const HomescreenFormat Toif = HomescreenFormat._(1, _omitEnumNames ? '' : 'Toif');
+  static const HomescreenFormat Jpeg = HomescreenFormat._(2, _omitEnumNames ? '' : 'Jpeg');
+  static const HomescreenFormat ToiG = HomescreenFormat._(3, _omitEnumNames ? '' : 'ToiG');
+
+  static const $core.List<HomescreenFormat> values = <HomescreenFormat> [
+    Toif,
+    Jpeg,
+    ToiG,
+  ];
+
+  static final $core.Map<$core.int, HomescreenFormat> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static HomescreenFormat? valueOf($core.int value) => _byValue[value];
+
+  const HomescreenFormat._($core.int v, $core.String n) : super(v, n);
+}
+
+class Features_Capability extends $pb.ProtobufEnum {
+  static const Features_Capability Capability_Bitcoin = Features_Capability._(1, _omitEnumNames ? '' : 'Capability_Bitcoin');
+  static const Features_Capability Capability_Bitcoin_like = Features_Capability._(2, _omitEnumNames ? '' : 'Capability_Bitcoin_like');
+  static const Features_Capability Capability_Binance = Features_Capability._(3, _omitEnumNames ? '' : 'Capability_Binance');
+  static const Features_Capability Capability_Cardano = Features_Capability._(4, _omitEnumNames ? '' : 'Capability_Cardano');
+  static const Features_Capability Capability_Crypto = Features_Capability._(5, _omitEnumNames ? '' : 'Capability_Crypto');
+  static const Features_Capability Capability_EOS = Features_Capability._(6, _omitEnumNames ? '' : 'Capability_EOS');
+  static const Features_Capability Capability_Ethereum = Features_Capability._(7, _omitEnumNames ? '' : 'Capability_Ethereum');
+  static const Features_Capability Capability_Lisk = Features_Capability._(8, _omitEnumNames ? '' : 'Capability_Lisk');
+  static const Features_Capability Capability_Monero = Features_Capability._(9, _omitEnumNames ? '' : 'Capability_Monero');
+  static const Features_Capability Capability_NEM = Features_Capability._(10, _omitEnumNames ? '' : 'Capability_NEM');
+  static const Features_Capability Capability_Ripple = Features_Capability._(11, _omitEnumNames ? '' : 'Capability_Ripple');
+  static const Features_Capability Capability_Stellar = Features_Capability._(12, _omitEnumNames ? '' : 'Capability_Stellar');
+  static const Features_Capability Capability_Tezos = Features_Capability._(13, _omitEnumNames ? '' : 'Capability_Tezos');
+  static const Features_Capability Capability_U2F = Features_Capability._(14, _omitEnumNames ? '' : 'Capability_U2F');
+  static const Features_Capability Capability_Shamir = Features_Capability._(15, _omitEnumNames ? '' : 'Capability_Shamir');
+  static const Features_Capability Capability_ShamirGroups = Features_Capability._(16, _omitEnumNames ? '' : 'Capability_ShamirGroups');
+  static const Features_Capability Capability_PassphraseEntry = Features_Capability._(17, _omitEnumNames ? '' : 'Capability_PassphraseEntry');
+  static const Features_Capability Capability_Solana = Features_Capability._(18, _omitEnumNames ? '' : 'Capability_Solana');
+  static const Features_Capability Capability_Translations = Features_Capability._(19, _omitEnumNames ? '' : 'Capability_Translations');
+
+  static const $core.List<Features_Capability> values = <Features_Capability> [
+    Capability_Bitcoin,
+    Capability_Bitcoin_like,
+    Capability_Binance,
+    Capability_Cardano,
+    Capability_Crypto,
+    Capability_EOS,
+    Capability_Ethereum,
+    Capability_Lisk,
+    Capability_Monero,
+    Capability_NEM,
+    Capability_Ripple,
+    Capability_Stellar,
+    Capability_Tezos,
+    Capability_U2F,
+    Capability_Shamir,
+    Capability_ShamirGroups,
+    Capability_PassphraseEntry,
+    Capability_Solana,
+    Capability_Translations,
+  ];
+
+  static final $core.Map<$core.int, Features_Capability> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static Features_Capability? valueOf($core.int value) => _byValue[value];
+
+  const Features_Capability._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Structure representing SD card protection operation
+class SdProtect_SdProtectOperationType extends $pb.ProtobufEnum {
+  static const SdProtect_SdProtectOperationType DISABLE = SdProtect_SdProtectOperationType._(0, _omitEnumNames ? '' : 'DISABLE');
+  static const SdProtect_SdProtectOperationType ENABLE = SdProtect_SdProtectOperationType._(1, _omitEnumNames ? '' : 'ENABLE');
+  static const SdProtect_SdProtectOperationType REFRESH = SdProtect_SdProtectOperationType._(2, _omitEnumNames ? '' : 'REFRESH');
+
+  static const $core.List<SdProtect_SdProtectOperationType> values = <SdProtect_SdProtectOperationType> [
+    DISABLE,
+    ENABLE,
+    REFRESH,
+  ];
+
+  static final $core.Map<$core.int, SdProtect_SdProtectOperationType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static SdProtect_SdProtectOperationType? valueOf($core.int value) => _byValue[value];
+
+  const SdProtect_SdProtectOperationType._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Type of recovery procedure. These should be used as bitmask, e.g.,
+///  `RecoveryDeviceType_ScrambledWords | RecoveryDeviceType_Matrix`
+///  listing every method supported by the host computer.
+///
+///  Note that ScrambledWords must be supported by every implementation
+///  for backward compatibility; there is no way to not support it.
+class RecoveryDevice_RecoveryDeviceType extends $pb.ProtobufEnum {
+  static const RecoveryDevice_RecoveryDeviceType RecoveryDeviceType_ScrambledWords = RecoveryDevice_RecoveryDeviceType._(0, _omitEnumNames ? '' : 'RecoveryDeviceType_ScrambledWords');
+  static const RecoveryDevice_RecoveryDeviceType RecoveryDeviceType_Matrix = RecoveryDevice_RecoveryDeviceType._(1, _omitEnumNames ? '' : 'RecoveryDeviceType_Matrix');
+
+  static const $core.List<RecoveryDevice_RecoveryDeviceType> values = <RecoveryDevice_RecoveryDeviceType> [
+    RecoveryDeviceType_ScrambledWords,
+    RecoveryDeviceType_Matrix,
+  ];
+
+  static final $core.Map<$core.int, RecoveryDevice_RecoveryDeviceType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static RecoveryDevice_RecoveryDeviceType? valueOf($core.int value) => _byValue[value];
+
+  const RecoveryDevice_RecoveryDeviceType._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Type of Recovery Word request
+class WordRequest_WordRequestType extends $pb.ProtobufEnum {
+  static const WordRequest_WordRequestType WordRequestType_Plain = WordRequest_WordRequestType._(0, _omitEnumNames ? '' : 'WordRequestType_Plain');
+  static const WordRequest_WordRequestType WordRequestType_Matrix9 = WordRequest_WordRequestType._(1, _omitEnumNames ? '' : 'WordRequestType_Matrix9');
+  static const WordRequest_WordRequestType WordRequestType_Matrix6 = WordRequest_WordRequestType._(2, _omitEnumNames ? '' : 'WordRequestType_Matrix6');
+
+  static const $core.List<WordRequest_WordRequestType> values = <WordRequest_WordRequestType> [
+    WordRequestType_Plain,
+    WordRequestType_Matrix9,
+    WordRequestType_Matrix6,
+  ];
+
+  static final $core.Map<$core.int, WordRequest_WordRequestType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static WordRequest_WordRequestType? valueOf($core.int value) => _byValue[value];
+
+  const WordRequest_WordRequestType._($core.int v, $core.String n) : super(v, n);
+}
+
+class RebootToBootloader_BootCommand extends $pb.ProtobufEnum {
+  static const RebootToBootloader_BootCommand STOP_AND_WAIT = RebootToBootloader_BootCommand._(0, _omitEnumNames ? '' : 'STOP_AND_WAIT');
+  static const RebootToBootloader_BootCommand INSTALL_UPGRADE = RebootToBootloader_BootCommand._(1, _omitEnumNames ? '' : 'INSTALL_UPGRADE');
+
+  static const $core.List<RebootToBootloader_BootCommand> values = <RebootToBootloader_BootCommand> [
+    STOP_AND_WAIT,
+    INSTALL_UPGRADE,
+  ];
+
+  static final $core.Map<$core.int, RebootToBootloader_BootCommand> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static RebootToBootloader_BootCommand? valueOf($core.int value) => _byValue[value];
+
+  const RebootToBootloader_BootCommand._($core.int v, $core.String n) : super(v, n);
+}
+
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-management.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-management.pbjson.dart
@@ -1,0 +1,853 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-management.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use backupTypeDescriptor instead')
+const BackupType$json = {
+  '1': 'BackupType',
+  '2': [
+    {'1': 'Bip39', '2': 0},
+    {'1': 'Slip39_Basic', '2': 1},
+    {'1': 'Slip39_Advanced', '2': 2},
+  ],
+};
+
+/// Descriptor for `BackupType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List backupTypeDescriptor = $convert.base64Decode(
+    'CgpCYWNrdXBUeXBlEgkKBUJpcDM5EAASEAoMU2xpcDM5X0Jhc2ljEAESEwoPU2xpcDM5X0Fkdm'
+    'FuY2VkEAI=');
+
+@$core.Deprecated('Use safetyCheckLevelDescriptor instead')
+const SafetyCheckLevel$json = {
+  '1': 'SafetyCheckLevel',
+  '2': [
+    {'1': 'Strict', '2': 0},
+    {'1': 'PromptAlways', '2': 1},
+    {'1': 'PromptTemporarily', '2': 2},
+  ],
+};
+
+/// Descriptor for `SafetyCheckLevel`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List safetyCheckLevelDescriptor = $convert.base64Decode(
+    'ChBTYWZldHlDaGVja0xldmVsEgoKBlN0cmljdBAAEhAKDFByb21wdEFsd2F5cxABEhUKEVByb2'
+    '1wdFRlbXBvcmFyaWx5EAI=');
+
+@$core.Deprecated('Use homescreenFormatDescriptor instead')
+const HomescreenFormat$json = {
+  '1': 'HomescreenFormat',
+  '2': [
+    {'1': 'Toif', '2': 1},
+    {'1': 'Jpeg', '2': 2},
+    {'1': 'ToiG', '2': 3},
+  ],
+};
+
+/// Descriptor for `HomescreenFormat`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List homescreenFormatDescriptor = $convert.base64Decode(
+    'ChBIb21lc2NyZWVuRm9ybWF0EggKBFRvaWYQARIICgRKcGVnEAISCAoEVG9pRxAD');
+
+@$core.Deprecated('Use initializeDescriptor instead')
+const Initialize$json = {
+  '1': 'Initialize',
+  '2': [
+    {'1': 'session_id', '3': 1, '4': 1, '5': 12, '10': 'sessionId'},
+    {
+      '1': '_skip_passphrase',
+      '3': 2,
+      '4': 1,
+      '5': 8,
+      '8': {'3': true},
+      '10': 'SkipPassphrase',
+    },
+    {'1': 'derive_cardano', '3': 3, '4': 1, '5': 8, '10': 'deriveCardano'},
+  ],
+};
+
+/// Descriptor for `Initialize`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List initializeDescriptor = $convert.base64Decode(
+    'CgpJbml0aWFsaXplEh0KCnNlc3Npb25faWQYASABKAxSCXNlc3Npb25JZBIsChBfc2tpcF9wYX'
+    'NzcGhyYXNlGAIgASgIQgIYAVIOU2tpcFBhc3NwaHJhc2USJQoOZGVyaXZlX2NhcmRhbm8YAyAB'
+    'KAhSDWRlcml2ZUNhcmRhbm8=');
+
+@$core.Deprecated('Use getFeaturesDescriptor instead')
+const GetFeatures$json = {
+  '1': 'GetFeatures',
+};
+
+/// Descriptor for `GetFeatures`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getFeaturesDescriptor = $convert.base64Decode(
+    'CgtHZXRGZWF0dXJlcw==');
+
+@$core.Deprecated('Use featuresDescriptor instead')
+const Features$json = {
+  '1': 'Features',
+  '2': [
+    {'1': 'vendor', '3': 1, '4': 1, '5': 9, '10': 'vendor'},
+    {'1': 'major_version', '3': 2, '4': 2, '5': 13, '10': 'majorVersion'},
+    {'1': 'minor_version', '3': 3, '4': 2, '5': 13, '10': 'minorVersion'},
+    {'1': 'patch_version', '3': 4, '4': 2, '5': 13, '10': 'patchVersion'},
+    {'1': 'bootloader_mode', '3': 5, '4': 1, '5': 8, '10': 'bootloaderMode'},
+    {'1': 'device_id', '3': 6, '4': 1, '5': 9, '10': 'deviceId'},
+    {'1': 'pin_protection', '3': 7, '4': 1, '5': 8, '10': 'pinProtection'},
+    {'1': 'passphrase_protection', '3': 8, '4': 1, '5': 8, '10': 'passphraseProtection'},
+    {'1': 'language', '3': 9, '4': 1, '5': 9, '10': 'language'},
+    {'1': 'label', '3': 10, '4': 1, '5': 9, '10': 'label'},
+    {'1': 'initialized', '3': 12, '4': 1, '5': 8, '10': 'initialized'},
+    {'1': 'revision', '3': 13, '4': 1, '5': 12, '10': 'revision'},
+    {'1': 'bootloader_hash', '3': 14, '4': 1, '5': 12, '10': 'bootloaderHash'},
+    {'1': 'imported', '3': 15, '4': 1, '5': 8, '10': 'imported'},
+    {'1': 'unlocked', '3': 16, '4': 1, '5': 8, '10': 'unlocked'},
+    {
+      '1': '_passphrase_cached',
+      '3': 17,
+      '4': 1,
+      '5': 8,
+      '8': {'3': true},
+      '10': 'PassphraseCached',
+    },
+    {'1': 'firmware_present', '3': 18, '4': 1, '5': 8, '10': 'firmwarePresent'},
+    {'1': 'needs_backup', '3': 19, '4': 1, '5': 8, '10': 'needsBackup'},
+    {'1': 'flags', '3': 20, '4': 1, '5': 13, '10': 'flags'},
+    {'1': 'model', '3': 21, '4': 1, '5': 9, '10': 'model'},
+    {'1': 'fw_major', '3': 22, '4': 1, '5': 13, '10': 'fwMajor'},
+    {'1': 'fw_minor', '3': 23, '4': 1, '5': 13, '10': 'fwMinor'},
+    {'1': 'fw_patch', '3': 24, '4': 1, '5': 13, '10': 'fwPatch'},
+    {'1': 'fw_vendor', '3': 25, '4': 1, '5': 9, '10': 'fwVendor'},
+    {'1': 'unfinished_backup', '3': 27, '4': 1, '5': 8, '10': 'unfinishedBackup'},
+    {'1': 'no_backup', '3': 28, '4': 1, '5': 8, '10': 'noBackup'},
+    {'1': 'recovery_mode', '3': 29, '4': 1, '5': 8, '10': 'recoveryMode'},
+    {'1': 'capabilities', '3': 30, '4': 3, '5': 14, '6': '.hw.trezor.messages.management.Features.Capability', '10': 'capabilities'},
+    {'1': 'backup_type', '3': 31, '4': 1, '5': 14, '6': '.hw.trezor.messages.management.BackupType', '10': 'backupType'},
+    {'1': 'sd_card_present', '3': 32, '4': 1, '5': 8, '10': 'sdCardPresent'},
+    {'1': 'sd_protection', '3': 33, '4': 1, '5': 8, '10': 'sdProtection'},
+    {'1': 'wipe_code_protection', '3': 34, '4': 1, '5': 8, '10': 'wipeCodeProtection'},
+    {'1': 'session_id', '3': 35, '4': 1, '5': 12, '10': 'sessionId'},
+    {'1': 'passphrase_always_on_device', '3': 36, '4': 1, '5': 8, '10': 'passphraseAlwaysOnDevice'},
+    {'1': 'safety_checks', '3': 37, '4': 1, '5': 14, '6': '.hw.trezor.messages.management.SafetyCheckLevel', '10': 'safetyChecks'},
+    {'1': 'auto_lock_delay_ms', '3': 38, '4': 1, '5': 13, '10': 'autoLockDelayMs'},
+    {'1': 'display_rotation', '3': 39, '4': 1, '5': 13, '10': 'displayRotation'},
+    {'1': 'experimental_features', '3': 40, '4': 1, '5': 8, '10': 'experimentalFeatures'},
+    {'1': 'busy', '3': 41, '4': 1, '5': 8, '10': 'busy'},
+    {'1': 'homescreen_format', '3': 42, '4': 1, '5': 14, '6': '.hw.trezor.messages.management.HomescreenFormat', '10': 'homescreenFormat'},
+    {'1': 'hide_passphrase_from_host', '3': 43, '4': 1, '5': 8, '10': 'hidePassphraseFromHost'},
+    {'1': 'internal_model', '3': 44, '4': 1, '5': 9, '10': 'internalModel'},
+    {'1': 'unit_color', '3': 45, '4': 1, '5': 13, '10': 'unitColor'},
+    {'1': 'unit_btconly', '3': 46, '4': 1, '5': 8, '10': 'unitBtconly'},
+    {'1': 'homescreen_width', '3': 47, '4': 1, '5': 13, '10': 'homescreenWidth'},
+    {'1': 'homescreen_height', '3': 48, '4': 1, '5': 13, '10': 'homescreenHeight'},
+    {'1': 'bootloader_locked', '3': 49, '4': 1, '5': 8, '10': 'bootloaderLocked'},
+    {'1': 'language_version_matches', '3': 50, '4': 1, '5': 8, '7': 'true', '10': 'languageVersionMatches'},
+  ],
+  '4': [Features_Capability$json],
+};
+
+@$core.Deprecated('Use featuresDescriptor instead')
+const Features_Capability$json = {
+  '1': 'Capability',
+  '2': [
+    {'1': 'Capability_Bitcoin', '2': 1, '3': {}},
+    {'1': 'Capability_Bitcoin_like', '2': 2},
+    {'1': 'Capability_Binance', '2': 3},
+    {'1': 'Capability_Cardano', '2': 4},
+    {'1': 'Capability_Crypto', '2': 5, '3': {}},
+    {'1': 'Capability_EOS', '2': 6},
+    {'1': 'Capability_Ethereum', '2': 7},
+    {
+      '1': 'Capability_Lisk',
+      '2': 8,
+      '3': {'1': true},
+    },
+    {'1': 'Capability_Monero', '2': 9},
+    {'1': 'Capability_NEM', '2': 10},
+    {'1': 'Capability_Ripple', '2': 11},
+    {'1': 'Capability_Stellar', '2': 12},
+    {'1': 'Capability_Tezos', '2': 13},
+    {'1': 'Capability_U2F', '2': 14},
+    {'1': 'Capability_Shamir', '2': 15, '3': {}},
+    {'1': 'Capability_ShamirGroups', '2': 16, '3': {}},
+    {'1': 'Capability_PassphraseEntry', '2': 17, '3': {}},
+    {'1': 'Capability_Solana', '2': 18},
+    {'1': 'Capability_Translations', '2': 19, '3': {}},
+  ],
+  '3': {},
+};
+
+/// Descriptor for `Features`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List featuresDescriptor = $convert.base64Decode(
+    'CghGZWF0dXJlcxIWCgZ2ZW5kb3IYASABKAlSBnZlbmRvchIjCg1tYWpvcl92ZXJzaW9uGAIgAi'
+    'gNUgxtYWpvclZlcnNpb24SIwoNbWlub3JfdmVyc2lvbhgDIAIoDVIMbWlub3JWZXJzaW9uEiMK'
+    'DXBhdGNoX3ZlcnNpb24YBCACKA1SDHBhdGNoVmVyc2lvbhInCg9ib290bG9hZGVyX21vZGUYBS'
+    'ABKAhSDmJvb3Rsb2FkZXJNb2RlEhsKCWRldmljZV9pZBgGIAEoCVIIZGV2aWNlSWQSJQoOcGlu'
+    'X3Byb3RlY3Rpb24YByABKAhSDXBpblByb3RlY3Rpb24SMwoVcGFzc3BocmFzZV9wcm90ZWN0aW'
+    '9uGAggASgIUhRwYXNzcGhyYXNlUHJvdGVjdGlvbhIaCghsYW5ndWFnZRgJIAEoCVIIbGFuZ3Vh'
+    'Z2USFAoFbGFiZWwYCiABKAlSBWxhYmVsEiAKC2luaXRpYWxpemVkGAwgASgIUgtpbml0aWFsaX'
+    'plZBIaCghyZXZpc2lvbhgNIAEoDFIIcmV2aXNpb24SJwoPYm9vdGxvYWRlcl9oYXNoGA4gASgM'
+    'Ug5ib290bG9hZGVySGFzaBIaCghpbXBvcnRlZBgPIAEoCFIIaW1wb3J0ZWQSGgoIdW5sb2NrZW'
+    'QYECABKAhSCHVubG9ja2VkEjAKEl9wYXNzcGhyYXNlX2NhY2hlZBgRIAEoCEICGAFSEFBhc3Nw'
+    'aHJhc2VDYWNoZWQSKQoQZmlybXdhcmVfcHJlc2VudBgSIAEoCFIPZmlybXdhcmVQcmVzZW50Ei'
+    'EKDG5lZWRzX2JhY2t1cBgTIAEoCFILbmVlZHNCYWNrdXASFAoFZmxhZ3MYFCABKA1SBWZsYWdz'
+    'EhQKBW1vZGVsGBUgASgJUgVtb2RlbBIZCghmd19tYWpvchgWIAEoDVIHZndNYWpvchIZCghmd1'
+    '9taW5vchgXIAEoDVIHZndNaW5vchIZCghmd19wYXRjaBgYIAEoDVIHZndQYXRjaBIbCglmd192'
+    'ZW5kb3IYGSABKAlSCGZ3VmVuZG9yEisKEXVuZmluaXNoZWRfYmFja3VwGBsgASgIUhB1bmZpbm'
+    'lzaGVkQmFja3VwEhsKCW5vX2JhY2t1cBgcIAEoCFIIbm9CYWNrdXASIwoNcmVjb3ZlcnlfbW9k'
+    'ZRgdIAEoCFIMcmVjb3ZlcnlNb2RlElYKDGNhcGFiaWxpdGllcxgeIAMoDjIyLmh3LnRyZXpvci'
+    '5tZXNzYWdlcy5tYW5hZ2VtZW50LkZlYXR1cmVzLkNhcGFiaWxpdHlSDGNhcGFiaWxpdGllcxJK'
+    'CgtiYWNrdXBfdHlwZRgfIAEoDjIpLmh3LnRyZXpvci5tZXNzYWdlcy5tYW5hZ2VtZW50LkJhY2'
+    't1cFR5cGVSCmJhY2t1cFR5cGUSJgoPc2RfY2FyZF9wcmVzZW50GCAgASgIUg1zZENhcmRQcmVz'
+    'ZW50EiMKDXNkX3Byb3RlY3Rpb24YISABKAhSDHNkUHJvdGVjdGlvbhIwChR3aXBlX2NvZGVfcH'
+    'JvdGVjdGlvbhgiIAEoCFISd2lwZUNvZGVQcm90ZWN0aW9uEh0KCnNlc3Npb25faWQYIyABKAxS'
+    'CXNlc3Npb25JZBI9ChtwYXNzcGhyYXNlX2Fsd2F5c19vbl9kZXZpY2UYJCABKAhSGHBhc3NwaH'
+    'Jhc2VBbHdheXNPbkRldmljZRJUCg1zYWZldHlfY2hlY2tzGCUgASgOMi8uaHcudHJlem9yLm1l'
+    'c3NhZ2VzLm1hbmFnZW1lbnQuU2FmZXR5Q2hlY2tMZXZlbFIMc2FmZXR5Q2hlY2tzEisKEmF1dG'
+    '9fbG9ja19kZWxheV9tcxgmIAEoDVIPYXV0b0xvY2tEZWxheU1zEikKEGRpc3BsYXlfcm90YXRp'
+    'b24YJyABKA1SD2Rpc3BsYXlSb3RhdGlvbhIzChVleHBlcmltZW50YWxfZmVhdHVyZXMYKCABKA'
+    'hSFGV4cGVyaW1lbnRhbEZlYXR1cmVzEhIKBGJ1c3kYKSABKAhSBGJ1c3kSXAoRaG9tZXNjcmVl'
+    'bl9mb3JtYXQYKiABKA4yLy5ody50cmV6b3IubWVzc2FnZXMubWFuYWdlbWVudC5Ib21lc2NyZW'
+    'VuRm9ybWF0UhBob21lc2NyZWVuRm9ybWF0EjkKGWhpZGVfcGFzc3BocmFzZV9mcm9tX2hvc3QY'
+    'KyABKAhSFmhpZGVQYXNzcGhyYXNlRnJvbUhvc3QSJQoOaW50ZXJuYWxfbW9kZWwYLCABKAlSDW'
+    'ludGVybmFsTW9kZWwSHQoKdW5pdF9jb2xvchgtIAEoDVIJdW5pdENvbG9yEiEKDHVuaXRfYnRj'
+    'b25seRguIAEoCFILdW5pdEJ0Y29ubHkSKQoQaG9tZXNjcmVlbl93aWR0aBgvIAEoDVIPaG9tZX'
+    'NjcmVlbldpZHRoEisKEWhvbWVzY3JlZW5faGVpZ2h0GDAgASgNUhBob21lc2NyZWVuSGVpZ2h0'
+    'EisKEWJvb3Rsb2FkZXJfbG9ja2VkGDEgASgIUhBib290bG9hZGVyTG9ja2VkEj4KGGxhbmd1YW'
+    'dlX3ZlcnNpb25fbWF0Y2hlcxgyIAEoCDoEdHJ1ZVIWbGFuZ3VhZ2VWZXJzaW9uTWF0Y2hlcyKE'
+    'BAoKQ2FwYWJpbGl0eRIcChJDYXBhYmlsaXR5X0JpdGNvaW4QARoEgKYdARIbChdDYXBhYmlsaX'
+    'R5X0JpdGNvaW5fbGlrZRACEhYKEkNhcGFiaWxpdHlfQmluYW5jZRADEhYKEkNhcGFiaWxpdHlf'
+    'Q2FyZGFubxAEEhsKEUNhcGFiaWxpdHlfQ3J5cHRvEAUaBICmHQESEgoOQ2FwYWJpbGl0eV9FT1'
+    'MQBhIXChNDYXBhYmlsaXR5X0V0aGVyZXVtEAcSFwoPQ2FwYWJpbGl0eV9MaXNrEAgaAggBEhUK'
+    'EUNhcGFiaWxpdHlfTW9uZXJvEAkSEgoOQ2FwYWJpbGl0eV9ORU0QChIVChFDYXBhYmlsaXR5X1'
+    'JpcHBsZRALEhYKEkNhcGFiaWxpdHlfU3RlbGxhchAMEhQKEENhcGFiaWxpdHlfVGV6b3MQDRIS'
+    'Cg5DYXBhYmlsaXR5X1UyRhAOEhsKEUNhcGFiaWxpdHlfU2hhbWlyEA8aBICmHQESIQoXQ2FwYW'
+    'JpbGl0eV9TaGFtaXJHcm91cHMQEBoEgKYdARIkChpDYXBhYmlsaXR5X1Bhc3NwaHJhc2VFbnRy'
+    'eRARGgSAph0BEhUKEUNhcGFiaWxpdHlfU29sYW5hEBISIQoXQ2FwYWJpbGl0eV9UcmFuc2xhdG'
+    'lvbnMQExoEgKYdARoEyPMYAQ==');
+
+@$core.Deprecated('Use lockDeviceDescriptor instead')
+const LockDevice$json = {
+  '1': 'LockDevice',
+};
+
+/// Descriptor for `LockDevice`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List lockDeviceDescriptor = $convert.base64Decode(
+    'CgpMb2NrRGV2aWNl');
+
+@$core.Deprecated('Use setBusyDescriptor instead')
+const SetBusy$json = {
+  '1': 'SetBusy',
+  '2': [
+    {'1': 'expiry_ms', '3': 1, '4': 1, '5': 13, '10': 'expiryMs'},
+  ],
+};
+
+/// Descriptor for `SetBusy`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List setBusyDescriptor = $convert.base64Decode(
+    'CgdTZXRCdXN5EhsKCWV4cGlyeV9tcxgBIAEoDVIIZXhwaXJ5TXM=');
+
+@$core.Deprecated('Use endSessionDescriptor instead')
+const EndSession$json = {
+  '1': 'EndSession',
+};
+
+/// Descriptor for `EndSession`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List endSessionDescriptor = $convert.base64Decode(
+    'CgpFbmRTZXNzaW9u');
+
+@$core.Deprecated('Use applySettingsDescriptor instead')
+const ApplySettings$json = {
+  '1': 'ApplySettings',
+  '2': [
+    {
+      '1': 'language',
+      '3': 1,
+      '4': 1,
+      '5': 9,
+      '8': {'3': true},
+      '10': 'language',
+    },
+    {'1': 'label', '3': 2, '4': 1, '5': 9, '10': 'label'},
+    {'1': 'use_passphrase', '3': 3, '4': 1, '5': 8, '10': 'usePassphrase'},
+    {'1': 'homescreen', '3': 4, '4': 1, '5': 12, '10': 'homescreen'},
+    {
+      '1': '_passphrase_source',
+      '3': 5,
+      '4': 1,
+      '5': 13,
+      '8': {'3': true},
+      '10': 'PassphraseSource',
+    },
+    {'1': 'auto_lock_delay_ms', '3': 6, '4': 1, '5': 13, '10': 'autoLockDelayMs'},
+    {'1': 'display_rotation', '3': 7, '4': 1, '5': 13, '10': 'displayRotation'},
+    {'1': 'passphrase_always_on_device', '3': 8, '4': 1, '5': 8, '10': 'passphraseAlwaysOnDevice'},
+    {'1': 'safety_checks', '3': 9, '4': 1, '5': 14, '6': '.hw.trezor.messages.management.SafetyCheckLevel', '10': 'safetyChecks'},
+    {'1': 'experimental_features', '3': 10, '4': 1, '5': 8, '10': 'experimentalFeatures'},
+    {'1': 'hide_passphrase_from_host', '3': 11, '4': 1, '5': 8, '10': 'hidePassphraseFromHost'},
+  ],
+};
+
+/// Descriptor for `ApplySettings`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List applySettingsDescriptor = $convert.base64Decode(
+    'Cg1BcHBseVNldHRpbmdzEh4KCGxhbmd1YWdlGAEgASgJQgIYAVIIbGFuZ3VhZ2USFAoFbGFiZW'
+    'wYAiABKAlSBWxhYmVsEiUKDnVzZV9wYXNzcGhyYXNlGAMgASgIUg11c2VQYXNzcGhyYXNlEh4K'
+    'CmhvbWVzY3JlZW4YBCABKAxSCmhvbWVzY3JlZW4SMAoSX3Bhc3NwaHJhc2Vfc291cmNlGAUgAS'
+    'gNQgIYAVIQUGFzc3BocmFzZVNvdXJjZRIrChJhdXRvX2xvY2tfZGVsYXlfbXMYBiABKA1SD2F1'
+    'dG9Mb2NrRGVsYXlNcxIpChBkaXNwbGF5X3JvdGF0aW9uGAcgASgNUg9kaXNwbGF5Um90YXRpb2'
+    '4SPQobcGFzc3BocmFzZV9hbHdheXNfb25fZGV2aWNlGAggASgIUhhwYXNzcGhyYXNlQWx3YXlz'
+    'T25EZXZpY2USVAoNc2FmZXR5X2NoZWNrcxgJIAEoDjIvLmh3LnRyZXpvci5tZXNzYWdlcy5tYW'
+    '5hZ2VtZW50LlNhZmV0eUNoZWNrTGV2ZWxSDHNhZmV0eUNoZWNrcxIzChVleHBlcmltZW50YWxf'
+    'ZmVhdHVyZXMYCiABKAhSFGV4cGVyaW1lbnRhbEZlYXR1cmVzEjkKGWhpZGVfcGFzc3BocmFzZV'
+    '9mcm9tX2hvc3QYCyABKAhSFmhpZGVQYXNzcGhyYXNlRnJvbUhvc3Q=');
+
+@$core.Deprecated('Use changeLanguageDescriptor instead')
+const ChangeLanguage$json = {
+  '1': 'ChangeLanguage',
+  '2': [
+    {'1': 'data_length', '3': 1, '4': 2, '5': 13, '10': 'dataLength'},
+    {'1': 'show_display', '3': 2, '4': 1, '5': 8, '10': 'showDisplay'},
+  ],
+};
+
+/// Descriptor for `ChangeLanguage`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List changeLanguageDescriptor = $convert.base64Decode(
+    'Cg5DaGFuZ2VMYW5ndWFnZRIfCgtkYXRhX2xlbmd0aBgBIAIoDVIKZGF0YUxlbmd0aBIhCgxzaG'
+    '93X2Rpc3BsYXkYAiABKAhSC3Nob3dEaXNwbGF5');
+
+@$core.Deprecated('Use translationDataRequestDescriptor instead')
+const TranslationDataRequest$json = {
+  '1': 'TranslationDataRequest',
+  '2': [
+    {'1': 'data_length', '3': 1, '4': 2, '5': 13, '10': 'dataLength'},
+    {'1': 'data_offset', '3': 2, '4': 2, '5': 13, '10': 'dataOffset'},
+  ],
+};
+
+/// Descriptor for `TranslationDataRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List translationDataRequestDescriptor = $convert.base64Decode(
+    'ChZUcmFuc2xhdGlvbkRhdGFSZXF1ZXN0Eh8KC2RhdGFfbGVuZ3RoGAEgAigNUgpkYXRhTGVuZ3'
+    'RoEh8KC2RhdGFfb2Zmc2V0GAIgAigNUgpkYXRhT2Zmc2V0');
+
+@$core.Deprecated('Use translationDataAckDescriptor instead')
+const TranslationDataAck$json = {
+  '1': 'TranslationDataAck',
+  '2': [
+    {'1': 'data_chunk', '3': 1, '4': 2, '5': 12, '10': 'dataChunk'},
+  ],
+};
+
+/// Descriptor for `TranslationDataAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List translationDataAckDescriptor = $convert.base64Decode(
+    'ChJUcmFuc2xhdGlvbkRhdGFBY2sSHQoKZGF0YV9jaHVuaxgBIAIoDFIJZGF0YUNodW5r');
+
+@$core.Deprecated('Use applyFlagsDescriptor instead')
+const ApplyFlags$json = {
+  '1': 'ApplyFlags',
+  '2': [
+    {'1': 'flags', '3': 1, '4': 2, '5': 13, '10': 'flags'},
+  ],
+};
+
+/// Descriptor for `ApplyFlags`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List applyFlagsDescriptor = $convert.base64Decode(
+    'CgpBcHBseUZsYWdzEhQKBWZsYWdzGAEgAigNUgVmbGFncw==');
+
+@$core.Deprecated('Use changePinDescriptor instead')
+const ChangePin$json = {
+  '1': 'ChangePin',
+  '2': [
+    {'1': 'remove', '3': 1, '4': 1, '5': 8, '10': 'remove'},
+  ],
+};
+
+/// Descriptor for `ChangePin`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List changePinDescriptor = $convert.base64Decode(
+    'CglDaGFuZ2VQaW4SFgoGcmVtb3ZlGAEgASgIUgZyZW1vdmU=');
+
+@$core.Deprecated('Use changeWipeCodeDescriptor instead')
+const ChangeWipeCode$json = {
+  '1': 'ChangeWipeCode',
+  '2': [
+    {'1': 'remove', '3': 1, '4': 1, '5': 8, '10': 'remove'},
+  ],
+};
+
+/// Descriptor for `ChangeWipeCode`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List changeWipeCodeDescriptor = $convert.base64Decode(
+    'Cg5DaGFuZ2VXaXBlQ29kZRIWCgZyZW1vdmUYASABKAhSBnJlbW92ZQ==');
+
+@$core.Deprecated('Use sdProtectDescriptor instead')
+const SdProtect$json = {
+  '1': 'SdProtect',
+  '2': [
+    {'1': 'operation', '3': 1, '4': 2, '5': 14, '6': '.hw.trezor.messages.management.SdProtect.SdProtectOperationType', '10': 'operation'},
+  ],
+  '4': [SdProtect_SdProtectOperationType$json],
+};
+
+@$core.Deprecated('Use sdProtectDescriptor instead')
+const SdProtect_SdProtectOperationType$json = {
+  '1': 'SdProtectOperationType',
+  '2': [
+    {'1': 'DISABLE', '2': 0},
+    {'1': 'ENABLE', '2': 1},
+    {'1': 'REFRESH', '2': 2},
+  ],
+};
+
+/// Descriptor for `SdProtect`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List sdProtectDescriptor = $convert.base64Decode(
+    'CglTZFByb3RlY3QSXQoJb3BlcmF0aW9uGAEgAigOMj8uaHcudHJlem9yLm1lc3NhZ2VzLm1hbm'
+    'FnZW1lbnQuU2RQcm90ZWN0LlNkUHJvdGVjdE9wZXJhdGlvblR5cGVSCW9wZXJhdGlvbiI+ChZT'
+    'ZFByb3RlY3RPcGVyYXRpb25UeXBlEgsKB0RJU0FCTEUQABIKCgZFTkFCTEUQARILCgdSRUZSRV'
+    'NIEAI=');
+
+@$core.Deprecated('Use pingDescriptor instead')
+const Ping$json = {
+  '1': 'Ping',
+  '2': [
+    {'1': 'message', '3': 1, '4': 1, '5': 9, '7': '', '10': 'message'},
+    {'1': 'button_protection', '3': 2, '4': 1, '5': 8, '10': 'buttonProtection'},
+  ],
+};
+
+/// Descriptor for `Ping`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List pingDescriptor = $convert.base64Decode(
+    'CgRQaW5nEhoKB21lc3NhZ2UYASABKAk6AFIHbWVzc2FnZRIrChFidXR0b25fcHJvdGVjdGlvbh'
+    'gCIAEoCFIQYnV0dG9uUHJvdGVjdGlvbg==');
+
+@$core.Deprecated('Use cancelDescriptor instead')
+const Cancel$json = {
+  '1': 'Cancel',
+};
+
+/// Descriptor for `Cancel`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cancelDescriptor = $convert.base64Decode(
+    'CgZDYW5jZWw=');
+
+@$core.Deprecated('Use getEntropyDescriptor instead')
+const GetEntropy$json = {
+  '1': 'GetEntropy',
+  '2': [
+    {'1': 'size', '3': 1, '4': 2, '5': 13, '10': 'size'},
+  ],
+};
+
+/// Descriptor for `GetEntropy`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getEntropyDescriptor = $convert.base64Decode(
+    'CgpHZXRFbnRyb3B5EhIKBHNpemUYASACKA1SBHNpemU=');
+
+@$core.Deprecated('Use entropyDescriptor instead')
+const Entropy$json = {
+  '1': 'Entropy',
+  '2': [
+    {'1': 'entropy', '3': 1, '4': 2, '5': 12, '10': 'entropy'},
+  ],
+};
+
+/// Descriptor for `Entropy`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List entropyDescriptor = $convert.base64Decode(
+    'CgdFbnRyb3B5EhgKB2VudHJvcHkYASACKAxSB2VudHJvcHk=');
+
+@$core.Deprecated('Use getFirmwareHashDescriptor instead')
+const GetFirmwareHash$json = {
+  '1': 'GetFirmwareHash',
+  '2': [
+    {'1': 'challenge', '3': 1, '4': 1, '5': 12, '10': 'challenge'},
+  ],
+};
+
+/// Descriptor for `GetFirmwareHash`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getFirmwareHashDescriptor = $convert.base64Decode(
+    'Cg9HZXRGaXJtd2FyZUhhc2gSHAoJY2hhbGxlbmdlGAEgASgMUgljaGFsbGVuZ2U=');
+
+@$core.Deprecated('Use firmwareHashDescriptor instead')
+const FirmwareHash$json = {
+  '1': 'FirmwareHash',
+  '2': [
+    {'1': 'hash', '3': 1, '4': 2, '5': 12, '10': 'hash'},
+  ],
+};
+
+/// Descriptor for `FirmwareHash`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List firmwareHashDescriptor = $convert.base64Decode(
+    'CgxGaXJtd2FyZUhhc2gSEgoEaGFzaBgBIAIoDFIEaGFzaA==');
+
+@$core.Deprecated('Use authenticateDeviceDescriptor instead')
+const AuthenticateDevice$json = {
+  '1': 'AuthenticateDevice',
+  '2': [
+    {'1': 'challenge', '3': 1, '4': 2, '5': 12, '10': 'challenge'},
+  ],
+};
+
+/// Descriptor for `AuthenticateDevice`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List authenticateDeviceDescriptor = $convert.base64Decode(
+    'ChJBdXRoZW50aWNhdGVEZXZpY2USHAoJY2hhbGxlbmdlGAEgAigMUgljaGFsbGVuZ2U=');
+
+@$core.Deprecated('Use authenticityProofDescriptor instead')
+const AuthenticityProof$json = {
+  '1': 'AuthenticityProof',
+  '2': [
+    {'1': 'certificates', '3': 1, '4': 3, '5': 12, '10': 'certificates'},
+    {'1': 'signature', '3': 2, '4': 2, '5': 12, '10': 'signature'},
+  ],
+};
+
+/// Descriptor for `AuthenticityProof`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List authenticityProofDescriptor = $convert.base64Decode(
+    'ChFBdXRoZW50aWNpdHlQcm9vZhIiCgxjZXJ0aWZpY2F0ZXMYASADKAxSDGNlcnRpZmljYXRlcx'
+    'IcCglzaWduYXR1cmUYAiACKAxSCXNpZ25hdHVyZQ==');
+
+@$core.Deprecated('Use wipeDeviceDescriptor instead')
+const WipeDevice$json = {
+  '1': 'WipeDevice',
+};
+
+/// Descriptor for `WipeDevice`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List wipeDeviceDescriptor = $convert.base64Decode(
+    'CgpXaXBlRGV2aWNl');
+
+@$core.Deprecated('Use loadDeviceDescriptor instead')
+const LoadDevice$json = {
+  '1': 'LoadDevice',
+  '2': [
+    {'1': 'mnemonics', '3': 1, '4': 3, '5': 9, '10': 'mnemonics'},
+    {'1': 'pin', '3': 3, '4': 1, '5': 9, '10': 'pin'},
+    {'1': 'passphrase_protection', '3': 4, '4': 1, '5': 8, '10': 'passphraseProtection'},
+    {
+      '1': 'language',
+      '3': 5,
+      '4': 1,
+      '5': 9,
+      '8': {'3': true},
+      '10': 'language',
+    },
+    {'1': 'label', '3': 6, '4': 1, '5': 9, '10': 'label'},
+    {'1': 'skip_checksum', '3': 7, '4': 1, '5': 8, '10': 'skipChecksum'},
+    {'1': 'u2f_counter', '3': 8, '4': 1, '5': 13, '10': 'u2fCounter'},
+    {'1': 'needs_backup', '3': 9, '4': 1, '5': 8, '10': 'needsBackup'},
+    {'1': 'no_backup', '3': 10, '4': 1, '5': 8, '10': 'noBackup'},
+  ],
+};
+
+/// Descriptor for `LoadDevice`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List loadDeviceDescriptor = $convert.base64Decode(
+    'CgpMb2FkRGV2aWNlEhwKCW1uZW1vbmljcxgBIAMoCVIJbW5lbW9uaWNzEhAKA3BpbhgDIAEoCV'
+    'IDcGluEjMKFXBhc3NwaHJhc2VfcHJvdGVjdGlvbhgEIAEoCFIUcGFzc3BocmFzZVByb3RlY3Rp'
+    'b24SHgoIbGFuZ3VhZ2UYBSABKAlCAhgBUghsYW5ndWFnZRIUCgVsYWJlbBgGIAEoCVIFbGFiZW'
+    'wSIwoNc2tpcF9jaGVja3N1bRgHIAEoCFIMc2tpcENoZWNrc3VtEh8KC3UyZl9jb3VudGVyGAgg'
+    'ASgNUgp1MmZDb3VudGVyEiEKDG5lZWRzX2JhY2t1cBgJIAEoCFILbmVlZHNCYWNrdXASGwoJbm'
+    '9fYmFja3VwGAogASgIUghub0JhY2t1cA==');
+
+@$core.Deprecated('Use resetDeviceDescriptor instead')
+const ResetDevice$json = {
+  '1': 'ResetDevice',
+  '2': [
+    {'1': 'display_random', '3': 1, '4': 1, '5': 8, '10': 'displayRandom'},
+    {'1': 'strength', '3': 2, '4': 1, '5': 13, '7': '256', '10': 'strength'},
+    {'1': 'passphrase_protection', '3': 3, '4': 1, '5': 8, '10': 'passphraseProtection'},
+    {'1': 'pin_protection', '3': 4, '4': 1, '5': 8, '10': 'pinProtection'},
+    {
+      '1': 'language',
+      '3': 5,
+      '4': 1,
+      '5': 9,
+      '8': {'3': true},
+      '10': 'language',
+    },
+    {'1': 'label', '3': 6, '4': 1, '5': 9, '10': 'label'},
+    {'1': 'u2f_counter', '3': 7, '4': 1, '5': 13, '10': 'u2fCounter'},
+    {'1': 'skip_backup', '3': 8, '4': 1, '5': 8, '10': 'skipBackup'},
+    {'1': 'no_backup', '3': 9, '4': 1, '5': 8, '10': 'noBackup'},
+    {'1': 'backup_type', '3': 10, '4': 1, '5': 14, '6': '.hw.trezor.messages.management.BackupType', '7': 'Bip39', '10': 'backupType'},
+  ],
+};
+
+/// Descriptor for `ResetDevice`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List resetDeviceDescriptor = $convert.base64Decode(
+    'CgtSZXNldERldmljZRIlCg5kaXNwbGF5X3JhbmRvbRgBIAEoCFINZGlzcGxheVJhbmRvbRIfCg'
+    'hzdHJlbmd0aBgCIAEoDToDMjU2UghzdHJlbmd0aBIzChVwYXNzcGhyYXNlX3Byb3RlY3Rpb24Y'
+    'AyABKAhSFHBhc3NwaHJhc2VQcm90ZWN0aW9uEiUKDnBpbl9wcm90ZWN0aW9uGAQgASgIUg1waW'
+    '5Qcm90ZWN0aW9uEh4KCGxhbmd1YWdlGAUgASgJQgIYAVIIbGFuZ3VhZ2USFAoFbGFiZWwYBiAB'
+    'KAlSBWxhYmVsEh8KC3UyZl9jb3VudGVyGAcgASgNUgp1MmZDb3VudGVyEh8KC3NraXBfYmFja3'
+    'VwGAggASgIUgpza2lwQmFja3VwEhsKCW5vX2JhY2t1cBgJIAEoCFIIbm9CYWNrdXASUQoLYmFj'
+    'a3VwX3R5cGUYCiABKA4yKS5ody50cmV6b3IubWVzc2FnZXMubWFuYWdlbWVudC5CYWNrdXBUeX'
+    'BlOgVCaXAzOVIKYmFja3VwVHlwZQ==');
+
+@$core.Deprecated('Use backupDeviceDescriptor instead')
+const BackupDevice$json = {
+  '1': 'BackupDevice',
+};
+
+/// Descriptor for `BackupDevice`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List backupDeviceDescriptor = $convert.base64Decode(
+    'CgxCYWNrdXBEZXZpY2U=');
+
+@$core.Deprecated('Use entropyRequestDescriptor instead')
+const EntropyRequest$json = {
+  '1': 'EntropyRequest',
+};
+
+/// Descriptor for `EntropyRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List entropyRequestDescriptor = $convert.base64Decode(
+    'Cg5FbnRyb3B5UmVxdWVzdA==');
+
+@$core.Deprecated('Use entropyAckDescriptor instead')
+const EntropyAck$json = {
+  '1': 'EntropyAck',
+  '2': [
+    {'1': 'entropy', '3': 1, '4': 2, '5': 12, '10': 'entropy'},
+  ],
+};
+
+/// Descriptor for `EntropyAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List entropyAckDescriptor = $convert.base64Decode(
+    'CgpFbnRyb3B5QWNrEhgKB2VudHJvcHkYASACKAxSB2VudHJvcHk=');
+
+@$core.Deprecated('Use recoveryDeviceDescriptor instead')
+const RecoveryDevice$json = {
+  '1': 'RecoveryDevice',
+  '2': [
+    {'1': 'word_count', '3': 1, '4': 1, '5': 13, '10': 'wordCount'},
+    {'1': 'passphrase_protection', '3': 2, '4': 1, '5': 8, '10': 'passphraseProtection'},
+    {'1': 'pin_protection', '3': 3, '4': 1, '5': 8, '10': 'pinProtection'},
+    {
+      '1': 'language',
+      '3': 4,
+      '4': 1,
+      '5': 9,
+      '8': {'3': true},
+      '10': 'language',
+    },
+    {'1': 'label', '3': 5, '4': 1, '5': 9, '10': 'label'},
+    {'1': 'enforce_wordlist', '3': 6, '4': 1, '5': 8, '10': 'enforceWordlist'},
+    {'1': 'type', '3': 8, '4': 1, '5': 14, '6': '.hw.trezor.messages.management.RecoveryDevice.RecoveryDeviceType', '10': 'type'},
+    {'1': 'u2f_counter', '3': 9, '4': 1, '5': 13, '10': 'u2fCounter'},
+    {'1': 'dry_run', '3': 10, '4': 1, '5': 8, '10': 'dryRun'},
+  ],
+  '4': [RecoveryDevice_RecoveryDeviceType$json],
+};
+
+@$core.Deprecated('Use recoveryDeviceDescriptor instead')
+const RecoveryDevice_RecoveryDeviceType$json = {
+  '1': 'RecoveryDeviceType',
+  '2': [
+    {'1': 'RecoveryDeviceType_ScrambledWords', '2': 0},
+    {'1': 'RecoveryDeviceType_Matrix', '2': 1},
+  ],
+};
+
+/// Descriptor for `RecoveryDevice`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List recoveryDeviceDescriptor = $convert.base64Decode(
+    'Cg5SZWNvdmVyeURldmljZRIdCgp3b3JkX2NvdW50GAEgASgNUgl3b3JkQ291bnQSMwoVcGFzc3'
+    'BocmFzZV9wcm90ZWN0aW9uGAIgASgIUhRwYXNzcGhyYXNlUHJvdGVjdGlvbhIlCg5waW5fcHJv'
+    'dGVjdGlvbhgDIAEoCFINcGluUHJvdGVjdGlvbhIeCghsYW5ndWFnZRgEIAEoCUICGAFSCGxhbm'
+    'd1YWdlEhQKBWxhYmVsGAUgASgJUgVsYWJlbBIpChBlbmZvcmNlX3dvcmRsaXN0GAYgASgIUg9l'
+    'bmZvcmNlV29yZGxpc3QSVAoEdHlwZRgIIAEoDjJALmh3LnRyZXpvci5tZXNzYWdlcy5tYW5hZ2'
+    'VtZW50LlJlY292ZXJ5RGV2aWNlLlJlY292ZXJ5RGV2aWNlVHlwZVIEdHlwZRIfCgt1MmZfY291'
+    'bnRlchgJIAEoDVIKdTJmQ291bnRlchIXCgdkcnlfcnVuGAogASgIUgZkcnlSdW4iWgoSUmVjb3'
+    'ZlcnlEZXZpY2VUeXBlEiUKIVJlY292ZXJ5RGV2aWNlVHlwZV9TY3JhbWJsZWRXb3JkcxAAEh0K'
+    'GVJlY292ZXJ5RGV2aWNlVHlwZV9NYXRyaXgQAQ==');
+
+@$core.Deprecated('Use wordRequestDescriptor instead')
+const WordRequest$json = {
+  '1': 'WordRequest',
+  '2': [
+    {'1': 'type', '3': 1, '4': 2, '5': 14, '6': '.hw.trezor.messages.management.WordRequest.WordRequestType', '10': 'type'},
+  ],
+  '4': [WordRequest_WordRequestType$json],
+};
+
+@$core.Deprecated('Use wordRequestDescriptor instead')
+const WordRequest_WordRequestType$json = {
+  '1': 'WordRequestType',
+  '2': [
+    {'1': 'WordRequestType_Plain', '2': 0},
+    {'1': 'WordRequestType_Matrix9', '2': 1},
+    {'1': 'WordRequestType_Matrix6', '2': 2},
+  ],
+};
+
+/// Descriptor for `WordRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List wordRequestDescriptor = $convert.base64Decode(
+    'CgtXb3JkUmVxdWVzdBJOCgR0eXBlGAEgAigOMjouaHcudHJlem9yLm1lc3NhZ2VzLm1hbmFnZW'
+    '1lbnQuV29yZFJlcXVlc3QuV29yZFJlcXVlc3RUeXBlUgR0eXBlImYKD1dvcmRSZXF1ZXN0VHlw'
+    'ZRIZChVXb3JkUmVxdWVzdFR5cGVfUGxhaW4QABIbChdXb3JkUmVxdWVzdFR5cGVfTWF0cml4OR'
+    'ABEhsKF1dvcmRSZXF1ZXN0VHlwZV9NYXRyaXg2EAI=');
+
+@$core.Deprecated('Use wordAckDescriptor instead')
+const WordAck$json = {
+  '1': 'WordAck',
+  '2': [
+    {'1': 'word', '3': 1, '4': 2, '5': 9, '10': 'word'},
+  ],
+};
+
+/// Descriptor for `WordAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List wordAckDescriptor = $convert.base64Decode(
+    'CgdXb3JkQWNrEhIKBHdvcmQYASACKAlSBHdvcmQ=');
+
+@$core.Deprecated('Use setU2FCounterDescriptor instead')
+const SetU2FCounter$json = {
+  '1': 'SetU2FCounter',
+  '2': [
+    {'1': 'u2f_counter', '3': 1, '4': 2, '5': 13, '10': 'u2fCounter'},
+  ],
+};
+
+/// Descriptor for `SetU2FCounter`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List setU2FCounterDescriptor = $convert.base64Decode(
+    'Cg1TZXRVMkZDb3VudGVyEh8KC3UyZl9jb3VudGVyGAEgAigNUgp1MmZDb3VudGVy');
+
+@$core.Deprecated('Use getNextU2FCounterDescriptor instead')
+const GetNextU2FCounter$json = {
+  '1': 'GetNextU2FCounter',
+};
+
+/// Descriptor for `GetNextU2FCounter`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getNextU2FCounterDescriptor = $convert.base64Decode(
+    'ChFHZXROZXh0VTJGQ291bnRlcg==');
+
+@$core.Deprecated('Use nextU2FCounterDescriptor instead')
+const NextU2FCounter$json = {
+  '1': 'NextU2FCounter',
+  '2': [
+    {'1': 'u2f_counter', '3': 1, '4': 2, '5': 13, '10': 'u2fCounter'},
+  ],
+};
+
+/// Descriptor for `NextU2FCounter`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List nextU2FCounterDescriptor = $convert.base64Decode(
+    'Cg5OZXh0VTJGQ291bnRlchIfCgt1MmZfY291bnRlchgBIAIoDVIKdTJmQ291bnRlcg==');
+
+@$core.Deprecated('Use doPreauthorizedDescriptor instead')
+const DoPreauthorized$json = {
+  '1': 'DoPreauthorized',
+};
+
+/// Descriptor for `DoPreauthorized`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List doPreauthorizedDescriptor = $convert.base64Decode(
+    'Cg9Eb1ByZWF1dGhvcml6ZWQ=');
+
+@$core.Deprecated('Use preauthorizedRequestDescriptor instead')
+const PreauthorizedRequest$json = {
+  '1': 'PreauthorizedRequest',
+};
+
+/// Descriptor for `PreauthorizedRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List preauthorizedRequestDescriptor = $convert.base64Decode(
+    'ChRQcmVhdXRob3JpemVkUmVxdWVzdA==');
+
+@$core.Deprecated('Use cancelAuthorizationDescriptor instead')
+const CancelAuthorization$json = {
+  '1': 'CancelAuthorization',
+};
+
+/// Descriptor for `CancelAuthorization`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List cancelAuthorizationDescriptor = $convert.base64Decode(
+    'ChNDYW5jZWxBdXRob3JpemF0aW9u');
+
+@$core.Deprecated('Use rebootToBootloaderDescriptor instead')
+const RebootToBootloader$json = {
+  '1': 'RebootToBootloader',
+  '2': [
+    {'1': 'boot_command', '3': 1, '4': 1, '5': 14, '6': '.hw.trezor.messages.management.RebootToBootloader.BootCommand', '7': 'STOP_AND_WAIT', '10': 'bootCommand'},
+    {'1': 'firmware_header', '3': 2, '4': 1, '5': 12, '10': 'firmwareHeader'},
+    {'1': 'language_data_length', '3': 3, '4': 1, '5': 13, '7': '0', '10': 'languageDataLength'},
+  ],
+  '4': [RebootToBootloader_BootCommand$json],
+};
+
+@$core.Deprecated('Use rebootToBootloaderDescriptor instead')
+const RebootToBootloader_BootCommand$json = {
+  '1': 'BootCommand',
+  '2': [
+    {'1': 'STOP_AND_WAIT', '2': 0},
+    {'1': 'INSTALL_UPGRADE', '2': 1},
+  ],
+};
+
+/// Descriptor for `RebootToBootloader`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List rebootToBootloaderDescriptor = $convert.base64Decode(
+    'ChJSZWJvb3RUb0Jvb3Rsb2FkZXISbwoMYm9vdF9jb21tYW5kGAEgASgOMj0uaHcudHJlem9yLm'
+    '1lc3NhZ2VzLm1hbmFnZW1lbnQuUmVib290VG9Cb290bG9hZGVyLkJvb3RDb21tYW5kOg1TVE9Q'
+    'X0FORF9XQUlUUgtib290Q29tbWFuZBInCg9maXJtd2FyZV9oZWFkZXIYAiABKAxSDmZpcm13YX'
+    'JlSGVhZGVyEjMKFGxhbmd1YWdlX2RhdGFfbGVuZ3RoGAMgASgNOgEwUhJsYW5ndWFnZURhdGFM'
+    'ZW5ndGgiNQoLQm9vdENvbW1hbmQSEQoNU1RPUF9BTkRfV0FJVBAAEhMKD0lOU1RBTExfVVBHUk'
+    'FERRAB');
+
+@$core.Deprecated('Use getNonceDescriptor instead')
+const GetNonce$json = {
+  '1': 'GetNonce',
+  '7': {},
+};
+
+/// Descriptor for `GetNonce`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getNonceDescriptor = $convert.base64Decode(
+    'CghHZXROb25jZToEiLIZAQ==');
+
+@$core.Deprecated('Use nonceDescriptor instead')
+const Nonce$json = {
+  '1': 'Nonce',
+  '2': [
+    {'1': 'nonce', '3': 1, '4': 2, '5': 12, '10': 'nonce'},
+  ],
+  '7': {},
+};
+
+/// Descriptor for `Nonce`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List nonceDescriptor = $convert.base64Decode(
+    'CgVOb25jZRIUCgVub25jZRgBIAIoDFIFbm9uY2U6BIiyGQE=');
+
+@$core.Deprecated('Use unlockPathDescriptor instead')
+const UnlockPath$json = {
+  '1': 'UnlockPath',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'mac', '3': 2, '4': 1, '5': 12, '10': 'mac'},
+  ],
+};
+
+/// Descriptor for `UnlockPath`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List unlockPathDescriptor = $convert.base64Decode(
+    'CgpVbmxvY2tQYXRoEhsKCWFkZHJlc3NfbhgBIAMoDVIIYWRkcmVzc04SEAoDbWFjGAIgASgMUg'
+    'NtYWM=');
+
+@$core.Deprecated('Use unlockedPathRequestDescriptor instead')
+const UnlockedPathRequest$json = {
+  '1': 'UnlockedPathRequest',
+  '2': [
+    {'1': 'mac', '3': 1, '4': 1, '5': 12, '10': 'mac'},
+  ],
+};
+
+/// Descriptor for `UnlockedPathRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List unlockedPathRequestDescriptor = $convert.base64Decode(
+    'ChNVbmxvY2tlZFBhdGhSZXF1ZXN0EhAKA21hYxgBIAEoDFIDbWFj');
+
+@$core.Deprecated('Use showDeviceTutorialDescriptor instead')
+const ShowDeviceTutorial$json = {
+  '1': 'ShowDeviceTutorial',
+};
+
+/// Descriptor for `ShowDeviceTutorial`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List showDeviceTutorialDescriptor = $convert.base64Decode(
+    'ChJTaG93RGV2aWNlVHV0b3JpYWw=');
+
+@$core.Deprecated('Use unlockBootloaderDescriptor instead')
+const UnlockBootloader$json = {
+  '1': 'UnlockBootloader',
+};
+
+/// Descriptor for `UnlockBootloader`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List unlockBootloaderDescriptor = $convert.base64Decode(
+    'ChBVbmxvY2tCb290bG9hZGVy');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-management.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-management.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-management.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-management.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-monero.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-monero.pb.dart
@@ -1,0 +1,4024 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-monero.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'messages-monero.pbenum.dart';
+
+export 'messages-monero.pbenum.dart';
+
+class MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic extends $pb.GeneratedMessage {
+  factory MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic({
+    $core.List<$core.int>? dest,
+    $core.List<$core.int>? commitment,
+  }) {
+    final $result = create();
+    if (dest != null) {
+      $result.dest = dest;
+    }
+    if (commitment != null) {
+      $result.commitment = commitment;
+    }
+    return $result;
+  }
+  MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic._() : super();
+  factory MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionSourceEntry.MoneroOutputEntry.MoneroRctKeyPublic', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'dest', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'commitment', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic clone() => MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic copyWith(void Function(MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic) updates) => super.copyWith((message) => updates(message as MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic)) as MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic create() => MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic._();
+  MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic> createRepeated() => $pb.PbList<MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic>(create);
+  static MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get dest => $_getN(0);
+  @$pb.TagNumber(1)
+  set dest($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDest() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDest() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get commitment => $_getN(1);
+  @$pb.TagNumber(2)
+  set commitment($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasCommitment() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCommitment() => clearField(2);
+}
+
+class MoneroTransactionSourceEntry_MoneroOutputEntry extends $pb.GeneratedMessage {
+  factory MoneroTransactionSourceEntry_MoneroOutputEntry({
+    $fixnum.Int64? idx,
+    MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic? key,
+  }) {
+    final $result = create();
+    if (idx != null) {
+      $result.idx = idx;
+    }
+    if (key != null) {
+      $result.key = key;
+    }
+    return $result;
+  }
+  MoneroTransactionSourceEntry_MoneroOutputEntry._() : super();
+  factory MoneroTransactionSourceEntry_MoneroOutputEntry.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionSourceEntry_MoneroOutputEntry.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionSourceEntry.MoneroOutputEntry', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'idx', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aOM<MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic>(2, _omitFieldNames ? '' : 'key', subBuilder: MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSourceEntry_MoneroOutputEntry clone() => MoneroTransactionSourceEntry_MoneroOutputEntry()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSourceEntry_MoneroOutputEntry copyWith(void Function(MoneroTransactionSourceEntry_MoneroOutputEntry) updates) => super.copyWith((message) => updates(message as MoneroTransactionSourceEntry_MoneroOutputEntry)) as MoneroTransactionSourceEntry_MoneroOutputEntry;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSourceEntry_MoneroOutputEntry create() => MoneroTransactionSourceEntry_MoneroOutputEntry._();
+  MoneroTransactionSourceEntry_MoneroOutputEntry createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionSourceEntry_MoneroOutputEntry> createRepeated() => $pb.PbList<MoneroTransactionSourceEntry_MoneroOutputEntry>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSourceEntry_MoneroOutputEntry getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionSourceEntry_MoneroOutputEntry>(create);
+  static MoneroTransactionSourceEntry_MoneroOutputEntry? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get idx => $_getI64(0);
+  @$pb.TagNumber(1)
+  set idx($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasIdx() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearIdx() => clearField(1);
+
+  @$pb.TagNumber(2)
+  MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic get key => $_getN(1);
+  @$pb.TagNumber(2)
+  set key(MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasKey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearKey() => clearField(2);
+  @$pb.TagNumber(2)
+  MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic ensureKey() => $_ensure(1);
+}
+
+class MoneroTransactionSourceEntry_MoneroMultisigKLRki extends $pb.GeneratedMessage {
+  factory MoneroTransactionSourceEntry_MoneroMultisigKLRki({
+    $core.List<$core.int>? k,
+    $core.List<$core.int>? l,
+    $core.List<$core.int>? r,
+    $core.List<$core.int>? ki,
+  }) {
+    final $result = create();
+    if (k != null) {
+      $result.k = k;
+    }
+    if (l != null) {
+      $result.l = l;
+    }
+    if (r != null) {
+      $result.r = r;
+    }
+    if (ki != null) {
+      $result.ki = ki;
+    }
+    return $result;
+  }
+  MoneroTransactionSourceEntry_MoneroMultisigKLRki._() : super();
+  factory MoneroTransactionSourceEntry_MoneroMultisigKLRki.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionSourceEntry_MoneroMultisigKLRki.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionSourceEntry.MoneroMultisigKLRki', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'K', $pb.PbFieldType.OY, protoName: 'K')
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'L', $pb.PbFieldType.OY, protoName: 'L')
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'R', $pb.PbFieldType.OY, protoName: 'R')
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'ki', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSourceEntry_MoneroMultisigKLRki clone() => MoneroTransactionSourceEntry_MoneroMultisigKLRki()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSourceEntry_MoneroMultisigKLRki copyWith(void Function(MoneroTransactionSourceEntry_MoneroMultisigKLRki) updates) => super.copyWith((message) => updates(message as MoneroTransactionSourceEntry_MoneroMultisigKLRki)) as MoneroTransactionSourceEntry_MoneroMultisigKLRki;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSourceEntry_MoneroMultisigKLRki create() => MoneroTransactionSourceEntry_MoneroMultisigKLRki._();
+  MoneroTransactionSourceEntry_MoneroMultisigKLRki createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionSourceEntry_MoneroMultisigKLRki> createRepeated() => $pb.PbList<MoneroTransactionSourceEntry_MoneroMultisigKLRki>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSourceEntry_MoneroMultisigKLRki getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionSourceEntry_MoneroMultisigKLRki>(create);
+  static MoneroTransactionSourceEntry_MoneroMultisigKLRki? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get k => $_getN(0);
+  @$pb.TagNumber(1)
+  set k($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasK() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearK() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get l => $_getN(1);
+  @$pb.TagNumber(2)
+  set l($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasL() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearL() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get r => $_getN(2);
+  @$pb.TagNumber(3)
+  set r($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasR() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearR() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get ki => $_getN(3);
+  @$pb.TagNumber(4)
+  set ki($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasKi() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearKi() => clearField(4);
+}
+
+/// *
+///  Structure representing Monero transaction source entry, UTXO
+///  @embed
+class MoneroTransactionSourceEntry extends $pb.GeneratedMessage {
+  factory MoneroTransactionSourceEntry({
+    $core.Iterable<MoneroTransactionSourceEntry_MoneroOutputEntry>? outputs,
+    $fixnum.Int64? realOutput,
+    $core.List<$core.int>? realOutTxKey,
+    $core.Iterable<$core.List<$core.int>>? realOutAdditionalTxKeys,
+    $fixnum.Int64? realOutputInTxIndex,
+    $fixnum.Int64? amount,
+    $core.bool? rct,
+    $core.List<$core.int>? mask,
+    MoneroTransactionSourceEntry_MoneroMultisigKLRki? multisigKLRki,
+    $core.int? subaddrMinor,
+  }) {
+    final $result = create();
+    if (outputs != null) {
+      $result.outputs.addAll(outputs);
+    }
+    if (realOutput != null) {
+      $result.realOutput = realOutput;
+    }
+    if (realOutTxKey != null) {
+      $result.realOutTxKey = realOutTxKey;
+    }
+    if (realOutAdditionalTxKeys != null) {
+      $result.realOutAdditionalTxKeys.addAll(realOutAdditionalTxKeys);
+    }
+    if (realOutputInTxIndex != null) {
+      $result.realOutputInTxIndex = realOutputInTxIndex;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (rct != null) {
+      $result.rct = rct;
+    }
+    if (mask != null) {
+      $result.mask = mask;
+    }
+    if (multisigKLRki != null) {
+      $result.multisigKLRki = multisigKLRki;
+    }
+    if (subaddrMinor != null) {
+      $result.subaddrMinor = subaddrMinor;
+    }
+    return $result;
+  }
+  MoneroTransactionSourceEntry._() : super();
+  factory MoneroTransactionSourceEntry.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionSourceEntry.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionSourceEntry', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..pc<MoneroTransactionSourceEntry_MoneroOutputEntry>(1, _omitFieldNames ? '' : 'outputs', $pb.PbFieldType.PM, subBuilder: MoneroTransactionSourceEntry_MoneroOutputEntry.create)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'realOutput', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'realOutTxKey', $pb.PbFieldType.OY)
+    ..p<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'realOutAdditionalTxKeys', $pb.PbFieldType.PY)
+    ..a<$fixnum.Int64>(5, _omitFieldNames ? '' : 'realOutputInTxIndex', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(6, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aOB(7, _omitFieldNames ? '' : 'rct')
+    ..a<$core.List<$core.int>>(8, _omitFieldNames ? '' : 'mask', $pb.PbFieldType.OY)
+    ..aOM<MoneroTransactionSourceEntry_MoneroMultisigKLRki>(9, _omitFieldNames ? '' : 'multisigKLRki', protoName: 'multisig_kLRki', subBuilder: MoneroTransactionSourceEntry_MoneroMultisigKLRki.create)
+    ..a<$core.int>(10, _omitFieldNames ? '' : 'subaddrMinor', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSourceEntry clone() => MoneroTransactionSourceEntry()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSourceEntry copyWith(void Function(MoneroTransactionSourceEntry) updates) => super.copyWith((message) => updates(message as MoneroTransactionSourceEntry)) as MoneroTransactionSourceEntry;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSourceEntry create() => MoneroTransactionSourceEntry._();
+  MoneroTransactionSourceEntry createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionSourceEntry> createRepeated() => $pb.PbList<MoneroTransactionSourceEntry>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSourceEntry getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionSourceEntry>(create);
+  static MoneroTransactionSourceEntry? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<MoneroTransactionSourceEntry_MoneroOutputEntry> get outputs => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get realOutput => $_getI64(1);
+  @$pb.TagNumber(2)
+  set realOutput($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasRealOutput() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearRealOutput() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get realOutTxKey => $_getN(2);
+  @$pb.TagNumber(3)
+  set realOutTxKey($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasRealOutTxKey() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearRealOutTxKey() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.List<$core.int>> get realOutAdditionalTxKeys => $_getList(3);
+
+  @$pb.TagNumber(5)
+  $fixnum.Int64 get realOutputInTxIndex => $_getI64(4);
+  @$pb.TagNumber(5)
+  set realOutputInTxIndex($fixnum.Int64 v) { $_setInt64(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasRealOutputInTxIndex() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearRealOutputInTxIndex() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $fixnum.Int64 get amount => $_getI64(5);
+  @$pb.TagNumber(6)
+  set amount($fixnum.Int64 v) { $_setInt64(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasAmount() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearAmount() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.bool get rct => $_getBF(6);
+  @$pb.TagNumber(7)
+  set rct($core.bool v) { $_setBool(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasRct() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearRct() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.List<$core.int> get mask => $_getN(7);
+  @$pb.TagNumber(8)
+  set mask($core.List<$core.int> v) { $_setBytes(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasMask() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearMask() => clearField(8);
+
+  @$pb.TagNumber(9)
+  MoneroTransactionSourceEntry_MoneroMultisigKLRki get multisigKLRki => $_getN(8);
+  @$pb.TagNumber(9)
+  set multisigKLRki(MoneroTransactionSourceEntry_MoneroMultisigKLRki v) { setField(9, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasMultisigKLRki() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearMultisigKLRki() => clearField(9);
+  @$pb.TagNumber(9)
+  MoneroTransactionSourceEntry_MoneroMultisigKLRki ensureMultisigKLRki() => $_ensure(8);
+
+  @$pb.TagNumber(10)
+  $core.int get subaddrMinor => $_getIZ(9);
+  @$pb.TagNumber(10)
+  set subaddrMinor($core.int v) { $_setUnsignedInt32(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasSubaddrMinor() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearSubaddrMinor() => clearField(10);
+}
+
+/// *
+///  Structure representing Monero public address
+class MoneroTransactionDestinationEntry_MoneroAccountPublicAddress extends $pb.GeneratedMessage {
+  factory MoneroTransactionDestinationEntry_MoneroAccountPublicAddress({
+    $core.List<$core.int>? spendPublicKey,
+    $core.List<$core.int>? viewPublicKey,
+  }) {
+    final $result = create();
+    if (spendPublicKey != null) {
+      $result.spendPublicKey = spendPublicKey;
+    }
+    if (viewPublicKey != null) {
+      $result.viewPublicKey = viewPublicKey;
+    }
+    return $result;
+  }
+  MoneroTransactionDestinationEntry_MoneroAccountPublicAddress._() : super();
+  factory MoneroTransactionDestinationEntry_MoneroAccountPublicAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionDestinationEntry_MoneroAccountPublicAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionDestinationEntry.MoneroAccountPublicAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'spendPublicKey', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'viewPublicKey', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionDestinationEntry_MoneroAccountPublicAddress clone() => MoneroTransactionDestinationEntry_MoneroAccountPublicAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionDestinationEntry_MoneroAccountPublicAddress copyWith(void Function(MoneroTransactionDestinationEntry_MoneroAccountPublicAddress) updates) => super.copyWith((message) => updates(message as MoneroTransactionDestinationEntry_MoneroAccountPublicAddress)) as MoneroTransactionDestinationEntry_MoneroAccountPublicAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionDestinationEntry_MoneroAccountPublicAddress create() => MoneroTransactionDestinationEntry_MoneroAccountPublicAddress._();
+  MoneroTransactionDestinationEntry_MoneroAccountPublicAddress createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionDestinationEntry_MoneroAccountPublicAddress> createRepeated() => $pb.PbList<MoneroTransactionDestinationEntry_MoneroAccountPublicAddress>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionDestinationEntry_MoneroAccountPublicAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionDestinationEntry_MoneroAccountPublicAddress>(create);
+  static MoneroTransactionDestinationEntry_MoneroAccountPublicAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get spendPublicKey => $_getN(0);
+  @$pb.TagNumber(1)
+  set spendPublicKey($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSpendPublicKey() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSpendPublicKey() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get viewPublicKey => $_getN(1);
+  @$pb.TagNumber(2)
+  set viewPublicKey($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasViewPublicKey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearViewPublicKey() => clearField(2);
+}
+
+/// *
+///  Structure representing Monero transaction destination entry
+///  @embed
+class MoneroTransactionDestinationEntry extends $pb.GeneratedMessage {
+  factory MoneroTransactionDestinationEntry({
+    $fixnum.Int64? amount,
+    MoneroTransactionDestinationEntry_MoneroAccountPublicAddress? addr,
+    $core.bool? isSubaddress,
+    $core.List<$core.int>? original,
+    $core.bool? isIntegrated,
+  }) {
+    final $result = create();
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (addr != null) {
+      $result.addr = addr;
+    }
+    if (isSubaddress != null) {
+      $result.isSubaddress = isSubaddress;
+    }
+    if (original != null) {
+      $result.original = original;
+    }
+    if (isIntegrated != null) {
+      $result.isIntegrated = isIntegrated;
+    }
+    return $result;
+  }
+  MoneroTransactionDestinationEntry._() : super();
+  factory MoneroTransactionDestinationEntry.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionDestinationEntry.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionDestinationEntry', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aOM<MoneroTransactionDestinationEntry_MoneroAccountPublicAddress>(2, _omitFieldNames ? '' : 'addr', subBuilder: MoneroTransactionDestinationEntry_MoneroAccountPublicAddress.create)
+    ..aOB(3, _omitFieldNames ? '' : 'isSubaddress')
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'original', $pb.PbFieldType.OY)
+    ..aOB(5, _omitFieldNames ? '' : 'isIntegrated')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionDestinationEntry clone() => MoneroTransactionDestinationEntry()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionDestinationEntry copyWith(void Function(MoneroTransactionDestinationEntry) updates) => super.copyWith((message) => updates(message as MoneroTransactionDestinationEntry)) as MoneroTransactionDestinationEntry;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionDestinationEntry create() => MoneroTransactionDestinationEntry._();
+  MoneroTransactionDestinationEntry createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionDestinationEntry> createRepeated() => $pb.PbList<MoneroTransactionDestinationEntry>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionDestinationEntry getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionDestinationEntry>(create);
+  static MoneroTransactionDestinationEntry? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get amount => $_getI64(0);
+  @$pb.TagNumber(1)
+  set amount($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAmount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAmount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  MoneroTransactionDestinationEntry_MoneroAccountPublicAddress get addr => $_getN(1);
+  @$pb.TagNumber(2)
+  set addr(MoneroTransactionDestinationEntry_MoneroAccountPublicAddress v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAddr() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAddr() => clearField(2);
+  @$pb.TagNumber(2)
+  MoneroTransactionDestinationEntry_MoneroAccountPublicAddress ensureAddr() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  $core.bool get isSubaddress => $_getBF(2);
+  @$pb.TagNumber(3)
+  set isSubaddress($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasIsSubaddress() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearIsSubaddress() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get original => $_getN(3);
+  @$pb.TagNumber(4)
+  set original($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasOriginal() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearOriginal() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.bool get isIntegrated => $_getBF(4);
+  @$pb.TagNumber(5)
+  set isIntegrated($core.bool v) { $_setBool(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasIsIntegrated() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearIsIntegrated() => clearField(5);
+}
+
+/// *
+///  Range sig parameters / data.
+///  @embed
+class MoneroTransactionRsigData extends $pb.GeneratedMessage {
+  factory MoneroTransactionRsigData({
+    $core.int? rsigType,
+    $core.int? offloadType,
+    $core.Iterable<$fixnum.Int64>? grouping,
+    $core.List<$core.int>? mask,
+    $core.List<$core.int>? rsig,
+    $core.Iterable<$core.List<$core.int>>? rsigParts,
+    $core.int? bpVersion,
+  }) {
+    final $result = create();
+    if (rsigType != null) {
+      $result.rsigType = rsigType;
+    }
+    if (offloadType != null) {
+      $result.offloadType = offloadType;
+    }
+    if (grouping != null) {
+      $result.grouping.addAll(grouping);
+    }
+    if (mask != null) {
+      $result.mask = mask;
+    }
+    if (rsig != null) {
+      $result.rsig = rsig;
+    }
+    if (rsigParts != null) {
+      $result.rsigParts.addAll(rsigParts);
+    }
+    if (bpVersion != null) {
+      $result.bpVersion = bpVersion;
+    }
+    return $result;
+  }
+  MoneroTransactionRsigData._() : super();
+  factory MoneroTransactionRsigData.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionRsigData.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionRsigData', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'rsigType', $pb.PbFieldType.OU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'offloadType', $pb.PbFieldType.OU3)
+    ..p<$fixnum.Int64>(3, _omitFieldNames ? '' : 'grouping', $pb.PbFieldType.PU6)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'mask', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'rsig', $pb.PbFieldType.OY)
+    ..p<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'rsigParts', $pb.PbFieldType.PY)
+    ..a<$core.int>(7, _omitFieldNames ? '' : 'bpVersion', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionRsigData clone() => MoneroTransactionRsigData()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionRsigData copyWith(void Function(MoneroTransactionRsigData) updates) => super.copyWith((message) => updates(message as MoneroTransactionRsigData)) as MoneroTransactionRsigData;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionRsigData create() => MoneroTransactionRsigData._();
+  MoneroTransactionRsigData createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionRsigData> createRepeated() => $pb.PbList<MoneroTransactionRsigData>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionRsigData getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionRsigData>(create);
+  static MoneroTransactionRsigData? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get rsigType => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set rsigType($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasRsigType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRsigType() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get offloadType => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set offloadType($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasOffloadType() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearOffloadType() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$fixnum.Int64> get grouping => $_getList(2);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get mask => $_getN(3);
+  @$pb.TagNumber(4)
+  set mask($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasMask() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMask() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get rsig => $_getN(4);
+  @$pb.TagNumber(5)
+  set rsig($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasRsig() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearRsig() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.List<$core.int>> get rsigParts => $_getList(5);
+
+  @$pb.TagNumber(7)
+  $core.int get bpVersion => $_getIZ(6);
+  @$pb.TagNumber(7)
+  set bpVersion($core.int v) { $_setUnsignedInt32(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasBpVersion() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearBpVersion() => clearField(7);
+}
+
+/// *
+///  Request: Ask device for public address derived from seed and address_n
+///  @start
+///  @next MoneroAddress
+///  @next Failure
+class MoneroGetAddress extends $pb.GeneratedMessage {
+  factory MoneroGetAddress({
+    $core.Iterable<$core.int>? addressN,
+    $core.bool? showDisplay,
+    MoneroNetworkType? networkType,
+    $core.int? account,
+    $core.int? minor,
+    $core.List<$core.int>? paymentId,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    if (networkType != null) {
+      $result.networkType = networkType;
+    }
+    if (account != null) {
+      $result.account = account;
+    }
+    if (minor != null) {
+      $result.minor = minor;
+    }
+    if (paymentId != null) {
+      $result.paymentId = paymentId;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  MoneroGetAddress._() : super();
+  factory MoneroGetAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroGetAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroGetAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aOB(2, _omitFieldNames ? '' : 'showDisplay')
+    ..e<MoneroNetworkType>(3, _omitFieldNames ? '' : 'networkType', $pb.PbFieldType.OE, defaultOrMaker: MoneroNetworkType.MAINNET, valueOf: MoneroNetworkType.valueOf, enumValues: MoneroNetworkType.values)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'account', $pb.PbFieldType.OU3)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'minor', $pb.PbFieldType.OU3)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'paymentId', $pb.PbFieldType.OY)
+    ..aOB(7, _omitFieldNames ? '' : 'chunkify')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroGetAddress clone() => MoneroGetAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroGetAddress copyWith(void Function(MoneroGetAddress) updates) => super.copyWith((message) => updates(message as MoneroGetAddress)) as MoneroGetAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroGetAddress create() => MoneroGetAddress._();
+  MoneroGetAddress createEmptyInstance() => create();
+  static $pb.PbList<MoneroGetAddress> createRepeated() => $pb.PbList<MoneroGetAddress>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroGetAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroGetAddress>(create);
+  static MoneroGetAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.bool get showDisplay => $_getBF(1);
+  @$pb.TagNumber(2)
+  set showDisplay($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasShowDisplay() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearShowDisplay() => clearField(2);
+
+  @$pb.TagNumber(3)
+  MoneroNetworkType get networkType => $_getN(2);
+  @$pb.TagNumber(3)
+  set networkType(MoneroNetworkType v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasNetworkType() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearNetworkType() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get account => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set account($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasAccount() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearAccount() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get minor => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set minor($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasMinor() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearMinor() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get paymentId => $_getN(5);
+  @$pb.TagNumber(6)
+  set paymentId($core.List<$core.int> v) { $_setBytes(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasPaymentId() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearPaymentId() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.bool get chunkify => $_getBF(6);
+  @$pb.TagNumber(7)
+  set chunkify($core.bool v) { $_setBool(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasChunkify() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearChunkify() => clearField(7);
+}
+
+/// *
+///  Response: Contains Monero watch-only credentials derived from device private seed
+///  @end
+class MoneroAddress extends $pb.GeneratedMessage {
+  factory MoneroAddress({
+    $core.List<$core.int>? address,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    return $result;
+  }
+  MoneroAddress._() : super();
+  factory MoneroAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'address', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroAddress clone() => MoneroAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroAddress copyWith(void Function(MoneroAddress) updates) => super.copyWith((message) => updates(message as MoneroAddress)) as MoneroAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroAddress create() => MoneroAddress._();
+  MoneroAddress createEmptyInstance() => create();
+  static $pb.PbList<MoneroAddress> createRepeated() => $pb.PbList<MoneroAddress>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroAddress>(create);
+  static MoneroAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get address => $_getN(0);
+  @$pb.TagNumber(1)
+  set address($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+}
+
+/// *
+///  Request: Ask device for watch only credentials
+///  @start
+///  @next MoneroWatchKey
+///  @next Failure
+class MoneroGetWatchKey extends $pb.GeneratedMessage {
+  factory MoneroGetWatchKey({
+    $core.Iterable<$core.int>? addressN,
+    MoneroNetworkType? networkType,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (networkType != null) {
+      $result.networkType = networkType;
+    }
+    return $result;
+  }
+  MoneroGetWatchKey._() : super();
+  factory MoneroGetWatchKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroGetWatchKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroGetWatchKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..e<MoneroNetworkType>(2, _omitFieldNames ? '' : 'networkType', $pb.PbFieldType.OE, defaultOrMaker: MoneroNetworkType.MAINNET, valueOf: MoneroNetworkType.valueOf, enumValues: MoneroNetworkType.values)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroGetWatchKey clone() => MoneroGetWatchKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroGetWatchKey copyWith(void Function(MoneroGetWatchKey) updates) => super.copyWith((message) => updates(message as MoneroGetWatchKey)) as MoneroGetWatchKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroGetWatchKey create() => MoneroGetWatchKey._();
+  MoneroGetWatchKey createEmptyInstance() => create();
+  static $pb.PbList<MoneroGetWatchKey> createRepeated() => $pb.PbList<MoneroGetWatchKey>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroGetWatchKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroGetWatchKey>(create);
+  static MoneroGetWatchKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  MoneroNetworkType get networkType => $_getN(1);
+  @$pb.TagNumber(2)
+  set networkType(MoneroNetworkType v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasNetworkType() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNetworkType() => clearField(2);
+}
+
+/// *
+///  Response: Contains Monero watch-only credentials derived from device private seed
+///  @end
+class MoneroWatchKey extends $pb.GeneratedMessage {
+  factory MoneroWatchKey({
+    $core.List<$core.int>? watchKey,
+    $core.List<$core.int>? address,
+  }) {
+    final $result = create();
+    if (watchKey != null) {
+      $result.watchKey = watchKey;
+    }
+    if (address != null) {
+      $result.address = address;
+    }
+    return $result;
+  }
+  MoneroWatchKey._() : super();
+  factory MoneroWatchKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroWatchKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroWatchKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'watchKey', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'address', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroWatchKey clone() => MoneroWatchKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroWatchKey copyWith(void Function(MoneroWatchKey) updates) => super.copyWith((message) => updates(message as MoneroWatchKey)) as MoneroWatchKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroWatchKey create() => MoneroWatchKey._();
+  MoneroWatchKey createEmptyInstance() => create();
+  static $pb.PbList<MoneroWatchKey> createRepeated() => $pb.PbList<MoneroWatchKey>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroWatchKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroWatchKey>(create);
+  static MoneroWatchKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get watchKey => $_getN(0);
+  @$pb.TagNumber(1)
+  set watchKey($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWatchKey() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWatchKey() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get address => $_getN(1);
+  @$pb.TagNumber(2)
+  set address($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAddress() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAddress() => clearField(2);
+}
+
+/// *
+///  Structure representing Monero initial transaction information
+class MoneroTransactionInitRequest_MoneroTransactionData extends $pb.GeneratedMessage {
+  factory MoneroTransactionInitRequest_MoneroTransactionData({
+    $core.int? version,
+    $core.List<$core.int>? paymentId,
+    $fixnum.Int64? unlockTime,
+    $core.Iterable<MoneroTransactionDestinationEntry>? outputs,
+    MoneroTransactionDestinationEntry? changeDts,
+    $core.int? numInputs,
+    $core.int? mixin,
+    $fixnum.Int64? fee,
+    $core.int? account,
+    $core.Iterable<$core.int>? minorIndices,
+    MoneroTransactionRsigData? rsigData,
+    $core.Iterable<$core.int>? integratedIndices,
+    $core.int? clientVersion,
+    $core.int? hardFork,
+    $core.List<$core.int>? moneroVersion,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (version != null) {
+      $result.version = version;
+    }
+    if (paymentId != null) {
+      $result.paymentId = paymentId;
+    }
+    if (unlockTime != null) {
+      $result.unlockTime = unlockTime;
+    }
+    if (outputs != null) {
+      $result.outputs.addAll(outputs);
+    }
+    if (changeDts != null) {
+      $result.changeDts = changeDts;
+    }
+    if (numInputs != null) {
+      $result.numInputs = numInputs;
+    }
+    if (mixin != null) {
+      $result.mixin = mixin;
+    }
+    if (fee != null) {
+      $result.fee = fee;
+    }
+    if (account != null) {
+      $result.account = account;
+    }
+    if (minorIndices != null) {
+      $result.minorIndices.addAll(minorIndices);
+    }
+    if (rsigData != null) {
+      $result.rsigData = rsigData;
+    }
+    if (integratedIndices != null) {
+      $result.integratedIndices.addAll(integratedIndices);
+    }
+    if (clientVersion != null) {
+      $result.clientVersion = clientVersion;
+    }
+    if (hardFork != null) {
+      $result.hardFork = hardFork;
+    }
+    if (moneroVersion != null) {
+      $result.moneroVersion = moneroVersion;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  MoneroTransactionInitRequest_MoneroTransactionData._() : super();
+  factory MoneroTransactionInitRequest_MoneroTransactionData.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionInitRequest_MoneroTransactionData.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionInitRequest.MoneroTransactionData', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'version', $pb.PbFieldType.OU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'paymentId', $pb.PbFieldType.OY)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'unlockTime', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..pc<MoneroTransactionDestinationEntry>(4, _omitFieldNames ? '' : 'outputs', $pb.PbFieldType.PM, subBuilder: MoneroTransactionDestinationEntry.create)
+    ..aOM<MoneroTransactionDestinationEntry>(5, _omitFieldNames ? '' : 'changeDts', subBuilder: MoneroTransactionDestinationEntry.create)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'numInputs', $pb.PbFieldType.OU3)
+    ..a<$core.int>(7, _omitFieldNames ? '' : 'mixin', $pb.PbFieldType.OU3)
+    ..a<$fixnum.Int64>(8, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'account', $pb.PbFieldType.OU3)
+    ..p<$core.int>(10, _omitFieldNames ? '' : 'minorIndices', $pb.PbFieldType.PU3)
+    ..aOM<MoneroTransactionRsigData>(11, _omitFieldNames ? '' : 'rsigData', subBuilder: MoneroTransactionRsigData.create)
+    ..p<$core.int>(12, _omitFieldNames ? '' : 'integratedIndices', $pb.PbFieldType.PU3)
+    ..a<$core.int>(13, _omitFieldNames ? '' : 'clientVersion', $pb.PbFieldType.OU3)
+    ..a<$core.int>(14, _omitFieldNames ? '' : 'hardFork', $pb.PbFieldType.OU3)
+    ..a<$core.List<$core.int>>(15, _omitFieldNames ? '' : 'moneroVersion', $pb.PbFieldType.OY)
+    ..aOB(16, _omitFieldNames ? '' : 'chunkify')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionInitRequest_MoneroTransactionData clone() => MoneroTransactionInitRequest_MoneroTransactionData()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionInitRequest_MoneroTransactionData copyWith(void Function(MoneroTransactionInitRequest_MoneroTransactionData) updates) => super.copyWith((message) => updates(message as MoneroTransactionInitRequest_MoneroTransactionData)) as MoneroTransactionInitRequest_MoneroTransactionData;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionInitRequest_MoneroTransactionData create() => MoneroTransactionInitRequest_MoneroTransactionData._();
+  MoneroTransactionInitRequest_MoneroTransactionData createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionInitRequest_MoneroTransactionData> createRepeated() => $pb.PbList<MoneroTransactionInitRequest_MoneroTransactionData>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionInitRequest_MoneroTransactionData getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionInitRequest_MoneroTransactionData>(create);
+  static MoneroTransactionInitRequest_MoneroTransactionData? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get version => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set version($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasVersion() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearVersion() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get paymentId => $_getN(1);
+  @$pb.TagNumber(2)
+  set paymentId($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPaymentId() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPaymentId() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get unlockTime => $_getI64(2);
+  @$pb.TagNumber(3)
+  set unlockTime($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasUnlockTime() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearUnlockTime() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<MoneroTransactionDestinationEntry> get outputs => $_getList(3);
+
+  @$pb.TagNumber(5)
+  MoneroTransactionDestinationEntry get changeDts => $_getN(4);
+  @$pb.TagNumber(5)
+  set changeDts(MoneroTransactionDestinationEntry v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasChangeDts() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearChangeDts() => clearField(5);
+  @$pb.TagNumber(5)
+  MoneroTransactionDestinationEntry ensureChangeDts() => $_ensure(4);
+
+  @$pb.TagNumber(6)
+  $core.int get numInputs => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set numInputs($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasNumInputs() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearNumInputs() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.int get mixin => $_getIZ(6);
+  @$pb.TagNumber(7)
+  set mixin($core.int v) { $_setUnsignedInt32(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasMixin() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearMixin() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $fixnum.Int64 get fee => $_getI64(7);
+  @$pb.TagNumber(8)
+  set fee($fixnum.Int64 v) { $_setInt64(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasFee() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearFee() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.int get account => $_getIZ(8);
+  @$pb.TagNumber(9)
+  set account($core.int v) { $_setUnsignedInt32(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasAccount() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearAccount() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.List<$core.int> get minorIndices => $_getList(9);
+
+  @$pb.TagNumber(11)
+  MoneroTransactionRsigData get rsigData => $_getN(10);
+  @$pb.TagNumber(11)
+  set rsigData(MoneroTransactionRsigData v) { setField(11, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasRsigData() => $_has(10);
+  @$pb.TagNumber(11)
+  void clearRsigData() => clearField(11);
+  @$pb.TagNumber(11)
+  MoneroTransactionRsigData ensureRsigData() => $_ensure(10);
+
+  @$pb.TagNumber(12)
+  $core.List<$core.int> get integratedIndices => $_getList(11);
+
+  @$pb.TagNumber(13)
+  $core.int get clientVersion => $_getIZ(12);
+  @$pb.TagNumber(13)
+  set clientVersion($core.int v) { $_setUnsignedInt32(12, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasClientVersion() => $_has(12);
+  @$pb.TagNumber(13)
+  void clearClientVersion() => clearField(13);
+
+  @$pb.TagNumber(14)
+  $core.int get hardFork => $_getIZ(13);
+  @$pb.TagNumber(14)
+  set hardFork($core.int v) { $_setUnsignedInt32(13, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasHardFork() => $_has(13);
+  @$pb.TagNumber(14)
+  void clearHardFork() => clearField(14);
+
+  @$pb.TagNumber(15)
+  $core.List<$core.int> get moneroVersion => $_getN(14);
+  @$pb.TagNumber(15)
+  set moneroVersion($core.List<$core.int> v) { $_setBytes(14, v); }
+  @$pb.TagNumber(15)
+  $core.bool hasMoneroVersion() => $_has(14);
+  @$pb.TagNumber(15)
+  void clearMoneroVersion() => clearField(15);
+
+  @$pb.TagNumber(16)
+  $core.bool get chunkify => $_getBF(15);
+  @$pb.TagNumber(16)
+  set chunkify($core.bool v) { $_setBool(15, v); }
+  @$pb.TagNumber(16)
+  $core.bool hasChunkify() => $_has(15);
+  @$pb.TagNumber(16)
+  void clearChunkify() => clearField(16);
+}
+
+/// *
+///  Request: Sub request of MoneroTransactionSign. Initializes transaction signing.
+///  @start
+///  @next MoneroTransactionInitAck
+class MoneroTransactionInitRequest extends $pb.GeneratedMessage {
+  factory MoneroTransactionInitRequest({
+    $core.int? version,
+    $core.Iterable<$core.int>? addressN,
+    MoneroNetworkType? networkType,
+    MoneroTransactionInitRequest_MoneroTransactionData? tsxData,
+  }) {
+    final $result = create();
+    if (version != null) {
+      $result.version = version;
+    }
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (networkType != null) {
+      $result.networkType = networkType;
+    }
+    if (tsxData != null) {
+      $result.tsxData = tsxData;
+    }
+    return $result;
+  }
+  MoneroTransactionInitRequest._() : super();
+  factory MoneroTransactionInitRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionInitRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionInitRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'version', $pb.PbFieldType.OU3)
+    ..p<$core.int>(2, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..e<MoneroNetworkType>(3, _omitFieldNames ? '' : 'networkType', $pb.PbFieldType.OE, defaultOrMaker: MoneroNetworkType.MAINNET, valueOf: MoneroNetworkType.valueOf, enumValues: MoneroNetworkType.values)
+    ..aOM<MoneroTransactionInitRequest_MoneroTransactionData>(4, _omitFieldNames ? '' : 'tsxData', subBuilder: MoneroTransactionInitRequest_MoneroTransactionData.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionInitRequest clone() => MoneroTransactionInitRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionInitRequest copyWith(void Function(MoneroTransactionInitRequest) updates) => super.copyWith((message) => updates(message as MoneroTransactionInitRequest)) as MoneroTransactionInitRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionInitRequest create() => MoneroTransactionInitRequest._();
+  MoneroTransactionInitRequest createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionInitRequest> createRepeated() => $pb.PbList<MoneroTransactionInitRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionInitRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionInitRequest>(create);
+  static MoneroTransactionInitRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get version => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set version($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasVersion() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearVersion() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get addressN => $_getList(1);
+
+  @$pb.TagNumber(3)
+  MoneroNetworkType get networkType => $_getN(2);
+  @$pb.TagNumber(3)
+  set networkType(MoneroNetworkType v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasNetworkType() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearNetworkType() => clearField(3);
+
+  @$pb.TagNumber(4)
+  MoneroTransactionInitRequest_MoneroTransactionData get tsxData => $_getN(3);
+  @$pb.TagNumber(4)
+  set tsxData(MoneroTransactionInitRequest_MoneroTransactionData v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasTsxData() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearTsxData() => clearField(4);
+  @$pb.TagNumber(4)
+  MoneroTransactionInitRequest_MoneroTransactionData ensureTsxData() => $_ensure(3);
+}
+
+/// *
+///  Response: Response to transaction signing initialization.
+///  @next MoneroTransactionSetInputRequest
+class MoneroTransactionInitAck extends $pb.GeneratedMessage {
+  factory MoneroTransactionInitAck({
+    $core.Iterable<$core.List<$core.int>>? hmacs,
+    MoneroTransactionRsigData? rsigData,
+  }) {
+    final $result = create();
+    if (hmacs != null) {
+      $result.hmacs.addAll(hmacs);
+    }
+    if (rsigData != null) {
+      $result.rsigData = rsigData;
+    }
+    return $result;
+  }
+  MoneroTransactionInitAck._() : super();
+  factory MoneroTransactionInitAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionInitAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionInitAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..p<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'hmacs', $pb.PbFieldType.PY)
+    ..aOM<MoneroTransactionRsigData>(2, _omitFieldNames ? '' : 'rsigData', subBuilder: MoneroTransactionRsigData.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionInitAck clone() => MoneroTransactionInitAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionInitAck copyWith(void Function(MoneroTransactionInitAck) updates) => super.copyWith((message) => updates(message as MoneroTransactionInitAck)) as MoneroTransactionInitAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionInitAck create() => MoneroTransactionInitAck._();
+  MoneroTransactionInitAck createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionInitAck> createRepeated() => $pb.PbList<MoneroTransactionInitAck>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionInitAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionInitAck>(create);
+  static MoneroTransactionInitAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.List<$core.int>> get hmacs => $_getList(0);
+
+  @$pb.TagNumber(2)
+  MoneroTransactionRsigData get rsigData => $_getN(1);
+  @$pb.TagNumber(2)
+  set rsigData(MoneroTransactionRsigData v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasRsigData() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearRsigData() => clearField(2);
+  @$pb.TagNumber(2)
+  MoneroTransactionRsigData ensureRsigData() => $_ensure(1);
+}
+
+/// *
+///  Request: Sub request of MoneroTransactionSign. Sends one UTXO to device
+///  @next MoneroTransactionSetInputAck
+class MoneroTransactionSetInputRequest extends $pb.GeneratedMessage {
+  factory MoneroTransactionSetInputRequest({
+    MoneroTransactionSourceEntry? srcEntr,
+  }) {
+    final $result = create();
+    if (srcEntr != null) {
+      $result.srcEntr = srcEntr;
+    }
+    return $result;
+  }
+  MoneroTransactionSetInputRequest._() : super();
+  factory MoneroTransactionSetInputRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionSetInputRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionSetInputRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..aOM<MoneroTransactionSourceEntry>(1, _omitFieldNames ? '' : 'srcEntr', subBuilder: MoneroTransactionSourceEntry.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSetInputRequest clone() => MoneroTransactionSetInputRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSetInputRequest copyWith(void Function(MoneroTransactionSetInputRequest) updates) => super.copyWith((message) => updates(message as MoneroTransactionSetInputRequest)) as MoneroTransactionSetInputRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSetInputRequest create() => MoneroTransactionSetInputRequest._();
+  MoneroTransactionSetInputRequest createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionSetInputRequest> createRepeated() => $pb.PbList<MoneroTransactionSetInputRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSetInputRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionSetInputRequest>(create);
+  static MoneroTransactionSetInputRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  MoneroTransactionSourceEntry get srcEntr => $_getN(0);
+  @$pb.TagNumber(1)
+  set srcEntr(MoneroTransactionSourceEntry v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSrcEntr() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSrcEntr() => clearField(1);
+  @$pb.TagNumber(1)
+  MoneroTransactionSourceEntry ensureSrcEntr() => $_ensure(0);
+}
+
+/// *
+///  Response: Response to setting UTXO for signature. Contains sealed values needed for further protocol steps.
+///  @next MoneroTransactionSetInputAck
+///  @next MoneroTransactionInputViniRequest
+class MoneroTransactionSetInputAck extends $pb.GeneratedMessage {
+  factory MoneroTransactionSetInputAck({
+    $core.List<$core.int>? vini,
+    $core.List<$core.int>? viniHmac,
+    $core.List<$core.int>? pseudoOut,
+    $core.List<$core.int>? pseudoOutHmac,
+    $core.List<$core.int>? pseudoOutAlpha,
+    $core.List<$core.int>? spendKey,
+  }) {
+    final $result = create();
+    if (vini != null) {
+      $result.vini = vini;
+    }
+    if (viniHmac != null) {
+      $result.viniHmac = viniHmac;
+    }
+    if (pseudoOut != null) {
+      $result.pseudoOut = pseudoOut;
+    }
+    if (pseudoOutHmac != null) {
+      $result.pseudoOutHmac = pseudoOutHmac;
+    }
+    if (pseudoOutAlpha != null) {
+      $result.pseudoOutAlpha = pseudoOutAlpha;
+    }
+    if (spendKey != null) {
+      $result.spendKey = spendKey;
+    }
+    return $result;
+  }
+  MoneroTransactionSetInputAck._() : super();
+  factory MoneroTransactionSetInputAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionSetInputAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionSetInputAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'vini', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'viniHmac', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'pseudoOut', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'pseudoOutHmac', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'pseudoOutAlpha', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'spendKey', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSetInputAck clone() => MoneroTransactionSetInputAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSetInputAck copyWith(void Function(MoneroTransactionSetInputAck) updates) => super.copyWith((message) => updates(message as MoneroTransactionSetInputAck)) as MoneroTransactionSetInputAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSetInputAck create() => MoneroTransactionSetInputAck._();
+  MoneroTransactionSetInputAck createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionSetInputAck> createRepeated() => $pb.PbList<MoneroTransactionSetInputAck>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSetInputAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionSetInputAck>(create);
+  static MoneroTransactionSetInputAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get vini => $_getN(0);
+  @$pb.TagNumber(1)
+  set vini($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasVini() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearVini() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get viniHmac => $_getN(1);
+  @$pb.TagNumber(2)
+  set viniHmac($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasViniHmac() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearViniHmac() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get pseudoOut => $_getN(2);
+  @$pb.TagNumber(3)
+  set pseudoOut($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasPseudoOut() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearPseudoOut() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get pseudoOutHmac => $_getN(3);
+  @$pb.TagNumber(4)
+  set pseudoOutHmac($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasPseudoOutHmac() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearPseudoOutHmac() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get pseudoOutAlpha => $_getN(4);
+  @$pb.TagNumber(5)
+  set pseudoOutAlpha($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasPseudoOutAlpha() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearPseudoOutAlpha() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get spendKey => $_getN(5);
+  @$pb.TagNumber(6)
+  set spendKey($core.List<$core.int> v) { $_setBytes(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasSpendKey() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearSpendKey() => clearField(6);
+}
+
+/// *
+///  Request: Sub request of MoneroTransactionSign. Sends one UTXO to device together with sealed values.
+///  @next MoneroTransactionInputViniAck
+class MoneroTransactionInputViniRequest extends $pb.GeneratedMessage {
+  factory MoneroTransactionInputViniRequest({
+    MoneroTransactionSourceEntry? srcEntr,
+    $core.List<$core.int>? vini,
+    $core.List<$core.int>? viniHmac,
+    $core.List<$core.int>? pseudoOut,
+    $core.List<$core.int>? pseudoOutHmac,
+    $core.int? origIdx,
+  }) {
+    final $result = create();
+    if (srcEntr != null) {
+      $result.srcEntr = srcEntr;
+    }
+    if (vini != null) {
+      $result.vini = vini;
+    }
+    if (viniHmac != null) {
+      $result.viniHmac = viniHmac;
+    }
+    if (pseudoOut != null) {
+      $result.pseudoOut = pseudoOut;
+    }
+    if (pseudoOutHmac != null) {
+      $result.pseudoOutHmac = pseudoOutHmac;
+    }
+    if (origIdx != null) {
+      $result.origIdx = origIdx;
+    }
+    return $result;
+  }
+  MoneroTransactionInputViniRequest._() : super();
+  factory MoneroTransactionInputViniRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionInputViniRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionInputViniRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..aOM<MoneroTransactionSourceEntry>(1, _omitFieldNames ? '' : 'srcEntr', subBuilder: MoneroTransactionSourceEntry.create)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'vini', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'viniHmac', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'pseudoOut', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'pseudoOutHmac', $pb.PbFieldType.OY)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'origIdx', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionInputViniRequest clone() => MoneroTransactionInputViniRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionInputViniRequest copyWith(void Function(MoneroTransactionInputViniRequest) updates) => super.copyWith((message) => updates(message as MoneroTransactionInputViniRequest)) as MoneroTransactionInputViniRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionInputViniRequest create() => MoneroTransactionInputViniRequest._();
+  MoneroTransactionInputViniRequest createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionInputViniRequest> createRepeated() => $pb.PbList<MoneroTransactionInputViniRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionInputViniRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionInputViniRequest>(create);
+  static MoneroTransactionInputViniRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  MoneroTransactionSourceEntry get srcEntr => $_getN(0);
+  @$pb.TagNumber(1)
+  set srcEntr(MoneroTransactionSourceEntry v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSrcEntr() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSrcEntr() => clearField(1);
+  @$pb.TagNumber(1)
+  MoneroTransactionSourceEntry ensureSrcEntr() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get vini => $_getN(1);
+  @$pb.TagNumber(2)
+  set vini($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasVini() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearVini() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get viniHmac => $_getN(2);
+  @$pb.TagNumber(3)
+  set viniHmac($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasViniHmac() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearViniHmac() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get pseudoOut => $_getN(3);
+  @$pb.TagNumber(4)
+  set pseudoOut($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasPseudoOut() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearPseudoOut() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get pseudoOutHmac => $_getN(4);
+  @$pb.TagNumber(5)
+  set pseudoOutHmac($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasPseudoOutHmac() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearPseudoOutHmac() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.int get origIdx => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set origIdx($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasOrigIdx() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearOrigIdx() => clearField(6);
+}
+
+/// *
+///  Response: Response to setting UTXO to the device
+///  @next MoneroTransactionInputViniRequest
+///  @next MoneroTransactionAllInputsSetRequest
+class MoneroTransactionInputViniAck extends $pb.GeneratedMessage {
+  factory MoneroTransactionInputViniAck() => create();
+  MoneroTransactionInputViniAck._() : super();
+  factory MoneroTransactionInputViniAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionInputViniAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionInputViniAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionInputViniAck clone() => MoneroTransactionInputViniAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionInputViniAck copyWith(void Function(MoneroTransactionInputViniAck) updates) => super.copyWith((message) => updates(message as MoneroTransactionInputViniAck)) as MoneroTransactionInputViniAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionInputViniAck create() => MoneroTransactionInputViniAck._();
+  MoneroTransactionInputViniAck createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionInputViniAck> createRepeated() => $pb.PbList<MoneroTransactionInputViniAck>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionInputViniAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionInputViniAck>(create);
+  static MoneroTransactionInputViniAck? _defaultInstance;
+}
+
+/// *
+///  Request: Sub request of MoneroTransactionSign. Sent after all inputs have been sent. Useful for rangeisg offloading.
+///  @next MoneroTransactionAllInputsSetAck
+class MoneroTransactionAllInputsSetRequest extends $pb.GeneratedMessage {
+  factory MoneroTransactionAllInputsSetRequest() => create();
+  MoneroTransactionAllInputsSetRequest._() : super();
+  factory MoneroTransactionAllInputsSetRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionAllInputsSetRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionAllInputsSetRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionAllInputsSetRequest clone() => MoneroTransactionAllInputsSetRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionAllInputsSetRequest copyWith(void Function(MoneroTransactionAllInputsSetRequest) updates) => super.copyWith((message) => updates(message as MoneroTransactionAllInputsSetRequest)) as MoneroTransactionAllInputsSetRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionAllInputsSetRequest create() => MoneroTransactionAllInputsSetRequest._();
+  MoneroTransactionAllInputsSetRequest createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionAllInputsSetRequest> createRepeated() => $pb.PbList<MoneroTransactionAllInputsSetRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionAllInputsSetRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionAllInputsSetRequest>(create);
+  static MoneroTransactionAllInputsSetRequest? _defaultInstance;
+}
+
+/// *
+///  Response: Response to after all inputs have been set.
+///  @next MoneroTransactionSetOutputRequest
+class MoneroTransactionAllInputsSetAck extends $pb.GeneratedMessage {
+  factory MoneroTransactionAllInputsSetAck({
+    MoneroTransactionRsigData? rsigData,
+  }) {
+    final $result = create();
+    if (rsigData != null) {
+      $result.rsigData = rsigData;
+    }
+    return $result;
+  }
+  MoneroTransactionAllInputsSetAck._() : super();
+  factory MoneroTransactionAllInputsSetAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionAllInputsSetAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionAllInputsSetAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..aOM<MoneroTransactionRsigData>(1, _omitFieldNames ? '' : 'rsigData', subBuilder: MoneroTransactionRsigData.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionAllInputsSetAck clone() => MoneroTransactionAllInputsSetAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionAllInputsSetAck copyWith(void Function(MoneroTransactionAllInputsSetAck) updates) => super.copyWith((message) => updates(message as MoneroTransactionAllInputsSetAck)) as MoneroTransactionAllInputsSetAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionAllInputsSetAck create() => MoneroTransactionAllInputsSetAck._();
+  MoneroTransactionAllInputsSetAck createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionAllInputsSetAck> createRepeated() => $pb.PbList<MoneroTransactionAllInputsSetAck>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionAllInputsSetAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionAllInputsSetAck>(create);
+  static MoneroTransactionAllInputsSetAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  MoneroTransactionRsigData get rsigData => $_getN(0);
+  @$pb.TagNumber(1)
+  set rsigData(MoneroTransactionRsigData v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasRsigData() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRsigData() => clearField(1);
+  @$pb.TagNumber(1)
+  MoneroTransactionRsigData ensureRsigData() => $_ensure(0);
+}
+
+/// *
+///  Request: Sub request of MoneroTransactionSign. Sends one transaction destination to device (HMACed)
+///  @next MoneroTransactionSetOutputAck
+class MoneroTransactionSetOutputRequest extends $pb.GeneratedMessage {
+  factory MoneroTransactionSetOutputRequest({
+    MoneroTransactionDestinationEntry? dstEntr,
+    $core.List<$core.int>? dstEntrHmac,
+    MoneroTransactionRsigData? rsigData,
+    $core.bool? isOffloadedBp,
+  }) {
+    final $result = create();
+    if (dstEntr != null) {
+      $result.dstEntr = dstEntr;
+    }
+    if (dstEntrHmac != null) {
+      $result.dstEntrHmac = dstEntrHmac;
+    }
+    if (rsigData != null) {
+      $result.rsigData = rsigData;
+    }
+    if (isOffloadedBp != null) {
+      $result.isOffloadedBp = isOffloadedBp;
+    }
+    return $result;
+  }
+  MoneroTransactionSetOutputRequest._() : super();
+  factory MoneroTransactionSetOutputRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionSetOutputRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionSetOutputRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..aOM<MoneroTransactionDestinationEntry>(1, _omitFieldNames ? '' : 'dstEntr', subBuilder: MoneroTransactionDestinationEntry.create)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'dstEntrHmac', $pb.PbFieldType.OY)
+    ..aOM<MoneroTransactionRsigData>(3, _omitFieldNames ? '' : 'rsigData', subBuilder: MoneroTransactionRsigData.create)
+    ..aOB(4, _omitFieldNames ? '' : 'isOffloadedBp')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSetOutputRequest clone() => MoneroTransactionSetOutputRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSetOutputRequest copyWith(void Function(MoneroTransactionSetOutputRequest) updates) => super.copyWith((message) => updates(message as MoneroTransactionSetOutputRequest)) as MoneroTransactionSetOutputRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSetOutputRequest create() => MoneroTransactionSetOutputRequest._();
+  MoneroTransactionSetOutputRequest createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionSetOutputRequest> createRepeated() => $pb.PbList<MoneroTransactionSetOutputRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSetOutputRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionSetOutputRequest>(create);
+  static MoneroTransactionSetOutputRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  MoneroTransactionDestinationEntry get dstEntr => $_getN(0);
+  @$pb.TagNumber(1)
+  set dstEntr(MoneroTransactionDestinationEntry v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDstEntr() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDstEntr() => clearField(1);
+  @$pb.TagNumber(1)
+  MoneroTransactionDestinationEntry ensureDstEntr() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get dstEntrHmac => $_getN(1);
+  @$pb.TagNumber(2)
+  set dstEntrHmac($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasDstEntrHmac() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearDstEntrHmac() => clearField(2);
+
+  @$pb.TagNumber(3)
+  MoneroTransactionRsigData get rsigData => $_getN(2);
+  @$pb.TagNumber(3)
+  set rsigData(MoneroTransactionRsigData v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasRsigData() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearRsigData() => clearField(3);
+  @$pb.TagNumber(3)
+  MoneroTransactionRsigData ensureRsigData() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  $core.bool get isOffloadedBp => $_getBF(3);
+  @$pb.TagNumber(4)
+  set isOffloadedBp($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasIsOffloadedBp() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearIsOffloadedBp() => clearField(4);
+}
+
+/// *
+///  Response: Response to setting transaction destination. Contains sealed values needed for further protocol steps.
+///  @next MoneroTransactionSetOutputRequest
+///  @next MoneroTransactionAllOutSetRequest
+class MoneroTransactionSetOutputAck extends $pb.GeneratedMessage {
+  factory MoneroTransactionSetOutputAck({
+    $core.List<$core.int>? txOut,
+    $core.List<$core.int>? voutiHmac,
+    MoneroTransactionRsigData? rsigData,
+    $core.List<$core.int>? outPk,
+    $core.List<$core.int>? ecdhInfo,
+  }) {
+    final $result = create();
+    if (txOut != null) {
+      $result.txOut = txOut;
+    }
+    if (voutiHmac != null) {
+      $result.voutiHmac = voutiHmac;
+    }
+    if (rsigData != null) {
+      $result.rsigData = rsigData;
+    }
+    if (outPk != null) {
+      $result.outPk = outPk;
+    }
+    if (ecdhInfo != null) {
+      $result.ecdhInfo = ecdhInfo;
+    }
+    return $result;
+  }
+  MoneroTransactionSetOutputAck._() : super();
+  factory MoneroTransactionSetOutputAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionSetOutputAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionSetOutputAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'txOut', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'voutiHmac', $pb.PbFieldType.OY)
+    ..aOM<MoneroTransactionRsigData>(3, _omitFieldNames ? '' : 'rsigData', subBuilder: MoneroTransactionRsigData.create)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'outPk', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'ecdhInfo', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSetOutputAck clone() => MoneroTransactionSetOutputAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSetOutputAck copyWith(void Function(MoneroTransactionSetOutputAck) updates) => super.copyWith((message) => updates(message as MoneroTransactionSetOutputAck)) as MoneroTransactionSetOutputAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSetOutputAck create() => MoneroTransactionSetOutputAck._();
+  MoneroTransactionSetOutputAck createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionSetOutputAck> createRepeated() => $pb.PbList<MoneroTransactionSetOutputAck>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSetOutputAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionSetOutputAck>(create);
+  static MoneroTransactionSetOutputAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get txOut => $_getN(0);
+  @$pb.TagNumber(1)
+  set txOut($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTxOut() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTxOut() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get voutiHmac => $_getN(1);
+  @$pb.TagNumber(2)
+  set voutiHmac($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasVoutiHmac() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearVoutiHmac() => clearField(2);
+
+  @$pb.TagNumber(3)
+  MoneroTransactionRsigData get rsigData => $_getN(2);
+  @$pb.TagNumber(3)
+  set rsigData(MoneroTransactionRsigData v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasRsigData() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearRsigData() => clearField(3);
+  @$pb.TagNumber(3)
+  MoneroTransactionRsigData ensureRsigData() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get outPk => $_getN(3);
+  @$pb.TagNumber(4)
+  set outPk($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasOutPk() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearOutPk() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get ecdhInfo => $_getN(4);
+  @$pb.TagNumber(5)
+  set ecdhInfo($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasEcdhInfo() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearEcdhInfo() => clearField(5);
+}
+
+/// *
+///  Request: Sub request of MoneroTransactionSign. Sent after all outputs are sent.
+///  @next MoneroTransactionAllOutSetAck
+class MoneroTransactionAllOutSetRequest extends $pb.GeneratedMessage {
+  factory MoneroTransactionAllOutSetRequest({
+    MoneroTransactionRsigData? rsigData,
+  }) {
+    final $result = create();
+    if (rsigData != null) {
+      $result.rsigData = rsigData;
+    }
+    return $result;
+  }
+  MoneroTransactionAllOutSetRequest._() : super();
+  factory MoneroTransactionAllOutSetRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionAllOutSetRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionAllOutSetRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..aOM<MoneroTransactionRsigData>(1, _omitFieldNames ? '' : 'rsigData', subBuilder: MoneroTransactionRsigData.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionAllOutSetRequest clone() => MoneroTransactionAllOutSetRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionAllOutSetRequest copyWith(void Function(MoneroTransactionAllOutSetRequest) updates) => super.copyWith((message) => updates(message as MoneroTransactionAllOutSetRequest)) as MoneroTransactionAllOutSetRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionAllOutSetRequest create() => MoneroTransactionAllOutSetRequest._();
+  MoneroTransactionAllOutSetRequest createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionAllOutSetRequest> createRepeated() => $pb.PbList<MoneroTransactionAllOutSetRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionAllOutSetRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionAllOutSetRequest>(create);
+  static MoneroTransactionAllOutSetRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  MoneroTransactionRsigData get rsigData => $_getN(0);
+  @$pb.TagNumber(1)
+  set rsigData(MoneroTransactionRsigData v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasRsigData() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRsigData() => clearField(1);
+  @$pb.TagNumber(1)
+  MoneroTransactionRsigData ensureRsigData() => $_ensure(0);
+}
+
+///
+///  Structure represents initial fields of the Monero RCT signature
+class MoneroTransactionAllOutSetAck_MoneroRingCtSig extends $pb.GeneratedMessage {
+  factory MoneroTransactionAllOutSetAck_MoneroRingCtSig({
+    $fixnum.Int64? txnFee,
+    $core.List<$core.int>? message,
+    $core.int? rvType,
+  }) {
+    final $result = create();
+    if (txnFee != null) {
+      $result.txnFee = txnFee;
+    }
+    if (message != null) {
+      $result.message = message;
+    }
+    if (rvType != null) {
+      $result.rvType = rvType;
+    }
+    return $result;
+  }
+  MoneroTransactionAllOutSetAck_MoneroRingCtSig._() : super();
+  factory MoneroTransactionAllOutSetAck_MoneroRingCtSig.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionAllOutSetAck_MoneroRingCtSig.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionAllOutSetAck.MoneroRingCtSig', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'txnFee', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'message', $pb.PbFieldType.OY)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'rvType', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionAllOutSetAck_MoneroRingCtSig clone() => MoneroTransactionAllOutSetAck_MoneroRingCtSig()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionAllOutSetAck_MoneroRingCtSig copyWith(void Function(MoneroTransactionAllOutSetAck_MoneroRingCtSig) updates) => super.copyWith((message) => updates(message as MoneroTransactionAllOutSetAck_MoneroRingCtSig)) as MoneroTransactionAllOutSetAck_MoneroRingCtSig;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionAllOutSetAck_MoneroRingCtSig create() => MoneroTransactionAllOutSetAck_MoneroRingCtSig._();
+  MoneroTransactionAllOutSetAck_MoneroRingCtSig createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionAllOutSetAck_MoneroRingCtSig> createRepeated() => $pb.PbList<MoneroTransactionAllOutSetAck_MoneroRingCtSig>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionAllOutSetAck_MoneroRingCtSig getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionAllOutSetAck_MoneroRingCtSig>(create);
+  static MoneroTransactionAllOutSetAck_MoneroRingCtSig? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get txnFee => $_getI64(0);
+  @$pb.TagNumber(1)
+  set txnFee($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTxnFee() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTxnFee() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get message => $_getN(1);
+  @$pb.TagNumber(2)
+  set message($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMessage() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMessage() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get rvType => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set rvType($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasRvType() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearRvType() => clearField(3);
+}
+
+/// *
+///  Response: After all outputs are sent the initial RCT signature fields are sent.
+///  @next MoneroTransactionSignInputRequest
+class MoneroTransactionAllOutSetAck extends $pb.GeneratedMessage {
+  factory MoneroTransactionAllOutSetAck({
+    $core.List<$core.int>? extra,
+    $core.List<$core.int>? txPrefixHash,
+    MoneroTransactionAllOutSetAck_MoneroRingCtSig? rv,
+    $core.List<$core.int>? fullMessageHash,
+  }) {
+    final $result = create();
+    if (extra != null) {
+      $result.extra = extra;
+    }
+    if (txPrefixHash != null) {
+      $result.txPrefixHash = txPrefixHash;
+    }
+    if (rv != null) {
+      $result.rv = rv;
+    }
+    if (fullMessageHash != null) {
+      $result.fullMessageHash = fullMessageHash;
+    }
+    return $result;
+  }
+  MoneroTransactionAllOutSetAck._() : super();
+  factory MoneroTransactionAllOutSetAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionAllOutSetAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionAllOutSetAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'extra', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'txPrefixHash', $pb.PbFieldType.OY)
+    ..aOM<MoneroTransactionAllOutSetAck_MoneroRingCtSig>(4, _omitFieldNames ? '' : 'rv', subBuilder: MoneroTransactionAllOutSetAck_MoneroRingCtSig.create)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'fullMessageHash', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionAllOutSetAck clone() => MoneroTransactionAllOutSetAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionAllOutSetAck copyWith(void Function(MoneroTransactionAllOutSetAck) updates) => super.copyWith((message) => updates(message as MoneroTransactionAllOutSetAck)) as MoneroTransactionAllOutSetAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionAllOutSetAck create() => MoneroTransactionAllOutSetAck._();
+  MoneroTransactionAllOutSetAck createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionAllOutSetAck> createRepeated() => $pb.PbList<MoneroTransactionAllOutSetAck>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionAllOutSetAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionAllOutSetAck>(create);
+  static MoneroTransactionAllOutSetAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get extra => $_getN(0);
+  @$pb.TagNumber(1)
+  set extra($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasExtra() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearExtra() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get txPrefixHash => $_getN(1);
+  @$pb.TagNumber(2)
+  set txPrefixHash($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTxPrefixHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTxPrefixHash() => clearField(2);
+
+  @$pb.TagNumber(4)
+  MoneroTransactionAllOutSetAck_MoneroRingCtSig get rv => $_getN(2);
+  @$pb.TagNumber(4)
+  set rv(MoneroTransactionAllOutSetAck_MoneroRingCtSig v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasRv() => $_has(2);
+  @$pb.TagNumber(4)
+  void clearRv() => clearField(4);
+  @$pb.TagNumber(4)
+  MoneroTransactionAllOutSetAck_MoneroRingCtSig ensureRv() => $_ensure(2);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get fullMessageHash => $_getN(3);
+  @$pb.TagNumber(5)
+  set fullMessageHash($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasFullMessageHash() => $_has(3);
+  @$pb.TagNumber(5)
+  void clearFullMessageHash() => clearField(5);
+}
+
+/// *
+///  Request: Sub request of MoneroTransactionSign. Sends UTXO for the signing.
+///  @next MoneroTransactionSignInputAck
+class MoneroTransactionSignInputRequest extends $pb.GeneratedMessage {
+  factory MoneroTransactionSignInputRequest({
+    MoneroTransactionSourceEntry? srcEntr,
+    $core.List<$core.int>? vini,
+    $core.List<$core.int>? viniHmac,
+    $core.List<$core.int>? pseudoOut,
+    $core.List<$core.int>? pseudoOutHmac,
+    $core.List<$core.int>? pseudoOutAlpha,
+    $core.List<$core.int>? spendKey,
+    $core.int? origIdx,
+  }) {
+    final $result = create();
+    if (srcEntr != null) {
+      $result.srcEntr = srcEntr;
+    }
+    if (vini != null) {
+      $result.vini = vini;
+    }
+    if (viniHmac != null) {
+      $result.viniHmac = viniHmac;
+    }
+    if (pseudoOut != null) {
+      $result.pseudoOut = pseudoOut;
+    }
+    if (pseudoOutHmac != null) {
+      $result.pseudoOutHmac = pseudoOutHmac;
+    }
+    if (pseudoOutAlpha != null) {
+      $result.pseudoOutAlpha = pseudoOutAlpha;
+    }
+    if (spendKey != null) {
+      $result.spendKey = spendKey;
+    }
+    if (origIdx != null) {
+      $result.origIdx = origIdx;
+    }
+    return $result;
+  }
+  MoneroTransactionSignInputRequest._() : super();
+  factory MoneroTransactionSignInputRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionSignInputRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionSignInputRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..aOM<MoneroTransactionSourceEntry>(1, _omitFieldNames ? '' : 'srcEntr', subBuilder: MoneroTransactionSourceEntry.create)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'vini', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'viniHmac', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'pseudoOut', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'pseudoOutHmac', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'pseudoOutAlpha', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(7, _omitFieldNames ? '' : 'spendKey', $pb.PbFieldType.OY)
+    ..a<$core.int>(8, _omitFieldNames ? '' : 'origIdx', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSignInputRequest clone() => MoneroTransactionSignInputRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSignInputRequest copyWith(void Function(MoneroTransactionSignInputRequest) updates) => super.copyWith((message) => updates(message as MoneroTransactionSignInputRequest)) as MoneroTransactionSignInputRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSignInputRequest create() => MoneroTransactionSignInputRequest._();
+  MoneroTransactionSignInputRequest createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionSignInputRequest> createRepeated() => $pb.PbList<MoneroTransactionSignInputRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSignInputRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionSignInputRequest>(create);
+  static MoneroTransactionSignInputRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  MoneroTransactionSourceEntry get srcEntr => $_getN(0);
+  @$pb.TagNumber(1)
+  set srcEntr(MoneroTransactionSourceEntry v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSrcEntr() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSrcEntr() => clearField(1);
+  @$pb.TagNumber(1)
+  MoneroTransactionSourceEntry ensureSrcEntr() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get vini => $_getN(1);
+  @$pb.TagNumber(2)
+  set vini($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasVini() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearVini() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get viniHmac => $_getN(2);
+  @$pb.TagNumber(3)
+  set viniHmac($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasViniHmac() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearViniHmac() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get pseudoOut => $_getN(3);
+  @$pb.TagNumber(4)
+  set pseudoOut($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasPseudoOut() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearPseudoOut() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get pseudoOutHmac => $_getN(4);
+  @$pb.TagNumber(5)
+  set pseudoOutHmac($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasPseudoOutHmac() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearPseudoOutHmac() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get pseudoOutAlpha => $_getN(5);
+  @$pb.TagNumber(6)
+  set pseudoOutAlpha($core.List<$core.int> v) { $_setBytes(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasPseudoOutAlpha() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearPseudoOutAlpha() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.List<$core.int> get spendKey => $_getN(6);
+  @$pb.TagNumber(7)
+  set spendKey($core.List<$core.int> v) { $_setBytes(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasSpendKey() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearSpendKey() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.int get origIdx => $_getIZ(7);
+  @$pb.TagNumber(8)
+  set origIdx($core.int v) { $_setUnsignedInt32(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasOrigIdx() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearOrigIdx() => clearField(8);
+}
+
+/// *
+///  Response: Contains full MG signature of the UTXO + multisig data if applicable.
+///  @next MoneroTransactionSignInputRequest
+///  @next MoneroTransactionFinalRequest
+class MoneroTransactionSignInputAck extends $pb.GeneratedMessage {
+  factory MoneroTransactionSignInputAck({
+    $core.List<$core.int>? signature,
+    $core.List<$core.int>? pseudoOut,
+  }) {
+    final $result = create();
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    if (pseudoOut != null) {
+      $result.pseudoOut = pseudoOut;
+    }
+    return $result;
+  }
+  MoneroTransactionSignInputAck._() : super();
+  factory MoneroTransactionSignInputAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionSignInputAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionSignInputAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'pseudoOut', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSignInputAck clone() => MoneroTransactionSignInputAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionSignInputAck copyWith(void Function(MoneroTransactionSignInputAck) updates) => super.copyWith((message) => updates(message as MoneroTransactionSignInputAck)) as MoneroTransactionSignInputAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSignInputAck create() => MoneroTransactionSignInputAck._();
+  MoneroTransactionSignInputAck createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionSignInputAck> createRepeated() => $pb.PbList<MoneroTransactionSignInputAck>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionSignInputAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionSignInputAck>(create);
+  static MoneroTransactionSignInputAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get signature => $_getN(0);
+  @$pb.TagNumber(1)
+  set signature($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSignature() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSignature() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get pseudoOut => $_getN(1);
+  @$pb.TagNumber(2)
+  set pseudoOut($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPseudoOut() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPseudoOut() => clearField(2);
+}
+
+/// *
+///  Request: Sub request of MoneroTransactionSign. Final message of the procol after all UTXOs are signed
+///  @next MoneroTransactionFinalAck
+class MoneroTransactionFinalRequest extends $pb.GeneratedMessage {
+  factory MoneroTransactionFinalRequest() => create();
+  MoneroTransactionFinalRequest._() : super();
+  factory MoneroTransactionFinalRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionFinalRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionFinalRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionFinalRequest clone() => MoneroTransactionFinalRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionFinalRequest copyWith(void Function(MoneroTransactionFinalRequest) updates) => super.copyWith((message) => updates(message as MoneroTransactionFinalRequest)) as MoneroTransactionFinalRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionFinalRequest create() => MoneroTransactionFinalRequest._();
+  MoneroTransactionFinalRequest createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionFinalRequest> createRepeated() => $pb.PbList<MoneroTransactionFinalRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionFinalRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionFinalRequest>(create);
+  static MoneroTransactionFinalRequest? _defaultInstance;
+}
+
+/// *
+///  Response: Contains transaction metadata and encryption keys needed for further transaction operations (e.g. multisig, send proof).
+///  @end
+class MoneroTransactionFinalAck extends $pb.GeneratedMessage {
+  factory MoneroTransactionFinalAck({
+    $core.List<$core.int>? coutKey,
+    $core.List<$core.int>? salt,
+    $core.List<$core.int>? randMult,
+    $core.List<$core.int>? txEncKeys,
+    $core.List<$core.int>? openingKey,
+  }) {
+    final $result = create();
+    if (coutKey != null) {
+      $result.coutKey = coutKey;
+    }
+    if (salt != null) {
+      $result.salt = salt;
+    }
+    if (randMult != null) {
+      $result.randMult = randMult;
+    }
+    if (txEncKeys != null) {
+      $result.txEncKeys = txEncKeys;
+    }
+    if (openingKey != null) {
+      $result.openingKey = openingKey;
+    }
+    return $result;
+  }
+  MoneroTransactionFinalAck._() : super();
+  factory MoneroTransactionFinalAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroTransactionFinalAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroTransactionFinalAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'coutKey', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'salt', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'randMult', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'txEncKeys', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'openingKey', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionFinalAck clone() => MoneroTransactionFinalAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroTransactionFinalAck copyWith(void Function(MoneroTransactionFinalAck) updates) => super.copyWith((message) => updates(message as MoneroTransactionFinalAck)) as MoneroTransactionFinalAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionFinalAck create() => MoneroTransactionFinalAck._();
+  MoneroTransactionFinalAck createEmptyInstance() => create();
+  static $pb.PbList<MoneroTransactionFinalAck> createRepeated() => $pb.PbList<MoneroTransactionFinalAck>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroTransactionFinalAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroTransactionFinalAck>(create);
+  static MoneroTransactionFinalAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get coutKey => $_getN(0);
+  @$pb.TagNumber(1)
+  set coutKey($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasCoutKey() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCoutKey() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get salt => $_getN(1);
+  @$pb.TagNumber(2)
+  set salt($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSalt() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSalt() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get randMult => $_getN(2);
+  @$pb.TagNumber(3)
+  set randMult($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasRandMult() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearRandMult() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get txEncKeys => $_getN(3);
+  @$pb.TagNumber(4)
+  set txEncKeys($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasTxEncKeys() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearTxEncKeys() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get openingKey => $_getN(4);
+  @$pb.TagNumber(5)
+  set openingKey($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasOpeningKey() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearOpeningKey() => clearField(5);
+}
+
+/// *
+///  Structure representing Monero list of sub-addresses
+class MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList extends $pb.GeneratedMessage {
+  factory MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList({
+    $core.int? account,
+    $core.Iterable<$core.int>? minorIndices,
+  }) {
+    final $result = create();
+    if (account != null) {
+      $result.account = account;
+    }
+    if (minorIndices != null) {
+      $result.minorIndices.addAll(minorIndices);
+    }
+    return $result;
+  }
+  MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList._() : super();
+  factory MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroKeyImageExportInitRequest.MoneroSubAddressIndicesList', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'account', $pb.PbFieldType.QU3)
+    ..p<$core.int>(2, _omitFieldNames ? '' : 'minorIndices', $pb.PbFieldType.PU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList clone() => MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList copyWith(void Function(MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList) updates) => super.copyWith((message) => updates(message as MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList)) as MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList create() => MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList._();
+  MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList createEmptyInstance() => create();
+  static $pb.PbList<MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList> createRepeated() => $pb.PbList<MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList>(create);
+  static MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get account => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set account($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get minorIndices => $_getList(1);
+}
+
+/// *
+///  Request: Sub request of MoneroKeyImageSync. Initializing key image sync.
+///  @start
+///  @next MoneroKeyImageExportInitAck
+class MoneroKeyImageExportInitRequest extends $pb.GeneratedMessage {
+  factory MoneroKeyImageExportInitRequest({
+    $fixnum.Int64? num,
+    $core.List<$core.int>? hash,
+    $core.Iterable<$core.int>? addressN,
+    MoneroNetworkType? networkType,
+    $core.Iterable<MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList>? subs,
+  }) {
+    final $result = create();
+    if (num != null) {
+      $result.num = num;
+    }
+    if (hash != null) {
+      $result.hash = hash;
+    }
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (networkType != null) {
+      $result.networkType = networkType;
+    }
+    if (subs != null) {
+      $result.subs.addAll(subs);
+    }
+    return $result;
+  }
+  MoneroKeyImageExportInitRequest._() : super();
+  factory MoneroKeyImageExportInitRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroKeyImageExportInitRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroKeyImageExportInitRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'num', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'hash', $pb.PbFieldType.QY)
+    ..p<$core.int>(3, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..e<MoneroNetworkType>(4, _omitFieldNames ? '' : 'networkType', $pb.PbFieldType.OE, defaultOrMaker: MoneroNetworkType.MAINNET, valueOf: MoneroNetworkType.valueOf, enumValues: MoneroNetworkType.values)
+    ..pc<MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList>(5, _omitFieldNames ? '' : 'subs', $pb.PbFieldType.PM, subBuilder: MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageExportInitRequest clone() => MoneroKeyImageExportInitRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageExportInitRequest copyWith(void Function(MoneroKeyImageExportInitRequest) updates) => super.copyWith((message) => updates(message as MoneroKeyImageExportInitRequest)) as MoneroKeyImageExportInitRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageExportInitRequest create() => MoneroKeyImageExportInitRequest._();
+  MoneroKeyImageExportInitRequest createEmptyInstance() => create();
+  static $pb.PbList<MoneroKeyImageExportInitRequest> createRepeated() => $pb.PbList<MoneroKeyImageExportInitRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageExportInitRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroKeyImageExportInitRequest>(create);
+  static MoneroKeyImageExportInitRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get num => $_getI64(0);
+  @$pb.TagNumber(1)
+  set num($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasNum() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearNum() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get hash => $_getN(1);
+  @$pb.TagNumber(2)
+  set hash($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearHash() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get addressN => $_getList(2);
+
+  @$pb.TagNumber(4)
+  MoneroNetworkType get networkType => $_getN(3);
+  @$pb.TagNumber(4)
+  set networkType(MoneroNetworkType v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasNetworkType() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearNetworkType() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList> get subs => $_getList(4);
+}
+
+/// *
+///  Response: Response to key image sync initialization.
+///  @next MoneroKeyImageSyncStepRequest
+class MoneroKeyImageExportInitAck extends $pb.GeneratedMessage {
+  factory MoneroKeyImageExportInitAck() => create();
+  MoneroKeyImageExportInitAck._() : super();
+  factory MoneroKeyImageExportInitAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroKeyImageExportInitAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroKeyImageExportInitAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageExportInitAck clone() => MoneroKeyImageExportInitAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageExportInitAck copyWith(void Function(MoneroKeyImageExportInitAck) updates) => super.copyWith((message) => updates(message as MoneroKeyImageExportInitAck)) as MoneroKeyImageExportInitAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageExportInitAck create() => MoneroKeyImageExportInitAck._();
+  MoneroKeyImageExportInitAck createEmptyInstance() => create();
+  static $pb.PbList<MoneroKeyImageExportInitAck> createRepeated() => $pb.PbList<MoneroKeyImageExportInitAck>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageExportInitAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroKeyImageExportInitAck>(create);
+  static MoneroKeyImageExportInitAck? _defaultInstance;
+}
+
+/// *
+///  Structure representing Monero UTXO for key image sync
+class MoneroKeyImageSyncStepRequest_MoneroTransferDetails extends $pb.GeneratedMessage {
+  factory MoneroKeyImageSyncStepRequest_MoneroTransferDetails({
+    $core.List<$core.int>? outKey,
+    $core.List<$core.int>? txPubKey,
+    $core.Iterable<$core.List<$core.int>>? additionalTxPubKeys,
+    $fixnum.Int64? internalOutputIndex,
+    $core.int? subAddrMajor,
+    $core.int? subAddrMinor,
+  }) {
+    final $result = create();
+    if (outKey != null) {
+      $result.outKey = outKey;
+    }
+    if (txPubKey != null) {
+      $result.txPubKey = txPubKey;
+    }
+    if (additionalTxPubKeys != null) {
+      $result.additionalTxPubKeys.addAll(additionalTxPubKeys);
+    }
+    if (internalOutputIndex != null) {
+      $result.internalOutputIndex = internalOutputIndex;
+    }
+    if (subAddrMajor != null) {
+      $result.subAddrMajor = subAddrMajor;
+    }
+    if (subAddrMinor != null) {
+      $result.subAddrMinor = subAddrMinor;
+    }
+    return $result;
+  }
+  MoneroKeyImageSyncStepRequest_MoneroTransferDetails._() : super();
+  factory MoneroKeyImageSyncStepRequest_MoneroTransferDetails.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroKeyImageSyncStepRequest_MoneroTransferDetails.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroKeyImageSyncStepRequest.MoneroTransferDetails', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'outKey', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'txPubKey', $pb.PbFieldType.QY)
+    ..p<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'additionalTxPubKeys', $pb.PbFieldType.PY)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'internalOutputIndex', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'subAddrMajor', $pb.PbFieldType.OU3)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'subAddrMinor', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageSyncStepRequest_MoneroTransferDetails clone() => MoneroKeyImageSyncStepRequest_MoneroTransferDetails()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageSyncStepRequest_MoneroTransferDetails copyWith(void Function(MoneroKeyImageSyncStepRequest_MoneroTransferDetails) updates) => super.copyWith((message) => updates(message as MoneroKeyImageSyncStepRequest_MoneroTransferDetails)) as MoneroKeyImageSyncStepRequest_MoneroTransferDetails;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageSyncStepRequest_MoneroTransferDetails create() => MoneroKeyImageSyncStepRequest_MoneroTransferDetails._();
+  MoneroKeyImageSyncStepRequest_MoneroTransferDetails createEmptyInstance() => create();
+  static $pb.PbList<MoneroKeyImageSyncStepRequest_MoneroTransferDetails> createRepeated() => $pb.PbList<MoneroKeyImageSyncStepRequest_MoneroTransferDetails>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageSyncStepRequest_MoneroTransferDetails getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroKeyImageSyncStepRequest_MoneroTransferDetails>(create);
+  static MoneroKeyImageSyncStepRequest_MoneroTransferDetails? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get outKey => $_getN(0);
+  @$pb.TagNumber(1)
+  set outKey($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasOutKey() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearOutKey() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get txPubKey => $_getN(1);
+  @$pb.TagNumber(2)
+  set txPubKey($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTxPubKey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTxPubKey() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.List<$core.int>> get additionalTxPubKeys => $_getList(2);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get internalOutputIndex => $_getI64(3);
+  @$pb.TagNumber(4)
+  set internalOutputIndex($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasInternalOutputIndex() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearInternalOutputIndex() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get subAddrMajor => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set subAddrMajor($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasSubAddrMajor() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearSubAddrMajor() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.int get subAddrMinor => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set subAddrMinor($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasSubAddrMinor() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearSubAddrMinor() => clearField(6);
+}
+
+/// *
+///  Request: Sub request of MoneroKeyImageSync. Contains batch of the UTXO to export key image for.
+///  @next MoneroKeyImageSyncStepAck
+class MoneroKeyImageSyncStepRequest extends $pb.GeneratedMessage {
+  factory MoneroKeyImageSyncStepRequest({
+    $core.Iterable<MoneroKeyImageSyncStepRequest_MoneroTransferDetails>? tdis,
+  }) {
+    final $result = create();
+    if (tdis != null) {
+      $result.tdis.addAll(tdis);
+    }
+    return $result;
+  }
+  MoneroKeyImageSyncStepRequest._() : super();
+  factory MoneroKeyImageSyncStepRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroKeyImageSyncStepRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroKeyImageSyncStepRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..pc<MoneroKeyImageSyncStepRequest_MoneroTransferDetails>(1, _omitFieldNames ? '' : 'tdis', $pb.PbFieldType.PM, subBuilder: MoneroKeyImageSyncStepRequest_MoneroTransferDetails.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageSyncStepRequest clone() => MoneroKeyImageSyncStepRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageSyncStepRequest copyWith(void Function(MoneroKeyImageSyncStepRequest) updates) => super.copyWith((message) => updates(message as MoneroKeyImageSyncStepRequest)) as MoneroKeyImageSyncStepRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageSyncStepRequest create() => MoneroKeyImageSyncStepRequest._();
+  MoneroKeyImageSyncStepRequest createEmptyInstance() => create();
+  static $pb.PbList<MoneroKeyImageSyncStepRequest> createRepeated() => $pb.PbList<MoneroKeyImageSyncStepRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageSyncStepRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroKeyImageSyncStepRequest>(create);
+  static MoneroKeyImageSyncStepRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<MoneroKeyImageSyncStepRequest_MoneroTransferDetails> get tdis => $_getList(0);
+}
+
+/// *
+///  Structure representing Monero encrypted exported key image
+class MoneroKeyImageSyncStepAck_MoneroExportedKeyImage extends $pb.GeneratedMessage {
+  factory MoneroKeyImageSyncStepAck_MoneroExportedKeyImage({
+    $core.List<$core.int>? iv,
+    $core.List<$core.int>? blob,
+  }) {
+    final $result = create();
+    if (iv != null) {
+      $result.iv = iv;
+    }
+    if (blob != null) {
+      $result.blob = blob;
+    }
+    return $result;
+  }
+  MoneroKeyImageSyncStepAck_MoneroExportedKeyImage._() : super();
+  factory MoneroKeyImageSyncStepAck_MoneroExportedKeyImage.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroKeyImageSyncStepAck_MoneroExportedKeyImage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroKeyImageSyncStepAck.MoneroExportedKeyImage', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'iv', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'blob', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageSyncStepAck_MoneroExportedKeyImage clone() => MoneroKeyImageSyncStepAck_MoneroExportedKeyImage()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageSyncStepAck_MoneroExportedKeyImage copyWith(void Function(MoneroKeyImageSyncStepAck_MoneroExportedKeyImage) updates) => super.copyWith((message) => updates(message as MoneroKeyImageSyncStepAck_MoneroExportedKeyImage)) as MoneroKeyImageSyncStepAck_MoneroExportedKeyImage;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageSyncStepAck_MoneroExportedKeyImage create() => MoneroKeyImageSyncStepAck_MoneroExportedKeyImage._();
+  MoneroKeyImageSyncStepAck_MoneroExportedKeyImage createEmptyInstance() => create();
+  static $pb.PbList<MoneroKeyImageSyncStepAck_MoneroExportedKeyImage> createRepeated() => $pb.PbList<MoneroKeyImageSyncStepAck_MoneroExportedKeyImage>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageSyncStepAck_MoneroExportedKeyImage getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroKeyImageSyncStepAck_MoneroExportedKeyImage>(create);
+  static MoneroKeyImageSyncStepAck_MoneroExportedKeyImage? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get iv => $_getN(0);
+  @$pb.TagNumber(1)
+  set iv($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasIv() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearIv() => clearField(1);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get blob => $_getN(1);
+  @$pb.TagNumber(3)
+  set blob($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasBlob() => $_has(1);
+  @$pb.TagNumber(3)
+  void clearBlob() => clearField(3);
+}
+
+/// *
+///  Response: Response to key image sync step. Contains encrypted exported key image.
+///  @next MoneroKeyImageSyncStepRequest
+///  @next MoneroKeyImageSyncFinalRequest
+class MoneroKeyImageSyncStepAck extends $pb.GeneratedMessage {
+  factory MoneroKeyImageSyncStepAck({
+    $core.Iterable<MoneroKeyImageSyncStepAck_MoneroExportedKeyImage>? kis,
+  }) {
+    final $result = create();
+    if (kis != null) {
+      $result.kis.addAll(kis);
+    }
+    return $result;
+  }
+  MoneroKeyImageSyncStepAck._() : super();
+  factory MoneroKeyImageSyncStepAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroKeyImageSyncStepAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroKeyImageSyncStepAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..pc<MoneroKeyImageSyncStepAck_MoneroExportedKeyImage>(1, _omitFieldNames ? '' : 'kis', $pb.PbFieldType.PM, subBuilder: MoneroKeyImageSyncStepAck_MoneroExportedKeyImage.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageSyncStepAck clone() => MoneroKeyImageSyncStepAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageSyncStepAck copyWith(void Function(MoneroKeyImageSyncStepAck) updates) => super.copyWith((message) => updates(message as MoneroKeyImageSyncStepAck)) as MoneroKeyImageSyncStepAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageSyncStepAck create() => MoneroKeyImageSyncStepAck._();
+  MoneroKeyImageSyncStepAck createEmptyInstance() => create();
+  static $pb.PbList<MoneroKeyImageSyncStepAck> createRepeated() => $pb.PbList<MoneroKeyImageSyncStepAck>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageSyncStepAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroKeyImageSyncStepAck>(create);
+  static MoneroKeyImageSyncStepAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<MoneroKeyImageSyncStepAck_MoneroExportedKeyImage> get kis => $_getList(0);
+}
+
+/// *
+///  Request: Sub request of MoneroKeyImageSync. Final message of the sync protocol.
+///  @next MoneroKeyImageSyncFinalAck
+class MoneroKeyImageSyncFinalRequest extends $pb.GeneratedMessage {
+  factory MoneroKeyImageSyncFinalRequest() => create();
+  MoneroKeyImageSyncFinalRequest._() : super();
+  factory MoneroKeyImageSyncFinalRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroKeyImageSyncFinalRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroKeyImageSyncFinalRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageSyncFinalRequest clone() => MoneroKeyImageSyncFinalRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageSyncFinalRequest copyWith(void Function(MoneroKeyImageSyncFinalRequest) updates) => super.copyWith((message) => updates(message as MoneroKeyImageSyncFinalRequest)) as MoneroKeyImageSyncFinalRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageSyncFinalRequest create() => MoneroKeyImageSyncFinalRequest._();
+  MoneroKeyImageSyncFinalRequest createEmptyInstance() => create();
+  static $pb.PbList<MoneroKeyImageSyncFinalRequest> createRepeated() => $pb.PbList<MoneroKeyImageSyncFinalRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageSyncFinalRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroKeyImageSyncFinalRequest>(create);
+  static MoneroKeyImageSyncFinalRequest? _defaultInstance;
+}
+
+/// *
+///  Response: Response to key image sync step. Contains encryption keys for exported key images.
+///  @end
+class MoneroKeyImageSyncFinalAck extends $pb.GeneratedMessage {
+  factory MoneroKeyImageSyncFinalAck({
+    $core.List<$core.int>? encKey,
+  }) {
+    final $result = create();
+    if (encKey != null) {
+      $result.encKey = encKey;
+    }
+    return $result;
+  }
+  MoneroKeyImageSyncFinalAck._() : super();
+  factory MoneroKeyImageSyncFinalAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroKeyImageSyncFinalAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroKeyImageSyncFinalAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'encKey', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageSyncFinalAck clone() => MoneroKeyImageSyncFinalAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroKeyImageSyncFinalAck copyWith(void Function(MoneroKeyImageSyncFinalAck) updates) => super.copyWith((message) => updates(message as MoneroKeyImageSyncFinalAck)) as MoneroKeyImageSyncFinalAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageSyncFinalAck create() => MoneroKeyImageSyncFinalAck._();
+  MoneroKeyImageSyncFinalAck createEmptyInstance() => create();
+  static $pb.PbList<MoneroKeyImageSyncFinalAck> createRepeated() => $pb.PbList<MoneroKeyImageSyncFinalAck>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroKeyImageSyncFinalAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroKeyImageSyncFinalAck>(create);
+  static MoneroKeyImageSyncFinalAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get encKey => $_getN(0);
+  @$pb.TagNumber(1)
+  set encKey($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasEncKey() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearEncKey() => clearField(1);
+}
+
+/// *
+///  Request: Decrypt tx private keys blob
+///  @next MoneroGetTxKeyAck
+class MoneroGetTxKeyRequest extends $pb.GeneratedMessage {
+  factory MoneroGetTxKeyRequest({
+    $core.Iterable<$core.int>? addressN,
+    MoneroNetworkType? networkType,
+    $core.List<$core.int>? salt1,
+    $core.List<$core.int>? salt2,
+    $core.List<$core.int>? txEncKeys,
+    $core.List<$core.int>? txPrefixHash,
+    $core.int? reason,
+    $core.List<$core.int>? viewPublicKey,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (networkType != null) {
+      $result.networkType = networkType;
+    }
+    if (salt1 != null) {
+      $result.salt1 = salt1;
+    }
+    if (salt2 != null) {
+      $result.salt2 = salt2;
+    }
+    if (txEncKeys != null) {
+      $result.txEncKeys = txEncKeys;
+    }
+    if (txPrefixHash != null) {
+      $result.txPrefixHash = txPrefixHash;
+    }
+    if (reason != null) {
+      $result.reason = reason;
+    }
+    if (viewPublicKey != null) {
+      $result.viewPublicKey = viewPublicKey;
+    }
+    return $result;
+  }
+  MoneroGetTxKeyRequest._() : super();
+  factory MoneroGetTxKeyRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroGetTxKeyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroGetTxKeyRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..e<MoneroNetworkType>(2, _omitFieldNames ? '' : 'networkType', $pb.PbFieldType.OE, defaultOrMaker: MoneroNetworkType.MAINNET, valueOf: MoneroNetworkType.valueOf, enumValues: MoneroNetworkType.values)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'salt1', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'salt2', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'txEncKeys', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'txPrefixHash', $pb.PbFieldType.QY)
+    ..a<$core.int>(7, _omitFieldNames ? '' : 'reason', $pb.PbFieldType.OU3)
+    ..a<$core.List<$core.int>>(8, _omitFieldNames ? '' : 'viewPublicKey', $pb.PbFieldType.OY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroGetTxKeyRequest clone() => MoneroGetTxKeyRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroGetTxKeyRequest copyWith(void Function(MoneroGetTxKeyRequest) updates) => super.copyWith((message) => updates(message as MoneroGetTxKeyRequest)) as MoneroGetTxKeyRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroGetTxKeyRequest create() => MoneroGetTxKeyRequest._();
+  MoneroGetTxKeyRequest createEmptyInstance() => create();
+  static $pb.PbList<MoneroGetTxKeyRequest> createRepeated() => $pb.PbList<MoneroGetTxKeyRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroGetTxKeyRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroGetTxKeyRequest>(create);
+  static MoneroGetTxKeyRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  MoneroNetworkType get networkType => $_getN(1);
+  @$pb.TagNumber(2)
+  set networkType(MoneroNetworkType v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasNetworkType() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNetworkType() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get salt1 => $_getN(2);
+  @$pb.TagNumber(3)
+  set salt1($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSalt1() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSalt1() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get salt2 => $_getN(3);
+  @$pb.TagNumber(4)
+  set salt2($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasSalt2() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearSalt2() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get txEncKeys => $_getN(4);
+  @$pb.TagNumber(5)
+  set txEncKeys($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasTxEncKeys() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearTxEncKeys() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get txPrefixHash => $_getN(5);
+  @$pb.TagNumber(6)
+  set txPrefixHash($core.List<$core.int> v) { $_setBytes(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasTxPrefixHash() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearTxPrefixHash() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.int get reason => $_getIZ(6);
+  @$pb.TagNumber(7)
+  set reason($core.int v) { $_setUnsignedInt32(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasReason() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearReason() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.List<$core.int> get viewPublicKey => $_getN(7);
+  @$pb.TagNumber(8)
+  set viewPublicKey($core.List<$core.int> v) { $_setBytes(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasViewPublicKey() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearViewPublicKey() => clearField(8);
+}
+
+/// *
+///  Response: Response with the re-encrypted private keys and derivations blob under view key
+///  @end
+class MoneroGetTxKeyAck extends $pb.GeneratedMessage {
+  factory MoneroGetTxKeyAck({
+    $core.List<$core.int>? salt,
+    $core.List<$core.int>? txKeys,
+    $core.List<$core.int>? txDerivations,
+  }) {
+    final $result = create();
+    if (salt != null) {
+      $result.salt = salt;
+    }
+    if (txKeys != null) {
+      $result.txKeys = txKeys;
+    }
+    if (txDerivations != null) {
+      $result.txDerivations = txDerivations;
+    }
+    return $result;
+  }
+  MoneroGetTxKeyAck._() : super();
+  factory MoneroGetTxKeyAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroGetTxKeyAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroGetTxKeyAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'salt', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'txKeys', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'txDerivations', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroGetTxKeyAck clone() => MoneroGetTxKeyAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroGetTxKeyAck copyWith(void Function(MoneroGetTxKeyAck) updates) => super.copyWith((message) => updates(message as MoneroGetTxKeyAck)) as MoneroGetTxKeyAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroGetTxKeyAck create() => MoneroGetTxKeyAck._();
+  MoneroGetTxKeyAck createEmptyInstance() => create();
+  static $pb.PbList<MoneroGetTxKeyAck> createRepeated() => $pb.PbList<MoneroGetTxKeyAck>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroGetTxKeyAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroGetTxKeyAck>(create);
+  static MoneroGetTxKeyAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get salt => $_getN(0);
+  @$pb.TagNumber(1)
+  set salt($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSalt() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSalt() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get txKeys => $_getN(1);
+  @$pb.TagNumber(2)
+  set txKeys($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTxKeys() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTxKeys() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get txDerivations => $_getN(2);
+  @$pb.TagNumber(3)
+  set txDerivations($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasTxDerivations() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearTxDerivations() => clearField(3);
+}
+
+/// *
+///  Request: Starts live refresh flow. Asks user permission, switches state
+///  @next MoneroLiveRefreshStartAck
+class MoneroLiveRefreshStartRequest extends $pb.GeneratedMessage {
+  factory MoneroLiveRefreshStartRequest({
+    $core.Iterable<$core.int>? addressN,
+    MoneroNetworkType? networkType,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (networkType != null) {
+      $result.networkType = networkType;
+    }
+    return $result;
+  }
+  MoneroLiveRefreshStartRequest._() : super();
+  factory MoneroLiveRefreshStartRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroLiveRefreshStartRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroLiveRefreshStartRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..e<MoneroNetworkType>(2, _omitFieldNames ? '' : 'networkType', $pb.PbFieldType.OE, defaultOrMaker: MoneroNetworkType.MAINNET, valueOf: MoneroNetworkType.valueOf, enumValues: MoneroNetworkType.values)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroLiveRefreshStartRequest clone() => MoneroLiveRefreshStartRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroLiveRefreshStartRequest copyWith(void Function(MoneroLiveRefreshStartRequest) updates) => super.copyWith((message) => updates(message as MoneroLiveRefreshStartRequest)) as MoneroLiveRefreshStartRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroLiveRefreshStartRequest create() => MoneroLiveRefreshStartRequest._();
+  MoneroLiveRefreshStartRequest createEmptyInstance() => create();
+  static $pb.PbList<MoneroLiveRefreshStartRequest> createRepeated() => $pb.PbList<MoneroLiveRefreshStartRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroLiveRefreshStartRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroLiveRefreshStartRequest>(create);
+  static MoneroLiveRefreshStartRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  MoneroNetworkType get networkType => $_getN(1);
+  @$pb.TagNumber(2)
+  set networkType(MoneroNetworkType v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasNetworkType() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNetworkType() => clearField(2);
+}
+
+/// *
+///  Response after user gave permission
+///  @next MoneroLiveRefreshStepRequest
+///  @next MoneroLiveRefreshFinalRequest
+class MoneroLiveRefreshStartAck extends $pb.GeneratedMessage {
+  factory MoneroLiveRefreshStartAck() => create();
+  MoneroLiveRefreshStartAck._() : super();
+  factory MoneroLiveRefreshStartAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroLiveRefreshStartAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroLiveRefreshStartAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroLiveRefreshStartAck clone() => MoneroLiveRefreshStartAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroLiveRefreshStartAck copyWith(void Function(MoneroLiveRefreshStartAck) updates) => super.copyWith((message) => updates(message as MoneroLiveRefreshStartAck)) as MoneroLiveRefreshStartAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroLiveRefreshStartAck create() => MoneroLiveRefreshStartAck._();
+  MoneroLiveRefreshStartAck createEmptyInstance() => create();
+  static $pb.PbList<MoneroLiveRefreshStartAck> createRepeated() => $pb.PbList<MoneroLiveRefreshStartAck>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroLiveRefreshStartAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroLiveRefreshStartAck>(create);
+  static MoneroLiveRefreshStartAck? _defaultInstance;
+}
+
+/// *
+///  Request: Request to compute a single key image during live sync
+///  @next MoneroLiveRefreshStepAck
+class MoneroLiveRefreshStepRequest extends $pb.GeneratedMessage {
+  factory MoneroLiveRefreshStepRequest({
+    $core.List<$core.int>? outKey,
+    $core.List<$core.int>? recvDeriv,
+    $fixnum.Int64? realOutIdx,
+    $core.int? subAddrMajor,
+    $core.int? subAddrMinor,
+  }) {
+    final $result = create();
+    if (outKey != null) {
+      $result.outKey = outKey;
+    }
+    if (recvDeriv != null) {
+      $result.recvDeriv = recvDeriv;
+    }
+    if (realOutIdx != null) {
+      $result.realOutIdx = realOutIdx;
+    }
+    if (subAddrMajor != null) {
+      $result.subAddrMajor = subAddrMajor;
+    }
+    if (subAddrMinor != null) {
+      $result.subAddrMinor = subAddrMinor;
+    }
+    return $result;
+  }
+  MoneroLiveRefreshStepRequest._() : super();
+  factory MoneroLiveRefreshStepRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroLiveRefreshStepRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroLiveRefreshStepRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'outKey', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'recvDeriv', $pb.PbFieldType.QY)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'realOutIdx', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'subAddrMajor', $pb.PbFieldType.QU3)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'subAddrMinor', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroLiveRefreshStepRequest clone() => MoneroLiveRefreshStepRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroLiveRefreshStepRequest copyWith(void Function(MoneroLiveRefreshStepRequest) updates) => super.copyWith((message) => updates(message as MoneroLiveRefreshStepRequest)) as MoneroLiveRefreshStepRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroLiveRefreshStepRequest create() => MoneroLiveRefreshStepRequest._();
+  MoneroLiveRefreshStepRequest createEmptyInstance() => create();
+  static $pb.PbList<MoneroLiveRefreshStepRequest> createRepeated() => $pb.PbList<MoneroLiveRefreshStepRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroLiveRefreshStepRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroLiveRefreshStepRequest>(create);
+  static MoneroLiveRefreshStepRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get outKey => $_getN(0);
+  @$pb.TagNumber(1)
+  set outKey($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasOutKey() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearOutKey() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get recvDeriv => $_getN(1);
+  @$pb.TagNumber(2)
+  set recvDeriv($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasRecvDeriv() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearRecvDeriv() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get realOutIdx => $_getI64(2);
+  @$pb.TagNumber(3)
+  set realOutIdx($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasRealOutIdx() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearRealOutIdx() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get subAddrMajor => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set subAddrMajor($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasSubAddrMajor() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearSubAddrMajor() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get subAddrMinor => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set subAddrMinor($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasSubAddrMinor() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearSubAddrMinor() => clearField(5);
+}
+
+/// *
+///  Response: Response with the encrypted key image + signature
+///  @next MoneroLiveRefreshStepRequest
+///  @next MoneroLiveRefreshFinishedRequest
+class MoneroLiveRefreshStepAck extends $pb.GeneratedMessage {
+  factory MoneroLiveRefreshStepAck({
+    $core.List<$core.int>? salt,
+    $core.List<$core.int>? keyImage,
+  }) {
+    final $result = create();
+    if (salt != null) {
+      $result.salt = salt;
+    }
+    if (keyImage != null) {
+      $result.keyImage = keyImage;
+    }
+    return $result;
+  }
+  MoneroLiveRefreshStepAck._() : super();
+  factory MoneroLiveRefreshStepAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroLiveRefreshStepAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroLiveRefreshStepAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'salt', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'keyImage', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroLiveRefreshStepAck clone() => MoneroLiveRefreshStepAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroLiveRefreshStepAck copyWith(void Function(MoneroLiveRefreshStepAck) updates) => super.copyWith((message) => updates(message as MoneroLiveRefreshStepAck)) as MoneroLiveRefreshStepAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroLiveRefreshStepAck create() => MoneroLiveRefreshStepAck._();
+  MoneroLiveRefreshStepAck createEmptyInstance() => create();
+  static $pb.PbList<MoneroLiveRefreshStepAck> createRepeated() => $pb.PbList<MoneroLiveRefreshStepAck>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroLiveRefreshStepAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroLiveRefreshStepAck>(create);
+  static MoneroLiveRefreshStepAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get salt => $_getN(0);
+  @$pb.TagNumber(1)
+  set salt($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSalt() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSalt() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get keyImage => $_getN(1);
+  @$pb.TagNumber(2)
+  set keyImage($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasKeyImage() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearKeyImage() => clearField(2);
+}
+
+/// *
+///  Request: Request terminating live refresh mode.
+///  @next MoneroLiveRefreshFinishedAck
+class MoneroLiveRefreshFinalRequest extends $pb.GeneratedMessage {
+  factory MoneroLiveRefreshFinalRequest() => create();
+  MoneroLiveRefreshFinalRequest._() : super();
+  factory MoneroLiveRefreshFinalRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroLiveRefreshFinalRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroLiveRefreshFinalRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroLiveRefreshFinalRequest clone() => MoneroLiveRefreshFinalRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroLiveRefreshFinalRequest copyWith(void Function(MoneroLiveRefreshFinalRequest) updates) => super.copyWith((message) => updates(message as MoneroLiveRefreshFinalRequest)) as MoneroLiveRefreshFinalRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroLiveRefreshFinalRequest create() => MoneroLiveRefreshFinalRequest._();
+  MoneroLiveRefreshFinalRequest createEmptyInstance() => create();
+  static $pb.PbList<MoneroLiveRefreshFinalRequest> createRepeated() => $pb.PbList<MoneroLiveRefreshFinalRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroLiveRefreshFinalRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroLiveRefreshFinalRequest>(create);
+  static MoneroLiveRefreshFinalRequest? _defaultInstance;
+}
+
+/// *
+///  Response: Response on termination of live refresh mode.
+///  @end
+class MoneroLiveRefreshFinalAck extends $pb.GeneratedMessage {
+  factory MoneroLiveRefreshFinalAck() => create();
+  MoneroLiveRefreshFinalAck._() : super();
+  factory MoneroLiveRefreshFinalAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MoneroLiveRefreshFinalAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MoneroLiveRefreshFinalAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MoneroLiveRefreshFinalAck clone() => MoneroLiveRefreshFinalAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MoneroLiveRefreshFinalAck copyWith(void Function(MoneroLiveRefreshFinalAck) updates) => super.copyWith((message) => updates(message as MoneroLiveRefreshFinalAck)) as MoneroLiveRefreshFinalAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MoneroLiveRefreshFinalAck create() => MoneroLiveRefreshFinalAck._();
+  MoneroLiveRefreshFinalAck createEmptyInstance() => create();
+  static $pb.PbList<MoneroLiveRefreshFinalAck> createRepeated() => $pb.PbList<MoneroLiveRefreshFinalAck>();
+  @$core.pragma('dart2js:noInline')
+  static MoneroLiveRefreshFinalAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MoneroLiveRefreshFinalAck>(create);
+  static MoneroLiveRefreshFinalAck? _defaultInstance;
+}
+
+/// *
+///  Request: Universal Monero protocol implementation diagnosis request.
+///  @start
+///  @next DebugMoneroDiagAck
+class DebugMoneroDiagRequest extends $pb.GeneratedMessage {
+  factory DebugMoneroDiagRequest({
+    $fixnum.Int64? ins,
+    $fixnum.Int64? p1,
+    $fixnum.Int64? p2,
+    $core.Iterable<$fixnum.Int64>? pd,
+    $core.List<$core.int>? data1,
+    $core.List<$core.int>? data2,
+  }) {
+    final $result = create();
+    if (ins != null) {
+      $result.ins = ins;
+    }
+    if (p1 != null) {
+      $result.p1 = p1;
+    }
+    if (p2 != null) {
+      $result.p2 = p2;
+    }
+    if (pd != null) {
+      $result.pd.addAll(pd);
+    }
+    if (data1 != null) {
+      $result.data1 = data1;
+    }
+    if (data2 != null) {
+      $result.data2 = data2;
+    }
+    return $result;
+  }
+  DebugMoneroDiagRequest._() : super();
+  factory DebugMoneroDiagRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugMoneroDiagRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugMoneroDiagRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'ins', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'p1', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'p2', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..p<$fixnum.Int64>(4, _omitFieldNames ? '' : 'pd', $pb.PbFieldType.PU6)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'data1', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'data2', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugMoneroDiagRequest clone() => DebugMoneroDiagRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugMoneroDiagRequest copyWith(void Function(DebugMoneroDiagRequest) updates) => super.copyWith((message) => updates(message as DebugMoneroDiagRequest)) as DebugMoneroDiagRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugMoneroDiagRequest create() => DebugMoneroDiagRequest._();
+  DebugMoneroDiagRequest createEmptyInstance() => create();
+  static $pb.PbList<DebugMoneroDiagRequest> createRepeated() => $pb.PbList<DebugMoneroDiagRequest>();
+  @$core.pragma('dart2js:noInline')
+  static DebugMoneroDiagRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugMoneroDiagRequest>(create);
+  static DebugMoneroDiagRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get ins => $_getI64(0);
+  @$pb.TagNumber(1)
+  set ins($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasIns() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearIns() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get p1 => $_getI64(1);
+  @$pb.TagNumber(2)
+  set p1($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasP1() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearP1() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get p2 => $_getI64(2);
+  @$pb.TagNumber(3)
+  set p2($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasP2() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearP2() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$fixnum.Int64> get pd => $_getList(3);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get data1 => $_getN(4);
+  @$pb.TagNumber(5)
+  set data1($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasData1() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearData1() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get data2 => $_getN(5);
+  @$pb.TagNumber(6)
+  set data2($core.List<$core.int> v) { $_setBytes(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasData2() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearData2() => clearField(6);
+}
+
+/// *
+///  Response: Response to Monero diagnosis protocol.
+///  @end
+class DebugMoneroDiagAck extends $pb.GeneratedMessage {
+  factory DebugMoneroDiagAck({
+    $fixnum.Int64? ins,
+    $fixnum.Int64? p1,
+    $fixnum.Int64? p2,
+    $core.Iterable<$fixnum.Int64>? pd,
+    $core.List<$core.int>? data1,
+    $core.List<$core.int>? data2,
+  }) {
+    final $result = create();
+    if (ins != null) {
+      $result.ins = ins;
+    }
+    if (p1 != null) {
+      $result.p1 = p1;
+    }
+    if (p2 != null) {
+      $result.p2 = p2;
+    }
+    if (pd != null) {
+      $result.pd.addAll(pd);
+    }
+    if (data1 != null) {
+      $result.data1 = data1;
+    }
+    if (data2 != null) {
+      $result.data2 = data2;
+    }
+    return $result;
+  }
+  DebugMoneroDiagAck._() : super();
+  factory DebugMoneroDiagAck.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DebugMoneroDiagAck.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DebugMoneroDiagAck', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.monero'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'ins', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'p1', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'p2', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..p<$fixnum.Int64>(4, _omitFieldNames ? '' : 'pd', $pb.PbFieldType.PU6)
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'data1', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'data2', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DebugMoneroDiagAck clone() => DebugMoneroDiagAck()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DebugMoneroDiagAck copyWith(void Function(DebugMoneroDiagAck) updates) => super.copyWith((message) => updates(message as DebugMoneroDiagAck)) as DebugMoneroDiagAck;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DebugMoneroDiagAck create() => DebugMoneroDiagAck._();
+  DebugMoneroDiagAck createEmptyInstance() => create();
+  static $pb.PbList<DebugMoneroDiagAck> createRepeated() => $pb.PbList<DebugMoneroDiagAck>();
+  @$core.pragma('dart2js:noInline')
+  static DebugMoneroDiagAck getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugMoneroDiagAck>(create);
+  static DebugMoneroDiagAck? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get ins => $_getI64(0);
+  @$pb.TagNumber(1)
+  set ins($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasIns() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearIns() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get p1 => $_getI64(1);
+  @$pb.TagNumber(2)
+  set p1($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasP1() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearP1() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get p2 => $_getI64(2);
+  @$pb.TagNumber(3)
+  set p2($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasP2() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearP2() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$fixnum.Int64> get pd => $_getList(3);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get data1 => $_getN(4);
+  @$pb.TagNumber(5)
+  set data1($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasData1() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearData1() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get data2 => $_getN(5);
+  @$pb.TagNumber(6)
+  set data2($core.List<$core.int> v) { $_setBytes(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasData2() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearData2() => clearField(6);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-monero.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-monero.pbenum.dart
@@ -1,0 +1,36 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-monero.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+class MoneroNetworkType extends $pb.ProtobufEnum {
+  static const MoneroNetworkType MAINNET = MoneroNetworkType._(0, _omitEnumNames ? '' : 'MAINNET');
+  static const MoneroNetworkType TESTNET = MoneroNetworkType._(1, _omitEnumNames ? '' : 'TESTNET');
+  static const MoneroNetworkType STAGENET = MoneroNetworkType._(2, _omitEnumNames ? '' : 'STAGENET');
+  static const MoneroNetworkType FAKECHAIN = MoneroNetworkType._(3, _omitEnumNames ? '' : 'FAKECHAIN');
+
+  static const $core.List<MoneroNetworkType> values = <MoneroNetworkType> [
+    MAINNET,
+    TESTNET,
+    STAGENET,
+    FAKECHAIN,
+  ];
+
+  static final $core.Map<$core.int, MoneroNetworkType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static MoneroNetworkType? valueOf($core.int value) => _byValue[value];
+
+  const MoneroNetworkType._($core.int v, $core.String n) : super(v, n);
+}
+
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-monero.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-monero.pbjson.dart
@@ -1,0 +1,797 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-monero.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use moneroNetworkTypeDescriptor instead')
+const MoneroNetworkType$json = {
+  '1': 'MoneroNetworkType',
+  '2': [
+    {'1': 'MAINNET', '2': 0},
+    {'1': 'TESTNET', '2': 1},
+    {'1': 'STAGENET', '2': 2},
+    {'1': 'FAKECHAIN', '2': 3},
+  ],
+};
+
+/// Descriptor for `MoneroNetworkType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List moneroNetworkTypeDescriptor = $convert.base64Decode(
+    'ChFNb25lcm9OZXR3b3JrVHlwZRILCgdNQUlOTkVUEAASCwoHVEVTVE5FVBABEgwKCFNUQUdFTk'
+    'VUEAISDQoJRkFLRUNIQUlOEAM=');
+
+@$core.Deprecated('Use moneroTransactionSourceEntryDescriptor instead')
+const MoneroTransactionSourceEntry$json = {
+  '1': 'MoneroTransactionSourceEntry',
+  '2': [
+    {'1': 'outputs', '3': 1, '4': 3, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionSourceEntry.MoneroOutputEntry', '10': 'outputs'},
+    {'1': 'real_output', '3': 2, '4': 1, '5': 4, '10': 'realOutput'},
+    {'1': 'real_out_tx_key', '3': 3, '4': 1, '5': 12, '10': 'realOutTxKey'},
+    {'1': 'real_out_additional_tx_keys', '3': 4, '4': 3, '5': 12, '10': 'realOutAdditionalTxKeys'},
+    {'1': 'real_output_in_tx_index', '3': 5, '4': 1, '5': 4, '10': 'realOutputInTxIndex'},
+    {'1': 'amount', '3': 6, '4': 1, '5': 4, '10': 'amount'},
+    {'1': 'rct', '3': 7, '4': 1, '5': 8, '10': 'rct'},
+    {'1': 'mask', '3': 8, '4': 1, '5': 12, '10': 'mask'},
+    {'1': 'multisig_kLRki', '3': 9, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionSourceEntry.MoneroMultisigKLRki', '10': 'multisigKLRki'},
+    {'1': 'subaddr_minor', '3': 10, '4': 1, '5': 13, '10': 'subaddrMinor'},
+  ],
+  '3': [MoneroTransactionSourceEntry_MoneroOutputEntry$json, MoneroTransactionSourceEntry_MoneroMultisigKLRki$json],
+};
+
+@$core.Deprecated('Use moneroTransactionSourceEntryDescriptor instead')
+const MoneroTransactionSourceEntry_MoneroOutputEntry$json = {
+  '1': 'MoneroOutputEntry',
+  '2': [
+    {'1': 'idx', '3': 1, '4': 1, '5': 4, '10': 'idx'},
+    {'1': 'key', '3': 2, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionSourceEntry.MoneroOutputEntry.MoneroRctKeyPublic', '10': 'key'},
+  ],
+  '3': [MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic$json],
+};
+
+@$core.Deprecated('Use moneroTransactionSourceEntryDescriptor instead')
+const MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic$json = {
+  '1': 'MoneroRctKeyPublic',
+  '2': [
+    {'1': 'dest', '3': 1, '4': 2, '5': 12, '10': 'dest'},
+    {'1': 'commitment', '3': 2, '4': 2, '5': 12, '10': 'commitment'},
+  ],
+};
+
+@$core.Deprecated('Use moneroTransactionSourceEntryDescriptor instead')
+const MoneroTransactionSourceEntry_MoneroMultisigKLRki$json = {
+  '1': 'MoneroMultisigKLRki',
+  '2': [
+    {'1': 'K', '3': 1, '4': 1, '5': 12, '10': 'K'},
+    {'1': 'L', '3': 2, '4': 1, '5': 12, '10': 'L'},
+    {'1': 'R', '3': 3, '4': 1, '5': 12, '10': 'R'},
+    {'1': 'ki', '3': 4, '4': 1, '5': 12, '10': 'ki'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionSourceEntry`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionSourceEntryDescriptor = $convert.base64Decode(
+    'ChxNb25lcm9UcmFuc2FjdGlvblNvdXJjZUVudHJ5EmMKB291dHB1dHMYASADKAsySS5ody50cm'
+    'V6b3IubWVzc2FnZXMubW9uZXJvLk1vbmVyb1RyYW5zYWN0aW9uU291cmNlRW50cnkuTW9uZXJv'
+    'T3V0cHV0RW50cnlSB291dHB1dHMSHwoLcmVhbF9vdXRwdXQYAiABKARSCnJlYWxPdXRwdXQSJQ'
+    'oPcmVhbF9vdXRfdHhfa2V5GAMgASgMUgxyZWFsT3V0VHhLZXkSPAobcmVhbF9vdXRfYWRkaXRp'
+    'b25hbF90eF9rZXlzGAQgAygMUhdyZWFsT3V0QWRkaXRpb25hbFR4S2V5cxI0ChdyZWFsX291dH'
+    'B1dF9pbl90eF9pbmRleBgFIAEoBFITcmVhbE91dHB1dEluVHhJbmRleBIWCgZhbW91bnQYBiAB'
+    'KARSBmFtb3VudBIQCgNyY3QYByABKAhSA3JjdBISCgRtYXNrGAggASgMUgRtYXNrEnIKDm11bH'
+    'Rpc2lnX2tMUmtpGAkgASgLMksuaHcudHJlem9yLm1lc3NhZ2VzLm1vbmVyby5Nb25lcm9UcmFu'
+    'c2FjdGlvblNvdXJjZUVudHJ5Lk1vbmVyb011bHRpc2lnS0xSa2lSDW11bHRpc2lnS0xSa2kSIw'
+    'oNc3ViYWRkcl9taW5vchgKIAEoDVIMc3ViYWRkck1pbm9yGt8BChFNb25lcm9PdXRwdXRFbnRy'
+    'eRIQCgNpZHgYASABKARSA2lkeBJuCgNrZXkYAiABKAsyXC5ody50cmV6b3IubWVzc2FnZXMubW'
+    '9uZXJvLk1vbmVyb1RyYW5zYWN0aW9uU291cmNlRW50cnkuTW9uZXJvT3V0cHV0RW50cnkuTW9u'
+    'ZXJvUmN0S2V5UHVibGljUgNrZXkaSAoSTW9uZXJvUmN0S2V5UHVibGljEhIKBGRlc3QYASACKA'
+    'xSBGRlc3QSHgoKY29tbWl0bWVudBgCIAIoDFIKY29tbWl0bWVudBpPChNNb25lcm9NdWx0aXNp'
+    'Z0tMUmtpEgwKAUsYASABKAxSAUsSDAoBTBgCIAEoDFIBTBIMCgFSGAMgASgMUgFSEg4KAmtpGA'
+    'QgASgMUgJraQ==');
+
+@$core.Deprecated('Use moneroTransactionDestinationEntryDescriptor instead')
+const MoneroTransactionDestinationEntry$json = {
+  '1': 'MoneroTransactionDestinationEntry',
+  '2': [
+    {'1': 'amount', '3': 1, '4': 1, '5': 4, '10': 'amount'},
+    {'1': 'addr', '3': 2, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionDestinationEntry.MoneroAccountPublicAddress', '10': 'addr'},
+    {'1': 'is_subaddress', '3': 3, '4': 1, '5': 8, '10': 'isSubaddress'},
+    {'1': 'original', '3': 4, '4': 1, '5': 12, '10': 'original'},
+    {'1': 'is_integrated', '3': 5, '4': 1, '5': 8, '10': 'isIntegrated'},
+  ],
+  '3': [MoneroTransactionDestinationEntry_MoneroAccountPublicAddress$json],
+};
+
+@$core.Deprecated('Use moneroTransactionDestinationEntryDescriptor instead')
+const MoneroTransactionDestinationEntry_MoneroAccountPublicAddress$json = {
+  '1': 'MoneroAccountPublicAddress',
+  '2': [
+    {'1': 'spend_public_key', '3': 1, '4': 1, '5': 12, '10': 'spendPublicKey'},
+    {'1': 'view_public_key', '3': 2, '4': 1, '5': 12, '10': 'viewPublicKey'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionDestinationEntry`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionDestinationEntryDescriptor = $convert.base64Decode(
+    'CiFNb25lcm9UcmFuc2FjdGlvbkRlc3RpbmF0aW9uRW50cnkSFgoGYW1vdW50GAEgASgEUgZhbW'
+    '91bnQSawoEYWRkchgCIAEoCzJXLmh3LnRyZXpvci5tZXNzYWdlcy5tb25lcm8uTW9uZXJvVHJh'
+    'bnNhY3Rpb25EZXN0aW5hdGlvbkVudHJ5Lk1vbmVyb0FjY291bnRQdWJsaWNBZGRyZXNzUgRhZG'
+    'RyEiMKDWlzX3N1YmFkZHJlc3MYAyABKAhSDGlzU3ViYWRkcmVzcxIaCghvcmlnaW5hbBgEIAEo'
+    'DFIIb3JpZ2luYWwSIwoNaXNfaW50ZWdyYXRlZBgFIAEoCFIMaXNJbnRlZ3JhdGVkGm4KGk1vbm'
+    'Vyb0FjY291bnRQdWJsaWNBZGRyZXNzEigKEHNwZW5kX3B1YmxpY19rZXkYASABKAxSDnNwZW5k'
+    'UHVibGljS2V5EiYKD3ZpZXdfcHVibGljX2tleRgCIAEoDFINdmlld1B1YmxpY0tleQ==');
+
+@$core.Deprecated('Use moneroTransactionRsigDataDescriptor instead')
+const MoneroTransactionRsigData$json = {
+  '1': 'MoneroTransactionRsigData',
+  '2': [
+    {'1': 'rsig_type', '3': 1, '4': 1, '5': 13, '10': 'rsigType'},
+    {'1': 'offload_type', '3': 2, '4': 1, '5': 13, '10': 'offloadType'},
+    {'1': 'grouping', '3': 3, '4': 3, '5': 4, '10': 'grouping'},
+    {'1': 'mask', '3': 4, '4': 1, '5': 12, '10': 'mask'},
+    {'1': 'rsig', '3': 5, '4': 1, '5': 12, '10': 'rsig'},
+    {'1': 'rsig_parts', '3': 6, '4': 3, '5': 12, '10': 'rsigParts'},
+    {'1': 'bp_version', '3': 7, '4': 1, '5': 13, '10': 'bpVersion'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionRsigData`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionRsigDataDescriptor = $convert.base64Decode(
+    'ChlNb25lcm9UcmFuc2FjdGlvblJzaWdEYXRhEhsKCXJzaWdfdHlwZRgBIAEoDVIIcnNpZ1R5cG'
+    'USIQoMb2ZmbG9hZF90eXBlGAIgASgNUgtvZmZsb2FkVHlwZRIaCghncm91cGluZxgDIAMoBFII'
+    'Z3JvdXBpbmcSEgoEbWFzaxgEIAEoDFIEbWFzaxISCgRyc2lnGAUgASgMUgRyc2lnEh0KCnJzaW'
+    'dfcGFydHMYBiADKAxSCXJzaWdQYXJ0cxIdCgpicF92ZXJzaW9uGAcgASgNUglicFZlcnNpb24=');
+
+@$core.Deprecated('Use moneroGetAddressDescriptor instead')
+const MoneroGetAddress$json = {
+  '1': 'MoneroGetAddress',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'show_display', '3': 2, '4': 1, '5': 8, '10': 'showDisplay'},
+    {'1': 'network_type', '3': 3, '4': 1, '5': 14, '6': '.hw.trezor.messages.monero.MoneroNetworkType', '7': 'MAINNET', '10': 'networkType'},
+    {'1': 'account', '3': 4, '4': 1, '5': 13, '10': 'account'},
+    {'1': 'minor', '3': 5, '4': 1, '5': 13, '10': 'minor'},
+    {'1': 'payment_id', '3': 6, '4': 1, '5': 12, '10': 'paymentId'},
+    {'1': 'chunkify', '3': 7, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `MoneroGetAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroGetAddressDescriptor = $convert.base64Decode(
+    'ChBNb25lcm9HZXRBZGRyZXNzEhsKCWFkZHJlc3NfbhgBIAMoDVIIYWRkcmVzc04SIQoMc2hvd1'
+    '9kaXNwbGF5GAIgASgIUgtzaG93RGlzcGxheRJYCgxuZXR3b3JrX3R5cGUYAyABKA4yLC5ody50'
+    'cmV6b3IubWVzc2FnZXMubW9uZXJvLk1vbmVyb05ldHdvcmtUeXBlOgdNQUlOTkVUUgtuZXR3b3'
+    'JrVHlwZRIYCgdhY2NvdW50GAQgASgNUgdhY2NvdW50EhQKBW1pbm9yGAUgASgNUgVtaW5vchId'
+    'CgpwYXltZW50X2lkGAYgASgMUglwYXltZW50SWQSGgoIY2h1bmtpZnkYByABKAhSCGNodW5raW'
+    'Z5');
+
+@$core.Deprecated('Use moneroAddressDescriptor instead')
+const MoneroAddress$json = {
+  '1': 'MoneroAddress',
+  '2': [
+    {'1': 'address', '3': 1, '4': 1, '5': 12, '10': 'address'},
+  ],
+};
+
+/// Descriptor for `MoneroAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroAddressDescriptor = $convert.base64Decode(
+    'Cg1Nb25lcm9BZGRyZXNzEhgKB2FkZHJlc3MYASABKAxSB2FkZHJlc3M=');
+
+@$core.Deprecated('Use moneroGetWatchKeyDescriptor instead')
+const MoneroGetWatchKey$json = {
+  '1': 'MoneroGetWatchKey',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'network_type', '3': 2, '4': 1, '5': 14, '6': '.hw.trezor.messages.monero.MoneroNetworkType', '7': 'MAINNET', '10': 'networkType'},
+  ],
+};
+
+/// Descriptor for `MoneroGetWatchKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroGetWatchKeyDescriptor = $convert.base64Decode(
+    'ChFNb25lcm9HZXRXYXRjaEtleRIbCglhZGRyZXNzX24YASADKA1SCGFkZHJlc3NOElgKDG5ldH'
+    'dvcmtfdHlwZRgCIAEoDjIsLmh3LnRyZXpvci5tZXNzYWdlcy5tb25lcm8uTW9uZXJvTmV0d29y'
+    'a1R5cGU6B01BSU5ORVRSC25ldHdvcmtUeXBl');
+
+@$core.Deprecated('Use moneroWatchKeyDescriptor instead')
+const MoneroWatchKey$json = {
+  '1': 'MoneroWatchKey',
+  '2': [
+    {'1': 'watch_key', '3': 1, '4': 1, '5': 12, '10': 'watchKey'},
+    {'1': 'address', '3': 2, '4': 1, '5': 12, '10': 'address'},
+  ],
+};
+
+/// Descriptor for `MoneroWatchKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroWatchKeyDescriptor = $convert.base64Decode(
+    'Cg5Nb25lcm9XYXRjaEtleRIbCgl3YXRjaF9rZXkYASABKAxSCHdhdGNoS2V5EhgKB2FkZHJlc3'
+    'MYAiABKAxSB2FkZHJlc3M=');
+
+@$core.Deprecated('Use moneroTransactionInitRequestDescriptor instead')
+const MoneroTransactionInitRequest$json = {
+  '1': 'MoneroTransactionInitRequest',
+  '2': [
+    {'1': 'version', '3': 1, '4': 1, '5': 13, '10': 'version'},
+    {'1': 'address_n', '3': 2, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'network_type', '3': 3, '4': 1, '5': 14, '6': '.hw.trezor.messages.monero.MoneroNetworkType', '7': 'MAINNET', '10': 'networkType'},
+    {'1': 'tsx_data', '3': 4, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionInitRequest.MoneroTransactionData', '10': 'tsxData'},
+  ],
+  '3': [MoneroTransactionInitRequest_MoneroTransactionData$json],
+};
+
+@$core.Deprecated('Use moneroTransactionInitRequestDescriptor instead')
+const MoneroTransactionInitRequest_MoneroTransactionData$json = {
+  '1': 'MoneroTransactionData',
+  '2': [
+    {'1': 'version', '3': 1, '4': 1, '5': 13, '10': 'version'},
+    {'1': 'payment_id', '3': 2, '4': 1, '5': 12, '10': 'paymentId'},
+    {'1': 'unlock_time', '3': 3, '4': 1, '5': 4, '10': 'unlockTime'},
+    {'1': 'outputs', '3': 4, '4': 3, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionDestinationEntry', '10': 'outputs'},
+    {'1': 'change_dts', '3': 5, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionDestinationEntry', '10': 'changeDts'},
+    {'1': 'num_inputs', '3': 6, '4': 1, '5': 13, '10': 'numInputs'},
+    {'1': 'mixin', '3': 7, '4': 1, '5': 13, '10': 'mixin'},
+    {'1': 'fee', '3': 8, '4': 1, '5': 4, '10': 'fee'},
+    {'1': 'account', '3': 9, '4': 1, '5': 13, '10': 'account'},
+    {'1': 'minor_indices', '3': 10, '4': 3, '5': 13, '10': 'minorIndices'},
+    {'1': 'rsig_data', '3': 11, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionRsigData', '10': 'rsigData'},
+    {'1': 'integrated_indices', '3': 12, '4': 3, '5': 13, '10': 'integratedIndices'},
+    {'1': 'client_version', '3': 13, '4': 1, '5': 13, '10': 'clientVersion'},
+    {'1': 'hard_fork', '3': 14, '4': 1, '5': 13, '10': 'hardFork'},
+    {'1': 'monero_version', '3': 15, '4': 1, '5': 12, '10': 'moneroVersion'},
+    {'1': 'chunkify', '3': 16, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionInitRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionInitRequestDescriptor = $convert.base64Decode(
+    'ChxNb25lcm9UcmFuc2FjdGlvbkluaXRSZXF1ZXN0EhgKB3ZlcnNpb24YASABKA1SB3ZlcnNpb2'
+    '4SGwoJYWRkcmVzc19uGAIgAygNUghhZGRyZXNzThJYCgxuZXR3b3JrX3R5cGUYAyABKA4yLC5o'
+    'dy50cmV6b3IubWVzc2FnZXMubW9uZXJvLk1vbmVyb05ldHdvcmtUeXBlOgdNQUlOTkVUUgtuZX'
+    'R3b3JrVHlwZRJoCgh0c3hfZGF0YRgEIAEoCzJNLmh3LnRyZXpvci5tZXNzYWdlcy5tb25lcm8u'
+    'TW9uZXJvVHJhbnNhY3Rpb25Jbml0UmVxdWVzdC5Nb25lcm9UcmFuc2FjdGlvbkRhdGFSB3RzeE'
+    'RhdGEatQUKFU1vbmVyb1RyYW5zYWN0aW9uRGF0YRIYCgd2ZXJzaW9uGAEgASgNUgd2ZXJzaW9u'
+    'Eh0KCnBheW1lbnRfaWQYAiABKAxSCXBheW1lbnRJZBIfCgt1bmxvY2tfdGltZRgDIAEoBFIKdW'
+    '5sb2NrVGltZRJWCgdvdXRwdXRzGAQgAygLMjwuaHcudHJlem9yLm1lc3NhZ2VzLm1vbmVyby5N'
+    'b25lcm9UcmFuc2FjdGlvbkRlc3RpbmF0aW9uRW50cnlSB291dHB1dHMSWwoKY2hhbmdlX2R0cx'
+    'gFIAEoCzI8Lmh3LnRyZXpvci5tZXNzYWdlcy5tb25lcm8uTW9uZXJvVHJhbnNhY3Rpb25EZXN0'
+    'aW5hdGlvbkVudHJ5UgljaGFuZ2VEdHMSHQoKbnVtX2lucHV0cxgGIAEoDVIJbnVtSW5wdXRzEh'
+    'QKBW1peGluGAcgASgNUgVtaXhpbhIQCgNmZWUYCCABKARSA2ZlZRIYCgdhY2NvdW50GAkgASgN'
+    'UgdhY2NvdW50EiMKDW1pbm9yX2luZGljZXMYCiADKA1SDG1pbm9ySW5kaWNlcxJRCglyc2lnX2'
+    'RhdGEYCyABKAsyNC5ody50cmV6b3IubWVzc2FnZXMubW9uZXJvLk1vbmVyb1RyYW5zYWN0aW9u'
+    'UnNpZ0RhdGFSCHJzaWdEYXRhEi0KEmludGVncmF0ZWRfaW5kaWNlcxgMIAMoDVIRaW50ZWdyYX'
+    'RlZEluZGljZXMSJQoOY2xpZW50X3ZlcnNpb24YDSABKA1SDWNsaWVudFZlcnNpb24SGwoJaGFy'
+    'ZF9mb3JrGA4gASgNUghoYXJkRm9yaxIlCg5tb25lcm9fdmVyc2lvbhgPIAEoDFINbW9uZXJvVm'
+    'Vyc2lvbhIaCghjaHVua2lmeRgQIAEoCFIIY2h1bmtpZnk=');
+
+@$core.Deprecated('Use moneroTransactionInitAckDescriptor instead')
+const MoneroTransactionInitAck$json = {
+  '1': 'MoneroTransactionInitAck',
+  '2': [
+    {'1': 'hmacs', '3': 1, '4': 3, '5': 12, '10': 'hmacs'},
+    {'1': 'rsig_data', '3': 2, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionRsigData', '10': 'rsigData'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionInitAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionInitAckDescriptor = $convert.base64Decode(
+    'ChhNb25lcm9UcmFuc2FjdGlvbkluaXRBY2sSFAoFaG1hY3MYASADKAxSBWhtYWNzElEKCXJzaW'
+    'dfZGF0YRgCIAEoCzI0Lmh3LnRyZXpvci5tZXNzYWdlcy5tb25lcm8uTW9uZXJvVHJhbnNhY3Rp'
+    'b25Sc2lnRGF0YVIIcnNpZ0RhdGE=');
+
+@$core.Deprecated('Use moneroTransactionSetInputRequestDescriptor instead')
+const MoneroTransactionSetInputRequest$json = {
+  '1': 'MoneroTransactionSetInputRequest',
+  '2': [
+    {'1': 'src_entr', '3': 1, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionSourceEntry', '10': 'srcEntr'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionSetInputRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionSetInputRequestDescriptor = $convert.base64Decode(
+    'CiBNb25lcm9UcmFuc2FjdGlvblNldElucHV0UmVxdWVzdBJSCghzcmNfZW50chgBIAEoCzI3Lm'
+    'h3LnRyZXpvci5tZXNzYWdlcy5tb25lcm8uTW9uZXJvVHJhbnNhY3Rpb25Tb3VyY2VFbnRyeVIH'
+    'c3JjRW50cg==');
+
+@$core.Deprecated('Use moneroTransactionSetInputAckDescriptor instead')
+const MoneroTransactionSetInputAck$json = {
+  '1': 'MoneroTransactionSetInputAck',
+  '2': [
+    {'1': 'vini', '3': 1, '4': 1, '5': 12, '10': 'vini'},
+    {'1': 'vini_hmac', '3': 2, '4': 1, '5': 12, '10': 'viniHmac'},
+    {'1': 'pseudo_out', '3': 3, '4': 1, '5': 12, '10': 'pseudoOut'},
+    {'1': 'pseudo_out_hmac', '3': 4, '4': 1, '5': 12, '10': 'pseudoOutHmac'},
+    {'1': 'pseudo_out_alpha', '3': 5, '4': 1, '5': 12, '10': 'pseudoOutAlpha'},
+    {'1': 'spend_key', '3': 6, '4': 1, '5': 12, '10': 'spendKey'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionSetInputAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionSetInputAckDescriptor = $convert.base64Decode(
+    'ChxNb25lcm9UcmFuc2FjdGlvblNldElucHV0QWNrEhIKBHZpbmkYASABKAxSBHZpbmkSGwoJdm'
+    'luaV9obWFjGAIgASgMUgh2aW5pSG1hYxIdCgpwc2V1ZG9fb3V0GAMgASgMUglwc2V1ZG9PdXQS'
+    'JgoPcHNldWRvX291dF9obWFjGAQgASgMUg1wc2V1ZG9PdXRIbWFjEigKEHBzZXVkb19vdXRfYW'
+    'xwaGEYBSABKAxSDnBzZXVkb091dEFscGhhEhsKCXNwZW5kX2tleRgGIAEoDFIIc3BlbmRLZXk=');
+
+@$core.Deprecated('Use moneroTransactionInputViniRequestDescriptor instead')
+const MoneroTransactionInputViniRequest$json = {
+  '1': 'MoneroTransactionInputViniRequest',
+  '2': [
+    {'1': 'src_entr', '3': 1, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionSourceEntry', '10': 'srcEntr'},
+    {'1': 'vini', '3': 2, '4': 1, '5': 12, '10': 'vini'},
+    {'1': 'vini_hmac', '3': 3, '4': 1, '5': 12, '10': 'viniHmac'},
+    {'1': 'pseudo_out', '3': 4, '4': 1, '5': 12, '10': 'pseudoOut'},
+    {'1': 'pseudo_out_hmac', '3': 5, '4': 1, '5': 12, '10': 'pseudoOutHmac'},
+    {'1': 'orig_idx', '3': 6, '4': 1, '5': 13, '10': 'origIdx'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionInputViniRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionInputViniRequestDescriptor = $convert.base64Decode(
+    'CiFNb25lcm9UcmFuc2FjdGlvbklucHV0VmluaVJlcXVlc3QSUgoIc3JjX2VudHIYASABKAsyNy'
+    '5ody50cmV6b3IubWVzc2FnZXMubW9uZXJvLk1vbmVyb1RyYW5zYWN0aW9uU291cmNlRW50cnlS'
+    'B3NyY0VudHISEgoEdmluaRgCIAEoDFIEdmluaRIbCgl2aW5pX2htYWMYAyABKAxSCHZpbmlIbW'
+    'FjEh0KCnBzZXVkb19vdXQYBCABKAxSCXBzZXVkb091dBImCg9wc2V1ZG9fb3V0X2htYWMYBSAB'
+    'KAxSDXBzZXVkb091dEhtYWMSGQoIb3JpZ19pZHgYBiABKA1SB29yaWdJZHg=');
+
+@$core.Deprecated('Use moneroTransactionInputViniAckDescriptor instead')
+const MoneroTransactionInputViniAck$json = {
+  '1': 'MoneroTransactionInputViniAck',
+};
+
+/// Descriptor for `MoneroTransactionInputViniAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionInputViniAckDescriptor = $convert.base64Decode(
+    'Ch1Nb25lcm9UcmFuc2FjdGlvbklucHV0VmluaUFjaw==');
+
+@$core.Deprecated('Use moneroTransactionAllInputsSetRequestDescriptor instead')
+const MoneroTransactionAllInputsSetRequest$json = {
+  '1': 'MoneroTransactionAllInputsSetRequest',
+};
+
+/// Descriptor for `MoneroTransactionAllInputsSetRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionAllInputsSetRequestDescriptor = $convert.base64Decode(
+    'CiRNb25lcm9UcmFuc2FjdGlvbkFsbElucHV0c1NldFJlcXVlc3Q=');
+
+@$core.Deprecated('Use moneroTransactionAllInputsSetAckDescriptor instead')
+const MoneroTransactionAllInputsSetAck$json = {
+  '1': 'MoneroTransactionAllInputsSetAck',
+  '2': [
+    {'1': 'rsig_data', '3': 1, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionRsigData', '10': 'rsigData'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionAllInputsSetAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionAllInputsSetAckDescriptor = $convert.base64Decode(
+    'CiBNb25lcm9UcmFuc2FjdGlvbkFsbElucHV0c1NldEFjaxJRCglyc2lnX2RhdGEYASABKAsyNC'
+    '5ody50cmV6b3IubWVzc2FnZXMubW9uZXJvLk1vbmVyb1RyYW5zYWN0aW9uUnNpZ0RhdGFSCHJz'
+    'aWdEYXRh');
+
+@$core.Deprecated('Use moneroTransactionSetOutputRequestDescriptor instead')
+const MoneroTransactionSetOutputRequest$json = {
+  '1': 'MoneroTransactionSetOutputRequest',
+  '2': [
+    {'1': 'dst_entr', '3': 1, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionDestinationEntry', '10': 'dstEntr'},
+    {'1': 'dst_entr_hmac', '3': 2, '4': 1, '5': 12, '10': 'dstEntrHmac'},
+    {'1': 'rsig_data', '3': 3, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionRsigData', '10': 'rsigData'},
+    {'1': 'is_offloaded_bp', '3': 4, '4': 1, '5': 8, '10': 'isOffloadedBp'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionSetOutputRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionSetOutputRequestDescriptor = $convert.base64Decode(
+    'CiFNb25lcm9UcmFuc2FjdGlvblNldE91dHB1dFJlcXVlc3QSVwoIZHN0X2VudHIYASABKAsyPC'
+    '5ody50cmV6b3IubWVzc2FnZXMubW9uZXJvLk1vbmVyb1RyYW5zYWN0aW9uRGVzdGluYXRpb25F'
+    'bnRyeVIHZHN0RW50chIiCg1kc3RfZW50cl9obWFjGAIgASgMUgtkc3RFbnRySG1hYxJRCglyc2'
+    'lnX2RhdGEYAyABKAsyNC5ody50cmV6b3IubWVzc2FnZXMubW9uZXJvLk1vbmVyb1RyYW5zYWN0'
+    'aW9uUnNpZ0RhdGFSCHJzaWdEYXRhEiYKD2lzX29mZmxvYWRlZF9icBgEIAEoCFINaXNPZmZsb2'
+    'FkZWRCcA==');
+
+@$core.Deprecated('Use moneroTransactionSetOutputAckDescriptor instead')
+const MoneroTransactionSetOutputAck$json = {
+  '1': 'MoneroTransactionSetOutputAck',
+  '2': [
+    {'1': 'tx_out', '3': 1, '4': 1, '5': 12, '10': 'txOut'},
+    {'1': 'vouti_hmac', '3': 2, '4': 1, '5': 12, '10': 'voutiHmac'},
+    {'1': 'rsig_data', '3': 3, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionRsigData', '10': 'rsigData'},
+    {'1': 'out_pk', '3': 4, '4': 1, '5': 12, '10': 'outPk'},
+    {'1': 'ecdh_info', '3': 5, '4': 1, '5': 12, '10': 'ecdhInfo'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionSetOutputAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionSetOutputAckDescriptor = $convert.base64Decode(
+    'Ch1Nb25lcm9UcmFuc2FjdGlvblNldE91dHB1dEFjaxIVCgZ0eF9vdXQYASABKAxSBXR4T3V0Eh'
+    '0KCnZvdXRpX2htYWMYAiABKAxSCXZvdXRpSG1hYxJRCglyc2lnX2RhdGEYAyABKAsyNC5ody50'
+    'cmV6b3IubWVzc2FnZXMubW9uZXJvLk1vbmVyb1RyYW5zYWN0aW9uUnNpZ0RhdGFSCHJzaWdEYX'
+    'RhEhUKBm91dF9waxgEIAEoDFIFb3V0UGsSGwoJZWNkaF9pbmZvGAUgASgMUghlY2RoSW5mbw==');
+
+@$core.Deprecated('Use moneroTransactionAllOutSetRequestDescriptor instead')
+const MoneroTransactionAllOutSetRequest$json = {
+  '1': 'MoneroTransactionAllOutSetRequest',
+  '2': [
+    {'1': 'rsig_data', '3': 1, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionRsigData', '10': 'rsigData'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionAllOutSetRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionAllOutSetRequestDescriptor = $convert.base64Decode(
+    'CiFNb25lcm9UcmFuc2FjdGlvbkFsbE91dFNldFJlcXVlc3QSUQoJcnNpZ19kYXRhGAEgASgLMj'
+    'QuaHcudHJlem9yLm1lc3NhZ2VzLm1vbmVyby5Nb25lcm9UcmFuc2FjdGlvblJzaWdEYXRhUghy'
+    'c2lnRGF0YQ==');
+
+@$core.Deprecated('Use moneroTransactionAllOutSetAckDescriptor instead')
+const MoneroTransactionAllOutSetAck$json = {
+  '1': 'MoneroTransactionAllOutSetAck',
+  '2': [
+    {'1': 'extra', '3': 1, '4': 1, '5': 12, '10': 'extra'},
+    {'1': 'tx_prefix_hash', '3': 2, '4': 1, '5': 12, '10': 'txPrefixHash'},
+    {'1': 'rv', '3': 4, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionAllOutSetAck.MoneroRingCtSig', '10': 'rv'},
+    {'1': 'full_message_hash', '3': 5, '4': 1, '5': 12, '10': 'fullMessageHash'},
+  ],
+  '3': [MoneroTransactionAllOutSetAck_MoneroRingCtSig$json],
+};
+
+@$core.Deprecated('Use moneroTransactionAllOutSetAckDescriptor instead')
+const MoneroTransactionAllOutSetAck_MoneroRingCtSig$json = {
+  '1': 'MoneroRingCtSig',
+  '2': [
+    {'1': 'txn_fee', '3': 1, '4': 1, '5': 4, '10': 'txnFee'},
+    {'1': 'message', '3': 2, '4': 1, '5': 12, '10': 'message'},
+    {'1': 'rv_type', '3': 3, '4': 1, '5': 13, '10': 'rvType'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionAllOutSetAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionAllOutSetAckDescriptor = $convert.base64Decode(
+    'Ch1Nb25lcm9UcmFuc2FjdGlvbkFsbE91dFNldEFjaxIUCgVleHRyYRgBIAEoDFIFZXh0cmESJA'
+    'oOdHhfcHJlZml4X2hhc2gYAiABKAxSDHR4UHJlZml4SGFzaBJYCgJydhgEIAEoCzJILmh3LnRy'
+    'ZXpvci5tZXNzYWdlcy5tb25lcm8uTW9uZXJvVHJhbnNhY3Rpb25BbGxPdXRTZXRBY2suTW9uZX'
+    'JvUmluZ0N0U2lnUgJydhIqChFmdWxsX21lc3NhZ2VfaGFzaBgFIAEoDFIPZnVsbE1lc3NhZ2VI'
+    'YXNoGl0KD01vbmVyb1JpbmdDdFNpZxIXCgd0eG5fZmVlGAEgASgEUgZ0eG5GZWUSGAoHbWVzc2'
+    'FnZRgCIAEoDFIHbWVzc2FnZRIXCgdydl90eXBlGAMgASgNUgZydlR5cGU=');
+
+@$core.Deprecated('Use moneroTransactionSignInputRequestDescriptor instead')
+const MoneroTransactionSignInputRequest$json = {
+  '1': 'MoneroTransactionSignInputRequest',
+  '2': [
+    {'1': 'src_entr', '3': 1, '4': 1, '5': 11, '6': '.hw.trezor.messages.monero.MoneroTransactionSourceEntry', '10': 'srcEntr'},
+    {'1': 'vini', '3': 2, '4': 1, '5': 12, '10': 'vini'},
+    {'1': 'vini_hmac', '3': 3, '4': 1, '5': 12, '10': 'viniHmac'},
+    {'1': 'pseudo_out', '3': 4, '4': 1, '5': 12, '10': 'pseudoOut'},
+    {'1': 'pseudo_out_hmac', '3': 5, '4': 1, '5': 12, '10': 'pseudoOutHmac'},
+    {'1': 'pseudo_out_alpha', '3': 6, '4': 1, '5': 12, '10': 'pseudoOutAlpha'},
+    {'1': 'spend_key', '3': 7, '4': 1, '5': 12, '10': 'spendKey'},
+    {'1': 'orig_idx', '3': 8, '4': 1, '5': 13, '10': 'origIdx'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionSignInputRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionSignInputRequestDescriptor = $convert.base64Decode(
+    'CiFNb25lcm9UcmFuc2FjdGlvblNpZ25JbnB1dFJlcXVlc3QSUgoIc3JjX2VudHIYASABKAsyNy'
+    '5ody50cmV6b3IubWVzc2FnZXMubW9uZXJvLk1vbmVyb1RyYW5zYWN0aW9uU291cmNlRW50cnlS'
+    'B3NyY0VudHISEgoEdmluaRgCIAEoDFIEdmluaRIbCgl2aW5pX2htYWMYAyABKAxSCHZpbmlIbW'
+    'FjEh0KCnBzZXVkb19vdXQYBCABKAxSCXBzZXVkb091dBImCg9wc2V1ZG9fb3V0X2htYWMYBSAB'
+    'KAxSDXBzZXVkb091dEhtYWMSKAoQcHNldWRvX291dF9hbHBoYRgGIAEoDFIOcHNldWRvT3V0QW'
+    'xwaGESGwoJc3BlbmRfa2V5GAcgASgMUghzcGVuZEtleRIZCghvcmlnX2lkeBgIIAEoDVIHb3Jp'
+    'Z0lkeA==');
+
+@$core.Deprecated('Use moneroTransactionSignInputAckDescriptor instead')
+const MoneroTransactionSignInputAck$json = {
+  '1': 'MoneroTransactionSignInputAck',
+  '2': [
+    {'1': 'signature', '3': 1, '4': 1, '5': 12, '10': 'signature'},
+    {'1': 'pseudo_out', '3': 2, '4': 1, '5': 12, '10': 'pseudoOut'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionSignInputAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionSignInputAckDescriptor = $convert.base64Decode(
+    'Ch1Nb25lcm9UcmFuc2FjdGlvblNpZ25JbnB1dEFjaxIcCglzaWduYXR1cmUYASABKAxSCXNpZ2'
+    '5hdHVyZRIdCgpwc2V1ZG9fb3V0GAIgASgMUglwc2V1ZG9PdXQ=');
+
+@$core.Deprecated('Use moneroTransactionFinalRequestDescriptor instead')
+const MoneroTransactionFinalRequest$json = {
+  '1': 'MoneroTransactionFinalRequest',
+};
+
+/// Descriptor for `MoneroTransactionFinalRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionFinalRequestDescriptor = $convert.base64Decode(
+    'Ch1Nb25lcm9UcmFuc2FjdGlvbkZpbmFsUmVxdWVzdA==');
+
+@$core.Deprecated('Use moneroTransactionFinalAckDescriptor instead')
+const MoneroTransactionFinalAck$json = {
+  '1': 'MoneroTransactionFinalAck',
+  '2': [
+    {'1': 'cout_key', '3': 1, '4': 1, '5': 12, '10': 'coutKey'},
+    {'1': 'salt', '3': 2, '4': 1, '5': 12, '10': 'salt'},
+    {'1': 'rand_mult', '3': 3, '4': 1, '5': 12, '10': 'randMult'},
+    {'1': 'tx_enc_keys', '3': 4, '4': 1, '5': 12, '10': 'txEncKeys'},
+    {'1': 'opening_key', '3': 5, '4': 1, '5': 12, '10': 'openingKey'},
+  ],
+};
+
+/// Descriptor for `MoneroTransactionFinalAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroTransactionFinalAckDescriptor = $convert.base64Decode(
+    'ChlNb25lcm9UcmFuc2FjdGlvbkZpbmFsQWNrEhkKCGNvdXRfa2V5GAEgASgMUgdjb3V0S2V5Eh'
+    'IKBHNhbHQYAiABKAxSBHNhbHQSGwoJcmFuZF9tdWx0GAMgASgMUghyYW5kTXVsdBIeCgt0eF9l'
+    'bmNfa2V5cxgEIAEoDFIJdHhFbmNLZXlzEh8KC29wZW5pbmdfa2V5GAUgASgMUgpvcGVuaW5nS2'
+    'V5');
+
+@$core.Deprecated('Use moneroKeyImageExportInitRequestDescriptor instead')
+const MoneroKeyImageExportInitRequest$json = {
+  '1': 'MoneroKeyImageExportInitRequest',
+  '2': [
+    {'1': 'num', '3': 1, '4': 2, '5': 4, '10': 'num'},
+    {'1': 'hash', '3': 2, '4': 2, '5': 12, '10': 'hash'},
+    {'1': 'address_n', '3': 3, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'network_type', '3': 4, '4': 1, '5': 14, '6': '.hw.trezor.messages.monero.MoneroNetworkType', '7': 'MAINNET', '10': 'networkType'},
+    {'1': 'subs', '3': 5, '4': 3, '5': 11, '6': '.hw.trezor.messages.monero.MoneroKeyImageExportInitRequest.MoneroSubAddressIndicesList', '10': 'subs'},
+  ],
+  '3': [MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList$json],
+};
+
+@$core.Deprecated('Use moneroKeyImageExportInitRequestDescriptor instead')
+const MoneroKeyImageExportInitRequest_MoneroSubAddressIndicesList$json = {
+  '1': 'MoneroSubAddressIndicesList',
+  '2': [
+    {'1': 'account', '3': 1, '4': 2, '5': 13, '10': 'account'},
+    {'1': 'minor_indices', '3': 2, '4': 3, '5': 13, '10': 'minorIndices'},
+  ],
+};
+
+/// Descriptor for `MoneroKeyImageExportInitRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroKeyImageExportInitRequestDescriptor = $convert.base64Decode(
+    'Ch9Nb25lcm9LZXlJbWFnZUV4cG9ydEluaXRSZXF1ZXN0EhAKA251bRgBIAIoBFIDbnVtEhIKBG'
+    'hhc2gYAiACKAxSBGhhc2gSGwoJYWRkcmVzc19uGAMgAygNUghhZGRyZXNzThJYCgxuZXR3b3Jr'
+    'X3R5cGUYBCABKA4yLC5ody50cmV6b3IubWVzc2FnZXMubW9uZXJvLk1vbmVyb05ldHdvcmtUeX'
+    'BlOgdNQUlOTkVUUgtuZXR3b3JrVHlwZRJqCgRzdWJzGAUgAygLMlYuaHcudHJlem9yLm1lc3Nh'
+    'Z2VzLm1vbmVyby5Nb25lcm9LZXlJbWFnZUV4cG9ydEluaXRSZXF1ZXN0Lk1vbmVyb1N1YkFkZH'
+    'Jlc3NJbmRpY2VzTGlzdFIEc3VicxpcChtNb25lcm9TdWJBZGRyZXNzSW5kaWNlc0xpc3QSGAoH'
+    'YWNjb3VudBgBIAIoDVIHYWNjb3VudBIjCg1taW5vcl9pbmRpY2VzGAIgAygNUgxtaW5vckluZG'
+    'ljZXM=');
+
+@$core.Deprecated('Use moneroKeyImageExportInitAckDescriptor instead')
+const MoneroKeyImageExportInitAck$json = {
+  '1': 'MoneroKeyImageExportInitAck',
+};
+
+/// Descriptor for `MoneroKeyImageExportInitAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroKeyImageExportInitAckDescriptor = $convert.base64Decode(
+    'ChtNb25lcm9LZXlJbWFnZUV4cG9ydEluaXRBY2s=');
+
+@$core.Deprecated('Use moneroKeyImageSyncStepRequestDescriptor instead')
+const MoneroKeyImageSyncStepRequest$json = {
+  '1': 'MoneroKeyImageSyncStepRequest',
+  '2': [
+    {'1': 'tdis', '3': 1, '4': 3, '5': 11, '6': '.hw.trezor.messages.monero.MoneroKeyImageSyncStepRequest.MoneroTransferDetails', '10': 'tdis'},
+  ],
+  '3': [MoneroKeyImageSyncStepRequest_MoneroTransferDetails$json],
+};
+
+@$core.Deprecated('Use moneroKeyImageSyncStepRequestDescriptor instead')
+const MoneroKeyImageSyncStepRequest_MoneroTransferDetails$json = {
+  '1': 'MoneroTransferDetails',
+  '2': [
+    {'1': 'out_key', '3': 1, '4': 2, '5': 12, '10': 'outKey'},
+    {'1': 'tx_pub_key', '3': 2, '4': 2, '5': 12, '10': 'txPubKey'},
+    {'1': 'additional_tx_pub_keys', '3': 3, '4': 3, '5': 12, '10': 'additionalTxPubKeys'},
+    {'1': 'internal_output_index', '3': 4, '4': 2, '5': 4, '10': 'internalOutputIndex'},
+    {'1': 'sub_addr_major', '3': 5, '4': 1, '5': 13, '10': 'subAddrMajor'},
+    {'1': 'sub_addr_minor', '3': 6, '4': 1, '5': 13, '10': 'subAddrMinor'},
+  ],
+};
+
+/// Descriptor for `MoneroKeyImageSyncStepRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroKeyImageSyncStepRequestDescriptor = $convert.base64Decode(
+    'Ch1Nb25lcm9LZXlJbWFnZVN5bmNTdGVwUmVxdWVzdBJiCgR0ZGlzGAEgAygLMk4uaHcudHJlem'
+    '9yLm1lc3NhZ2VzLm1vbmVyby5Nb25lcm9LZXlJbWFnZVN5bmNTdGVwUmVxdWVzdC5Nb25lcm9U'
+    'cmFuc2ZlckRldGFpbHNSBHRkaXMagwIKFU1vbmVyb1RyYW5zZmVyRGV0YWlscxIXCgdvdXRfa2'
+    'V5GAEgAigMUgZvdXRLZXkSHAoKdHhfcHViX2tleRgCIAIoDFIIdHhQdWJLZXkSMwoWYWRkaXRp'
+    'b25hbF90eF9wdWJfa2V5cxgDIAMoDFITYWRkaXRpb25hbFR4UHViS2V5cxIyChVpbnRlcm5hbF'
+    '9vdXRwdXRfaW5kZXgYBCACKARSE2ludGVybmFsT3V0cHV0SW5kZXgSJAoOc3ViX2FkZHJfbWFq'
+    'b3IYBSABKA1SDHN1YkFkZHJNYWpvchIkCg5zdWJfYWRkcl9taW5vchgGIAEoDVIMc3ViQWRkck'
+    '1pbm9y');
+
+@$core.Deprecated('Use moneroKeyImageSyncStepAckDescriptor instead')
+const MoneroKeyImageSyncStepAck$json = {
+  '1': 'MoneroKeyImageSyncStepAck',
+  '2': [
+    {'1': 'kis', '3': 1, '4': 3, '5': 11, '6': '.hw.trezor.messages.monero.MoneroKeyImageSyncStepAck.MoneroExportedKeyImage', '10': 'kis'},
+  ],
+  '3': [MoneroKeyImageSyncStepAck_MoneroExportedKeyImage$json],
+};
+
+@$core.Deprecated('Use moneroKeyImageSyncStepAckDescriptor instead')
+const MoneroKeyImageSyncStepAck_MoneroExportedKeyImage$json = {
+  '1': 'MoneroExportedKeyImage',
+  '2': [
+    {'1': 'iv', '3': 1, '4': 1, '5': 12, '10': 'iv'},
+    {'1': 'blob', '3': 3, '4': 1, '5': 12, '10': 'blob'},
+  ],
+};
+
+/// Descriptor for `MoneroKeyImageSyncStepAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroKeyImageSyncStepAckDescriptor = $convert.base64Decode(
+    'ChlNb25lcm9LZXlJbWFnZVN5bmNTdGVwQWNrEl0KA2tpcxgBIAMoCzJLLmh3LnRyZXpvci5tZX'
+    'NzYWdlcy5tb25lcm8uTW9uZXJvS2V5SW1hZ2VTeW5jU3RlcEFjay5Nb25lcm9FeHBvcnRlZEtl'
+    'eUltYWdlUgNraXMaPAoWTW9uZXJvRXhwb3J0ZWRLZXlJbWFnZRIOCgJpdhgBIAEoDFICaXYSEg'
+    'oEYmxvYhgDIAEoDFIEYmxvYg==');
+
+@$core.Deprecated('Use moneroKeyImageSyncFinalRequestDescriptor instead')
+const MoneroKeyImageSyncFinalRequest$json = {
+  '1': 'MoneroKeyImageSyncFinalRequest',
+};
+
+/// Descriptor for `MoneroKeyImageSyncFinalRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroKeyImageSyncFinalRequestDescriptor = $convert.base64Decode(
+    'Ch5Nb25lcm9LZXlJbWFnZVN5bmNGaW5hbFJlcXVlc3Q=');
+
+@$core.Deprecated('Use moneroKeyImageSyncFinalAckDescriptor instead')
+const MoneroKeyImageSyncFinalAck$json = {
+  '1': 'MoneroKeyImageSyncFinalAck',
+  '2': [
+    {'1': 'enc_key', '3': 1, '4': 1, '5': 12, '10': 'encKey'},
+  ],
+};
+
+/// Descriptor for `MoneroKeyImageSyncFinalAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroKeyImageSyncFinalAckDescriptor = $convert.base64Decode(
+    'ChpNb25lcm9LZXlJbWFnZVN5bmNGaW5hbEFjaxIXCgdlbmNfa2V5GAEgASgMUgZlbmNLZXk=');
+
+@$core.Deprecated('Use moneroGetTxKeyRequestDescriptor instead')
+const MoneroGetTxKeyRequest$json = {
+  '1': 'MoneroGetTxKeyRequest',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'network_type', '3': 2, '4': 1, '5': 14, '6': '.hw.trezor.messages.monero.MoneroNetworkType', '7': 'MAINNET', '10': 'networkType'},
+    {'1': 'salt1', '3': 3, '4': 2, '5': 12, '10': 'salt1'},
+    {'1': 'salt2', '3': 4, '4': 2, '5': 12, '10': 'salt2'},
+    {'1': 'tx_enc_keys', '3': 5, '4': 2, '5': 12, '10': 'txEncKeys'},
+    {'1': 'tx_prefix_hash', '3': 6, '4': 2, '5': 12, '10': 'txPrefixHash'},
+    {'1': 'reason', '3': 7, '4': 1, '5': 13, '10': 'reason'},
+    {'1': 'view_public_key', '3': 8, '4': 1, '5': 12, '10': 'viewPublicKey'},
+  ],
+};
+
+/// Descriptor for `MoneroGetTxKeyRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroGetTxKeyRequestDescriptor = $convert.base64Decode(
+    'ChVNb25lcm9HZXRUeEtleVJlcXVlc3QSGwoJYWRkcmVzc19uGAEgAygNUghhZGRyZXNzThJYCg'
+    'xuZXR3b3JrX3R5cGUYAiABKA4yLC5ody50cmV6b3IubWVzc2FnZXMubW9uZXJvLk1vbmVyb05l'
+    'dHdvcmtUeXBlOgdNQUlOTkVUUgtuZXR3b3JrVHlwZRIUCgVzYWx0MRgDIAIoDFIFc2FsdDESFA'
+    'oFc2FsdDIYBCACKAxSBXNhbHQyEh4KC3R4X2VuY19rZXlzGAUgAigMUgl0eEVuY0tleXMSJAoO'
+    'dHhfcHJlZml4X2hhc2gYBiACKAxSDHR4UHJlZml4SGFzaBIWCgZyZWFzb24YByABKA1SBnJlYX'
+    'NvbhImCg92aWV3X3B1YmxpY19rZXkYCCABKAxSDXZpZXdQdWJsaWNLZXk=');
+
+@$core.Deprecated('Use moneroGetTxKeyAckDescriptor instead')
+const MoneroGetTxKeyAck$json = {
+  '1': 'MoneroGetTxKeyAck',
+  '2': [
+    {'1': 'salt', '3': 1, '4': 1, '5': 12, '10': 'salt'},
+    {'1': 'tx_keys', '3': 2, '4': 1, '5': 12, '10': 'txKeys'},
+    {'1': 'tx_derivations', '3': 3, '4': 1, '5': 12, '10': 'txDerivations'},
+  ],
+};
+
+/// Descriptor for `MoneroGetTxKeyAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroGetTxKeyAckDescriptor = $convert.base64Decode(
+    'ChFNb25lcm9HZXRUeEtleUFjaxISCgRzYWx0GAEgASgMUgRzYWx0EhcKB3R4X2tleXMYAiABKA'
+    'xSBnR4S2V5cxIlCg50eF9kZXJpdmF0aW9ucxgDIAEoDFINdHhEZXJpdmF0aW9ucw==');
+
+@$core.Deprecated('Use moneroLiveRefreshStartRequestDescriptor instead')
+const MoneroLiveRefreshStartRequest$json = {
+  '1': 'MoneroLiveRefreshStartRequest',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'network_type', '3': 2, '4': 1, '5': 14, '6': '.hw.trezor.messages.monero.MoneroNetworkType', '7': 'MAINNET', '10': 'networkType'},
+  ],
+};
+
+/// Descriptor for `MoneroLiveRefreshStartRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroLiveRefreshStartRequestDescriptor = $convert.base64Decode(
+    'Ch1Nb25lcm9MaXZlUmVmcmVzaFN0YXJ0UmVxdWVzdBIbCglhZGRyZXNzX24YASADKA1SCGFkZH'
+    'Jlc3NOElgKDG5ldHdvcmtfdHlwZRgCIAEoDjIsLmh3LnRyZXpvci5tZXNzYWdlcy5tb25lcm8u'
+    'TW9uZXJvTmV0d29ya1R5cGU6B01BSU5ORVRSC25ldHdvcmtUeXBl');
+
+@$core.Deprecated('Use moneroLiveRefreshStartAckDescriptor instead')
+const MoneroLiveRefreshStartAck$json = {
+  '1': 'MoneroLiveRefreshStartAck',
+};
+
+/// Descriptor for `MoneroLiveRefreshStartAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroLiveRefreshStartAckDescriptor = $convert.base64Decode(
+    'ChlNb25lcm9MaXZlUmVmcmVzaFN0YXJ0QWNr');
+
+@$core.Deprecated('Use moneroLiveRefreshStepRequestDescriptor instead')
+const MoneroLiveRefreshStepRequest$json = {
+  '1': 'MoneroLiveRefreshStepRequest',
+  '2': [
+    {'1': 'out_key', '3': 1, '4': 2, '5': 12, '10': 'outKey'},
+    {'1': 'recv_deriv', '3': 2, '4': 2, '5': 12, '10': 'recvDeriv'},
+    {'1': 'real_out_idx', '3': 3, '4': 2, '5': 4, '10': 'realOutIdx'},
+    {'1': 'sub_addr_major', '3': 4, '4': 2, '5': 13, '10': 'subAddrMajor'},
+    {'1': 'sub_addr_minor', '3': 5, '4': 2, '5': 13, '10': 'subAddrMinor'},
+  ],
+};
+
+/// Descriptor for `MoneroLiveRefreshStepRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroLiveRefreshStepRequestDescriptor = $convert.base64Decode(
+    'ChxNb25lcm9MaXZlUmVmcmVzaFN0ZXBSZXF1ZXN0EhcKB291dF9rZXkYASACKAxSBm91dEtleR'
+    'IdCgpyZWN2X2Rlcml2GAIgAigMUglyZWN2RGVyaXYSIAoMcmVhbF9vdXRfaWR4GAMgAigEUgpy'
+    'ZWFsT3V0SWR4EiQKDnN1Yl9hZGRyX21ham9yGAQgAigNUgxzdWJBZGRyTWFqb3ISJAoOc3ViX2'
+    'FkZHJfbWlub3IYBSACKA1SDHN1YkFkZHJNaW5vcg==');
+
+@$core.Deprecated('Use moneroLiveRefreshStepAckDescriptor instead')
+const MoneroLiveRefreshStepAck$json = {
+  '1': 'MoneroLiveRefreshStepAck',
+  '2': [
+    {'1': 'salt', '3': 1, '4': 1, '5': 12, '10': 'salt'},
+    {'1': 'key_image', '3': 2, '4': 1, '5': 12, '10': 'keyImage'},
+  ],
+};
+
+/// Descriptor for `MoneroLiveRefreshStepAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroLiveRefreshStepAckDescriptor = $convert.base64Decode(
+    'ChhNb25lcm9MaXZlUmVmcmVzaFN0ZXBBY2sSEgoEc2FsdBgBIAEoDFIEc2FsdBIbCglrZXlfaW'
+    '1hZ2UYAiABKAxSCGtleUltYWdl');
+
+@$core.Deprecated('Use moneroLiveRefreshFinalRequestDescriptor instead')
+const MoneroLiveRefreshFinalRequest$json = {
+  '1': 'MoneroLiveRefreshFinalRequest',
+};
+
+/// Descriptor for `MoneroLiveRefreshFinalRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroLiveRefreshFinalRequestDescriptor = $convert.base64Decode(
+    'Ch1Nb25lcm9MaXZlUmVmcmVzaEZpbmFsUmVxdWVzdA==');
+
+@$core.Deprecated('Use moneroLiveRefreshFinalAckDescriptor instead')
+const MoneroLiveRefreshFinalAck$json = {
+  '1': 'MoneroLiveRefreshFinalAck',
+};
+
+/// Descriptor for `MoneroLiveRefreshFinalAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List moneroLiveRefreshFinalAckDescriptor = $convert.base64Decode(
+    'ChlNb25lcm9MaXZlUmVmcmVzaEZpbmFsQWNr');
+
+@$core.Deprecated('Use debugMoneroDiagRequestDescriptor instead')
+const DebugMoneroDiagRequest$json = {
+  '1': 'DebugMoneroDiagRequest',
+  '2': [
+    {'1': 'ins', '3': 1, '4': 1, '5': 4, '10': 'ins'},
+    {'1': 'p1', '3': 2, '4': 1, '5': 4, '10': 'p1'},
+    {'1': 'p2', '3': 3, '4': 1, '5': 4, '10': 'p2'},
+    {'1': 'pd', '3': 4, '4': 3, '5': 4, '10': 'pd'},
+    {'1': 'data1', '3': 5, '4': 1, '5': 12, '10': 'data1'},
+    {'1': 'data2', '3': 6, '4': 1, '5': 12, '10': 'data2'},
+  ],
+};
+
+/// Descriptor for `DebugMoneroDiagRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugMoneroDiagRequestDescriptor = $convert.base64Decode(
+    'ChZEZWJ1Z01vbmVyb0RpYWdSZXF1ZXN0EhAKA2lucxgBIAEoBFIDaW5zEg4KAnAxGAIgASgEUg'
+    'JwMRIOCgJwMhgDIAEoBFICcDISDgoCcGQYBCADKARSAnBkEhQKBWRhdGExGAUgASgMUgVkYXRh'
+    'MRIUCgVkYXRhMhgGIAEoDFIFZGF0YTI=');
+
+@$core.Deprecated('Use debugMoneroDiagAckDescriptor instead')
+const DebugMoneroDiagAck$json = {
+  '1': 'DebugMoneroDiagAck',
+  '2': [
+    {'1': 'ins', '3': 1, '4': 1, '5': 4, '10': 'ins'},
+    {'1': 'p1', '3': 2, '4': 1, '5': 4, '10': 'p1'},
+    {'1': 'p2', '3': 3, '4': 1, '5': 4, '10': 'p2'},
+    {'1': 'pd', '3': 4, '4': 3, '5': 4, '10': 'pd'},
+    {'1': 'data1', '3': 5, '4': 1, '5': 12, '10': 'data1'},
+    {'1': 'data2', '3': 6, '4': 1, '5': 12, '10': 'data2'},
+  ],
+};
+
+/// Descriptor for `DebugMoneroDiagAck`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List debugMoneroDiagAckDescriptor = $convert.base64Decode(
+    'ChJEZWJ1Z01vbmVyb0RpYWdBY2sSEAoDaW5zGAEgASgEUgNpbnMSDgoCcDEYAiABKARSAnAxEg'
+    '4KAnAyGAMgASgEUgJwMhIOCgJwZBgEIAMoBFICcGQSFAoFZGF0YTEYBSABKAxSBWRhdGExEhQK'
+    'BWRhdGEyGAYgASgMUgVkYXRhMg==');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-monero.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-monero.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-monero.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-monero.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-nem.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-nem.pb.dart
@@ -1,0 +1,1563 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-nem.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'messages-nem.pbenum.dart';
+
+export 'messages-nem.pbenum.dart';
+
+/// *
+///  Request: Ask device for NEM address corresponding to address_n path
+///  @start
+///  @next NEMAddress
+///  @next Failure
+class NEMGetAddress extends $pb.GeneratedMessage {
+  factory NEMGetAddress({
+    $core.Iterable<$core.int>? addressN,
+    $core.int? network,
+    $core.bool? showDisplay,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (network != null) {
+      $result.network = network;
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  NEMGetAddress._() : super();
+  factory NEMGetAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMGetAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMGetAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'network', $pb.PbFieldType.OU3, defaultOrMaker: 104)
+    ..aOB(3, _omitFieldNames ? '' : 'showDisplay')
+    ..aOB(4, _omitFieldNames ? '' : 'chunkify')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMGetAddress clone() => NEMGetAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMGetAddress copyWith(void Function(NEMGetAddress) updates) => super.copyWith((message) => updates(message as NEMGetAddress)) as NEMGetAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMGetAddress create() => NEMGetAddress._();
+  NEMGetAddress createEmptyInstance() => create();
+  static $pb.PbList<NEMGetAddress> createRepeated() => $pb.PbList<NEMGetAddress>();
+  @$core.pragma('dart2js:noInline')
+  static NEMGetAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMGetAddress>(create);
+  static NEMGetAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.int get network => $_getI(1, 104);
+  @$pb.TagNumber(2)
+  set network($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasNetwork() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNetwork() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get showDisplay => $_getBF(2);
+  @$pb.TagNumber(3)
+  set showDisplay($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasShowDisplay() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearShowDisplay() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.bool get chunkify => $_getBF(3);
+  @$pb.TagNumber(4)
+  set chunkify($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasChunkify() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearChunkify() => clearField(4);
+}
+
+/// *
+///  Response: Contains NEM address derived from device private seed
+///  @end
+class NEMAddress extends $pb.GeneratedMessage {
+  factory NEMAddress({
+    $core.String? address,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    return $result;
+  }
+  NEMAddress._() : super();
+  factory NEMAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'address')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMAddress clone() => NEMAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMAddress copyWith(void Function(NEMAddress) updates) => super.copyWith((message) => updates(message as NEMAddress)) as NEMAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMAddress create() => NEMAddress._();
+  NEMAddress createEmptyInstance() => create();
+  static $pb.PbList<NEMAddress> createRepeated() => $pb.PbList<NEMAddress>();
+  @$core.pragma('dart2js:noInline')
+  static NEMAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMAddress>(create);
+  static NEMAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+}
+
+/// *
+///  Structure representing the common part for NEM transactions
+class NEMSignTx_NEMTransactionCommon extends $pb.GeneratedMessage {
+  factory NEMSignTx_NEMTransactionCommon({
+    $core.Iterable<$core.int>? addressN,
+    $core.int? network,
+    $core.int? timestamp,
+    $fixnum.Int64? fee,
+    $core.int? deadline,
+    $core.List<$core.int>? signer,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (network != null) {
+      $result.network = network;
+    }
+    if (timestamp != null) {
+      $result.timestamp = timestamp;
+    }
+    if (fee != null) {
+      $result.fee = fee;
+    }
+    if (deadline != null) {
+      $result.deadline = deadline;
+    }
+    if (signer != null) {
+      $result.signer = signer;
+    }
+    return $result;
+  }
+  NEMSignTx_NEMTransactionCommon._() : super();
+  factory NEMSignTx_NEMTransactionCommon.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMSignTx_NEMTransactionCommon.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMSignTx.NEMTransactionCommon', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'network', $pb.PbFieldType.OU3, defaultOrMaker: 104)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'timestamp', $pb.PbFieldType.QU3)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'deadline', $pb.PbFieldType.QU3)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'signer', $pb.PbFieldType.OY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMTransactionCommon clone() => NEMSignTx_NEMTransactionCommon()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMTransactionCommon copyWith(void Function(NEMSignTx_NEMTransactionCommon) updates) => super.copyWith((message) => updates(message as NEMSignTx_NEMTransactionCommon)) as NEMSignTx_NEMTransactionCommon;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMTransactionCommon create() => NEMSignTx_NEMTransactionCommon._();
+  NEMSignTx_NEMTransactionCommon createEmptyInstance() => create();
+  static $pb.PbList<NEMSignTx_NEMTransactionCommon> createRepeated() => $pb.PbList<NEMSignTx_NEMTransactionCommon>();
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMTransactionCommon getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMSignTx_NEMTransactionCommon>(create);
+  static NEMSignTx_NEMTransactionCommon? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.int get network => $_getI(1, 104);
+  @$pb.TagNumber(2)
+  set network($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasNetwork() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNetwork() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get timestamp => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set timestamp($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasTimestamp() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearTimestamp() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get fee => $_getI64(3);
+  @$pb.TagNumber(4)
+  set fee($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasFee() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearFee() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get deadline => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set deadline($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasDeadline() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearDeadline() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get signer => $_getN(5);
+  @$pb.TagNumber(6)
+  set signer($core.List<$core.int> v) { $_setBytes(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasSigner() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearSigner() => clearField(6);
+}
+
+/// *
+///  Structure representing the mosaic attachment for NEM transfer transactions
+class NEMSignTx_NEMTransfer_NEMMosaic extends $pb.GeneratedMessage {
+  factory NEMSignTx_NEMTransfer_NEMMosaic({
+    $core.String? namespace,
+    $core.String? mosaic,
+    $fixnum.Int64? quantity,
+  }) {
+    final $result = create();
+    if (namespace != null) {
+      $result.namespace = namespace;
+    }
+    if (mosaic != null) {
+      $result.mosaic = mosaic;
+    }
+    if (quantity != null) {
+      $result.quantity = quantity;
+    }
+    return $result;
+  }
+  NEMSignTx_NEMTransfer_NEMMosaic._() : super();
+  factory NEMSignTx_NEMTransfer_NEMMosaic.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMSignTx_NEMTransfer_NEMMosaic.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMSignTx.NEMTransfer.NEMMosaic', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'namespace')
+    ..aQS(2, _omitFieldNames ? '' : 'mosaic')
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'quantity', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMTransfer_NEMMosaic clone() => NEMSignTx_NEMTransfer_NEMMosaic()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMTransfer_NEMMosaic copyWith(void Function(NEMSignTx_NEMTransfer_NEMMosaic) updates) => super.copyWith((message) => updates(message as NEMSignTx_NEMTransfer_NEMMosaic)) as NEMSignTx_NEMTransfer_NEMMosaic;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMTransfer_NEMMosaic create() => NEMSignTx_NEMTransfer_NEMMosaic._();
+  NEMSignTx_NEMTransfer_NEMMosaic createEmptyInstance() => create();
+  static $pb.PbList<NEMSignTx_NEMTransfer_NEMMosaic> createRepeated() => $pb.PbList<NEMSignTx_NEMTransfer_NEMMosaic>();
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMTransfer_NEMMosaic getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMSignTx_NEMTransfer_NEMMosaic>(create);
+  static NEMSignTx_NEMTransfer_NEMMosaic? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get namespace => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set namespace($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasNamespace() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearNamespace() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get mosaic => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set mosaic($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMosaic() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMosaic() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get quantity => $_getI64(2);
+  @$pb.TagNumber(3)
+  set quantity($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasQuantity() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearQuantity() => clearField(3);
+}
+
+/// *
+///  Structure representing the transfer transaction part for NEM transactions
+class NEMSignTx_NEMTransfer extends $pb.GeneratedMessage {
+  factory NEMSignTx_NEMTransfer({
+    $core.String? recipient,
+    $fixnum.Int64? amount,
+    $core.List<$core.int>? payload,
+    $core.List<$core.int>? publicKey,
+    $core.Iterable<NEMSignTx_NEMTransfer_NEMMosaic>? mosaics,
+  }) {
+    final $result = create();
+    if (recipient != null) {
+      $result.recipient = recipient;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (payload != null) {
+      $result.payload = payload;
+    }
+    if (publicKey != null) {
+      $result.publicKey = publicKey;
+    }
+    if (mosaics != null) {
+      $result.mosaics.addAll(mosaics);
+    }
+    return $result;
+  }
+  NEMSignTx_NEMTransfer._() : super();
+  factory NEMSignTx_NEMTransfer.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMSignTx_NEMTransfer.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMSignTx.NEMTransfer', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'recipient')
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'payload', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'publicKey', $pb.PbFieldType.OY)
+    ..pc<NEMSignTx_NEMTransfer_NEMMosaic>(5, _omitFieldNames ? '' : 'mosaics', $pb.PbFieldType.PM, subBuilder: NEMSignTx_NEMTransfer_NEMMosaic.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMTransfer clone() => NEMSignTx_NEMTransfer()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMTransfer copyWith(void Function(NEMSignTx_NEMTransfer) updates) => super.copyWith((message) => updates(message as NEMSignTx_NEMTransfer)) as NEMSignTx_NEMTransfer;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMTransfer create() => NEMSignTx_NEMTransfer._();
+  NEMSignTx_NEMTransfer createEmptyInstance() => create();
+  static $pb.PbList<NEMSignTx_NEMTransfer> createRepeated() => $pb.PbList<NEMSignTx_NEMTransfer>();
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMTransfer getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMSignTx_NEMTransfer>(create);
+  static NEMSignTx_NEMTransfer? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get recipient => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set recipient($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasRecipient() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRecipient() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get amount => $_getI64(1);
+  @$pb.TagNumber(2)
+  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAmount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAmount() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get payload => $_getN(2);
+  @$pb.TagNumber(3)
+  set payload($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasPayload() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearPayload() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get publicKey => $_getN(3);
+  @$pb.TagNumber(4)
+  set publicKey($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasPublicKey() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearPublicKey() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<NEMSignTx_NEMTransfer_NEMMosaic> get mosaics => $_getList(4);
+}
+
+/// *
+///  Structure representing the provision namespace part for NEM transactions
+class NEMSignTx_NEMProvisionNamespace extends $pb.GeneratedMessage {
+  factory NEMSignTx_NEMProvisionNamespace({
+    $core.String? namespace,
+    $core.String? parent,
+    $core.String? sink,
+    $fixnum.Int64? fee,
+  }) {
+    final $result = create();
+    if (namespace != null) {
+      $result.namespace = namespace;
+    }
+    if (parent != null) {
+      $result.parent = parent;
+    }
+    if (sink != null) {
+      $result.sink = sink;
+    }
+    if (fee != null) {
+      $result.fee = fee;
+    }
+    return $result;
+  }
+  NEMSignTx_NEMProvisionNamespace._() : super();
+  factory NEMSignTx_NEMProvisionNamespace.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMSignTx_NEMProvisionNamespace.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMSignTx.NEMProvisionNamespace', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'namespace')
+    ..aOS(2, _omitFieldNames ? '' : 'parent')
+    ..aQS(3, _omitFieldNames ? '' : 'sink')
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMProvisionNamespace clone() => NEMSignTx_NEMProvisionNamespace()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMProvisionNamespace copyWith(void Function(NEMSignTx_NEMProvisionNamespace) updates) => super.copyWith((message) => updates(message as NEMSignTx_NEMProvisionNamespace)) as NEMSignTx_NEMProvisionNamespace;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMProvisionNamespace create() => NEMSignTx_NEMProvisionNamespace._();
+  NEMSignTx_NEMProvisionNamespace createEmptyInstance() => create();
+  static $pb.PbList<NEMSignTx_NEMProvisionNamespace> createRepeated() => $pb.PbList<NEMSignTx_NEMProvisionNamespace>();
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMProvisionNamespace getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMSignTx_NEMProvisionNamespace>(create);
+  static NEMSignTx_NEMProvisionNamespace? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get namespace => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set namespace($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasNamespace() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearNamespace() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get parent => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set parent($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasParent() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearParent() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get sink => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set sink($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSink() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSink() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get fee => $_getI64(3);
+  @$pb.TagNumber(4)
+  set fee($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasFee() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearFee() => clearField(4);
+}
+
+/// *
+///  Structure representing a mosaic definition
+class NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition extends $pb.GeneratedMessage {
+  factory NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition({
+    $core.String? name,
+    $core.String? ticker,
+    $core.String? namespace,
+    $core.String? mosaic,
+    $core.int? divisibility,
+    NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy? levy,
+    $fixnum.Int64? fee,
+    $core.String? levyAddress,
+    $core.String? levyNamespace,
+    $core.String? levyMosaic,
+    $fixnum.Int64? supply,
+    $core.bool? mutableSupply,
+    $core.bool? transferable,
+    $core.String? description,
+    $core.Iterable<$core.int>? networks,
+  }) {
+    final $result = create();
+    if (name != null) {
+      $result.name = name;
+    }
+    if (ticker != null) {
+      $result.ticker = ticker;
+    }
+    if (namespace != null) {
+      $result.namespace = namespace;
+    }
+    if (mosaic != null) {
+      $result.mosaic = mosaic;
+    }
+    if (divisibility != null) {
+      $result.divisibility = divisibility;
+    }
+    if (levy != null) {
+      $result.levy = levy;
+    }
+    if (fee != null) {
+      $result.fee = fee;
+    }
+    if (levyAddress != null) {
+      $result.levyAddress = levyAddress;
+    }
+    if (levyNamespace != null) {
+      $result.levyNamespace = levyNamespace;
+    }
+    if (levyMosaic != null) {
+      $result.levyMosaic = levyMosaic;
+    }
+    if (supply != null) {
+      $result.supply = supply;
+    }
+    if (mutableSupply != null) {
+      $result.mutableSupply = mutableSupply;
+    }
+    if (transferable != null) {
+      $result.transferable = transferable;
+    }
+    if (description != null) {
+      $result.description = description;
+    }
+    if (networks != null) {
+      $result.networks.addAll(networks);
+    }
+    return $result;
+  }
+  NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition._() : super();
+  factory NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMSignTx.NEMMosaicCreation.NEMMosaicDefinition', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..aOS(2, _omitFieldNames ? '' : 'ticker')
+    ..aQS(3, _omitFieldNames ? '' : 'namespace')
+    ..aQS(4, _omitFieldNames ? '' : 'mosaic')
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'divisibility', $pb.PbFieldType.OU3)
+    ..e<NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy>(6, _omitFieldNames ? '' : 'levy', $pb.PbFieldType.OE, defaultOrMaker: NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy.MosaicLevy_Absolute, valueOf: NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy.valueOf, enumValues: NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy.values)
+    ..a<$fixnum.Int64>(7, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aOS(8, _omitFieldNames ? '' : 'levyAddress')
+    ..aOS(9, _omitFieldNames ? '' : 'levyNamespace')
+    ..aOS(10, _omitFieldNames ? '' : 'levyMosaic')
+    ..a<$fixnum.Int64>(11, _omitFieldNames ? '' : 'supply', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aOB(12, _omitFieldNames ? '' : 'mutableSupply')
+    ..aOB(13, _omitFieldNames ? '' : 'transferable')
+    ..aQS(14, _omitFieldNames ? '' : 'description')
+    ..p<$core.int>(15, _omitFieldNames ? '' : 'networks', $pb.PbFieldType.PU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition clone() => NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition copyWith(void Function(NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition) updates) => super.copyWith((message) => updates(message as NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition)) as NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition create() => NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition._();
+  NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition createEmptyInstance() => create();
+  static $pb.PbList<NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition> createRepeated() => $pb.PbList<NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition>();
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition>(create);
+  static NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get ticker => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set ticker($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTicker() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTicker() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get namespace => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set namespace($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasNamespace() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearNamespace() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get mosaic => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set mosaic($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasMosaic() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMosaic() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get divisibility => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set divisibility($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasDivisibility() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearDivisibility() => clearField(5);
+
+  @$pb.TagNumber(6)
+  NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy get levy => $_getN(5);
+  @$pb.TagNumber(6)
+  set levy(NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy v) { setField(6, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasLevy() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearLevy() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $fixnum.Int64 get fee => $_getI64(6);
+  @$pb.TagNumber(7)
+  set fee($fixnum.Int64 v) { $_setInt64(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasFee() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearFee() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.String get levyAddress => $_getSZ(7);
+  @$pb.TagNumber(8)
+  set levyAddress($core.String v) { $_setString(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasLevyAddress() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearLevyAddress() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.String get levyNamespace => $_getSZ(8);
+  @$pb.TagNumber(9)
+  set levyNamespace($core.String v) { $_setString(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasLevyNamespace() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearLevyNamespace() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.String get levyMosaic => $_getSZ(9);
+  @$pb.TagNumber(10)
+  set levyMosaic($core.String v) { $_setString(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasLevyMosaic() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearLevyMosaic() => clearField(10);
+
+  @$pb.TagNumber(11)
+  $fixnum.Int64 get supply => $_getI64(10);
+  @$pb.TagNumber(11)
+  set supply($fixnum.Int64 v) { $_setInt64(10, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasSupply() => $_has(10);
+  @$pb.TagNumber(11)
+  void clearSupply() => clearField(11);
+
+  @$pb.TagNumber(12)
+  $core.bool get mutableSupply => $_getBF(11);
+  @$pb.TagNumber(12)
+  set mutableSupply($core.bool v) { $_setBool(11, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasMutableSupply() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearMutableSupply() => clearField(12);
+
+  @$pb.TagNumber(13)
+  $core.bool get transferable => $_getBF(12);
+  @$pb.TagNumber(13)
+  set transferable($core.bool v) { $_setBool(12, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasTransferable() => $_has(12);
+  @$pb.TagNumber(13)
+  void clearTransferable() => clearField(13);
+
+  @$pb.TagNumber(14)
+  $core.String get description => $_getSZ(13);
+  @$pb.TagNumber(14)
+  set description($core.String v) { $_setString(13, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasDescription() => $_has(13);
+  @$pb.TagNumber(14)
+  void clearDescription() => clearField(14);
+
+  @$pb.TagNumber(15)
+  $core.List<$core.int> get networks => $_getList(14);
+}
+
+/// *
+///  Structure representing the mosaic definition creation part for NEM transactions
+class NEMSignTx_NEMMosaicCreation extends $pb.GeneratedMessage {
+  factory NEMSignTx_NEMMosaicCreation({
+    NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition? definition,
+    $core.String? sink,
+    $fixnum.Int64? fee,
+  }) {
+    final $result = create();
+    if (definition != null) {
+      $result.definition = definition;
+    }
+    if (sink != null) {
+      $result.sink = sink;
+    }
+    if (fee != null) {
+      $result.fee = fee;
+    }
+    return $result;
+  }
+  NEMSignTx_NEMMosaicCreation._() : super();
+  factory NEMSignTx_NEMMosaicCreation.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMSignTx_NEMMosaicCreation.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMSignTx.NEMMosaicCreation', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..aQM<NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition>(1, _omitFieldNames ? '' : 'definition', subBuilder: NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition.create)
+    ..aQS(2, _omitFieldNames ? '' : 'sink')
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMMosaicCreation clone() => NEMSignTx_NEMMosaicCreation()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMMosaicCreation copyWith(void Function(NEMSignTx_NEMMosaicCreation) updates) => super.copyWith((message) => updates(message as NEMSignTx_NEMMosaicCreation)) as NEMSignTx_NEMMosaicCreation;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMMosaicCreation create() => NEMSignTx_NEMMosaicCreation._();
+  NEMSignTx_NEMMosaicCreation createEmptyInstance() => create();
+  static $pb.PbList<NEMSignTx_NEMMosaicCreation> createRepeated() => $pb.PbList<NEMSignTx_NEMMosaicCreation>();
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMMosaicCreation getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMSignTx_NEMMosaicCreation>(create);
+  static NEMSignTx_NEMMosaicCreation? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition get definition => $_getN(0);
+  @$pb.TagNumber(1)
+  set definition(NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDefinition() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDefinition() => clearField(1);
+  @$pb.TagNumber(1)
+  NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition ensureDefinition() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $core.String get sink => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set sink($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSink() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSink() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get fee => $_getI64(2);
+  @$pb.TagNumber(3)
+  set fee($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasFee() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearFee() => clearField(3);
+}
+
+/// *
+///  Structure representing the mosaic supply change part for NEM transactions
+class NEMSignTx_NEMMosaicSupplyChange extends $pb.GeneratedMessage {
+  factory NEMSignTx_NEMMosaicSupplyChange({
+    $core.String? namespace,
+    $core.String? mosaic,
+    NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType? type,
+    $fixnum.Int64? delta,
+  }) {
+    final $result = create();
+    if (namespace != null) {
+      $result.namespace = namespace;
+    }
+    if (mosaic != null) {
+      $result.mosaic = mosaic;
+    }
+    if (type != null) {
+      $result.type = type;
+    }
+    if (delta != null) {
+      $result.delta = delta;
+    }
+    return $result;
+  }
+  NEMSignTx_NEMMosaicSupplyChange._() : super();
+  factory NEMSignTx_NEMMosaicSupplyChange.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMSignTx_NEMMosaicSupplyChange.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMSignTx.NEMMosaicSupplyChange', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'namespace')
+    ..aQS(2, _omitFieldNames ? '' : 'mosaic')
+    ..e<NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType>(3, _omitFieldNames ? '' : 'type', $pb.PbFieldType.QE, defaultOrMaker: NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType.SupplyChange_Increase, valueOf: NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType.valueOf, enumValues: NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType.values)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'delta', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMMosaicSupplyChange clone() => NEMSignTx_NEMMosaicSupplyChange()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMMosaicSupplyChange copyWith(void Function(NEMSignTx_NEMMosaicSupplyChange) updates) => super.copyWith((message) => updates(message as NEMSignTx_NEMMosaicSupplyChange)) as NEMSignTx_NEMMosaicSupplyChange;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMMosaicSupplyChange create() => NEMSignTx_NEMMosaicSupplyChange._();
+  NEMSignTx_NEMMosaicSupplyChange createEmptyInstance() => create();
+  static $pb.PbList<NEMSignTx_NEMMosaicSupplyChange> createRepeated() => $pb.PbList<NEMSignTx_NEMMosaicSupplyChange>();
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMMosaicSupplyChange getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMSignTx_NEMMosaicSupplyChange>(create);
+  static NEMSignTx_NEMMosaicSupplyChange? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get namespace => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set namespace($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasNamespace() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearNamespace() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get mosaic => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set mosaic($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMosaic() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMosaic() => clearField(2);
+
+  @$pb.TagNumber(3)
+  NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType get type => $_getN(2);
+  @$pb.TagNumber(3)
+  set type(NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasType() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearType() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get delta => $_getI64(3);
+  @$pb.TagNumber(4)
+  set delta($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasDelta() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearDelta() => clearField(4);
+}
+
+/// *
+///  Structure representing the cosignatory modification for aggregate modification transactions
+class NEMSignTx_NEMAggregateModification_NEMCosignatoryModification extends $pb.GeneratedMessage {
+  factory NEMSignTx_NEMAggregateModification_NEMCosignatoryModification({
+    NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType? type,
+    $core.List<$core.int>? publicKey,
+  }) {
+    final $result = create();
+    if (type != null) {
+      $result.type = type;
+    }
+    if (publicKey != null) {
+      $result.publicKey = publicKey;
+    }
+    return $result;
+  }
+  NEMSignTx_NEMAggregateModification_NEMCosignatoryModification._() : super();
+  factory NEMSignTx_NEMAggregateModification_NEMCosignatoryModification.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMSignTx_NEMAggregateModification_NEMCosignatoryModification.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMSignTx.NEMAggregateModification.NEMCosignatoryModification', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..e<NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType>(1, _omitFieldNames ? '' : 'type', $pb.PbFieldType.QE, defaultOrMaker: NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType.CosignatoryModification_Add, valueOf: NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType.valueOf, enumValues: NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType.values)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'publicKey', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMAggregateModification_NEMCosignatoryModification clone() => NEMSignTx_NEMAggregateModification_NEMCosignatoryModification()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMAggregateModification_NEMCosignatoryModification copyWith(void Function(NEMSignTx_NEMAggregateModification_NEMCosignatoryModification) updates) => super.copyWith((message) => updates(message as NEMSignTx_NEMAggregateModification_NEMCosignatoryModification)) as NEMSignTx_NEMAggregateModification_NEMCosignatoryModification;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMAggregateModification_NEMCosignatoryModification create() => NEMSignTx_NEMAggregateModification_NEMCosignatoryModification._();
+  NEMSignTx_NEMAggregateModification_NEMCosignatoryModification createEmptyInstance() => create();
+  static $pb.PbList<NEMSignTx_NEMAggregateModification_NEMCosignatoryModification> createRepeated() => $pb.PbList<NEMSignTx_NEMAggregateModification_NEMCosignatoryModification>();
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMAggregateModification_NEMCosignatoryModification getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMSignTx_NEMAggregateModification_NEMCosignatoryModification>(create);
+  static NEMSignTx_NEMAggregateModification_NEMCosignatoryModification? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType get type => $_getN(0);
+  @$pb.TagNumber(1)
+  set type(NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearType() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get publicKey => $_getN(1);
+  @$pb.TagNumber(2)
+  set publicKey($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPublicKey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPublicKey() => clearField(2);
+}
+
+/// *
+///  Structure representing the aggregate modification part for NEM transactions
+class NEMSignTx_NEMAggregateModification extends $pb.GeneratedMessage {
+  factory NEMSignTx_NEMAggregateModification({
+    $core.Iterable<NEMSignTx_NEMAggregateModification_NEMCosignatoryModification>? modifications,
+    $core.int? relativeChange,
+  }) {
+    final $result = create();
+    if (modifications != null) {
+      $result.modifications.addAll(modifications);
+    }
+    if (relativeChange != null) {
+      $result.relativeChange = relativeChange;
+    }
+    return $result;
+  }
+  NEMSignTx_NEMAggregateModification._() : super();
+  factory NEMSignTx_NEMAggregateModification.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMSignTx_NEMAggregateModification.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMSignTx.NEMAggregateModification', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..pc<NEMSignTx_NEMAggregateModification_NEMCosignatoryModification>(1, _omitFieldNames ? '' : 'modifications', $pb.PbFieldType.PM, subBuilder: NEMSignTx_NEMAggregateModification_NEMCosignatoryModification.create)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'relativeChange', $pb.PbFieldType.OS3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMAggregateModification clone() => NEMSignTx_NEMAggregateModification()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMAggregateModification copyWith(void Function(NEMSignTx_NEMAggregateModification) updates) => super.copyWith((message) => updates(message as NEMSignTx_NEMAggregateModification)) as NEMSignTx_NEMAggregateModification;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMAggregateModification create() => NEMSignTx_NEMAggregateModification._();
+  NEMSignTx_NEMAggregateModification createEmptyInstance() => create();
+  static $pb.PbList<NEMSignTx_NEMAggregateModification> createRepeated() => $pb.PbList<NEMSignTx_NEMAggregateModification>();
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMAggregateModification getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMSignTx_NEMAggregateModification>(create);
+  static NEMSignTx_NEMAggregateModification? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<NEMSignTx_NEMAggregateModification_NEMCosignatoryModification> get modifications => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.int get relativeChange => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set relativeChange($core.int v) { $_setSignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasRelativeChange() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearRelativeChange() => clearField(2);
+}
+
+/// *
+///  Structure representing the importance transfer part for NEM transactions
+class NEMSignTx_NEMImportanceTransfer extends $pb.GeneratedMessage {
+  factory NEMSignTx_NEMImportanceTransfer({
+    NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode? mode,
+    $core.List<$core.int>? publicKey,
+  }) {
+    final $result = create();
+    if (mode != null) {
+      $result.mode = mode;
+    }
+    if (publicKey != null) {
+      $result.publicKey = publicKey;
+    }
+    return $result;
+  }
+  NEMSignTx_NEMImportanceTransfer._() : super();
+  factory NEMSignTx_NEMImportanceTransfer.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMSignTx_NEMImportanceTransfer.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMSignTx.NEMImportanceTransfer', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..e<NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode>(1, _omitFieldNames ? '' : 'mode', $pb.PbFieldType.QE, defaultOrMaker: NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode.ImportanceTransfer_Activate, valueOf: NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode.valueOf, enumValues: NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode.values)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'publicKey', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMImportanceTransfer clone() => NEMSignTx_NEMImportanceTransfer()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMSignTx_NEMImportanceTransfer copyWith(void Function(NEMSignTx_NEMImportanceTransfer) updates) => super.copyWith((message) => updates(message as NEMSignTx_NEMImportanceTransfer)) as NEMSignTx_NEMImportanceTransfer;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMImportanceTransfer create() => NEMSignTx_NEMImportanceTransfer._();
+  NEMSignTx_NEMImportanceTransfer createEmptyInstance() => create();
+  static $pb.PbList<NEMSignTx_NEMImportanceTransfer> createRepeated() => $pb.PbList<NEMSignTx_NEMImportanceTransfer>();
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx_NEMImportanceTransfer getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMSignTx_NEMImportanceTransfer>(create);
+  static NEMSignTx_NEMImportanceTransfer? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode get mode => $_getN(0);
+  @$pb.TagNumber(1)
+  set mode(NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasMode() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearMode() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get publicKey => $_getN(1);
+  @$pb.TagNumber(2)
+  set publicKey($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPublicKey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPublicKey() => clearField(2);
+}
+
+/// *
+///  Request: Ask device to sign transaction
+///  @start
+///  @next NEMSignedTx
+///  @next Failure
+class NEMSignTx extends $pb.GeneratedMessage {
+  factory NEMSignTx({
+    NEMSignTx_NEMTransactionCommon? transaction,
+    NEMSignTx_NEMTransactionCommon? multisig,
+    NEMSignTx_NEMTransfer? transfer,
+    $core.bool? cosigning,
+    NEMSignTx_NEMProvisionNamespace? provisionNamespace,
+    NEMSignTx_NEMMosaicCreation? mosaicCreation,
+    NEMSignTx_NEMMosaicSupplyChange? supplyChange,
+    NEMSignTx_NEMAggregateModification? aggregateModification,
+    NEMSignTx_NEMImportanceTransfer? importanceTransfer,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (transaction != null) {
+      $result.transaction = transaction;
+    }
+    if (multisig != null) {
+      $result.multisig = multisig;
+    }
+    if (transfer != null) {
+      $result.transfer = transfer;
+    }
+    if (cosigning != null) {
+      $result.cosigning = cosigning;
+    }
+    if (provisionNamespace != null) {
+      $result.provisionNamespace = provisionNamespace;
+    }
+    if (mosaicCreation != null) {
+      $result.mosaicCreation = mosaicCreation;
+    }
+    if (supplyChange != null) {
+      $result.supplyChange = supplyChange;
+    }
+    if (aggregateModification != null) {
+      $result.aggregateModification = aggregateModification;
+    }
+    if (importanceTransfer != null) {
+      $result.importanceTransfer = importanceTransfer;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  NEMSignTx._() : super();
+  factory NEMSignTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMSignTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMSignTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..aQM<NEMSignTx_NEMTransactionCommon>(1, _omitFieldNames ? '' : 'transaction', subBuilder: NEMSignTx_NEMTransactionCommon.create)
+    ..aOM<NEMSignTx_NEMTransactionCommon>(2, _omitFieldNames ? '' : 'multisig', subBuilder: NEMSignTx_NEMTransactionCommon.create)
+    ..aOM<NEMSignTx_NEMTransfer>(3, _omitFieldNames ? '' : 'transfer', subBuilder: NEMSignTx_NEMTransfer.create)
+    ..aOB(4, _omitFieldNames ? '' : 'cosigning')
+    ..aOM<NEMSignTx_NEMProvisionNamespace>(5, _omitFieldNames ? '' : 'provisionNamespace', subBuilder: NEMSignTx_NEMProvisionNamespace.create)
+    ..aOM<NEMSignTx_NEMMosaicCreation>(6, _omitFieldNames ? '' : 'mosaicCreation', subBuilder: NEMSignTx_NEMMosaicCreation.create)
+    ..aOM<NEMSignTx_NEMMosaicSupplyChange>(7, _omitFieldNames ? '' : 'supplyChange', subBuilder: NEMSignTx_NEMMosaicSupplyChange.create)
+    ..aOM<NEMSignTx_NEMAggregateModification>(8, _omitFieldNames ? '' : 'aggregateModification', subBuilder: NEMSignTx_NEMAggregateModification.create)
+    ..aOM<NEMSignTx_NEMImportanceTransfer>(9, _omitFieldNames ? '' : 'importanceTransfer', subBuilder: NEMSignTx_NEMImportanceTransfer.create)
+    ..aOB(10, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMSignTx clone() => NEMSignTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMSignTx copyWith(void Function(NEMSignTx) updates) => super.copyWith((message) => updates(message as NEMSignTx)) as NEMSignTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx create() => NEMSignTx._();
+  NEMSignTx createEmptyInstance() => create();
+  static $pb.PbList<NEMSignTx> createRepeated() => $pb.PbList<NEMSignTx>();
+  @$core.pragma('dart2js:noInline')
+  static NEMSignTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMSignTx>(create);
+  static NEMSignTx? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  NEMSignTx_NEMTransactionCommon get transaction => $_getN(0);
+  @$pb.TagNumber(1)
+  set transaction(NEMSignTx_NEMTransactionCommon v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTransaction() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTransaction() => clearField(1);
+  @$pb.TagNumber(1)
+  NEMSignTx_NEMTransactionCommon ensureTransaction() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  NEMSignTx_NEMTransactionCommon get multisig => $_getN(1);
+  @$pb.TagNumber(2)
+  set multisig(NEMSignTx_NEMTransactionCommon v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMultisig() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMultisig() => clearField(2);
+  @$pb.TagNumber(2)
+  NEMSignTx_NEMTransactionCommon ensureMultisig() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  NEMSignTx_NEMTransfer get transfer => $_getN(2);
+  @$pb.TagNumber(3)
+  set transfer(NEMSignTx_NEMTransfer v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasTransfer() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearTransfer() => clearField(3);
+  @$pb.TagNumber(3)
+  NEMSignTx_NEMTransfer ensureTransfer() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  $core.bool get cosigning => $_getBF(3);
+  @$pb.TagNumber(4)
+  set cosigning($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasCosigning() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearCosigning() => clearField(4);
+
+  @$pb.TagNumber(5)
+  NEMSignTx_NEMProvisionNamespace get provisionNamespace => $_getN(4);
+  @$pb.TagNumber(5)
+  set provisionNamespace(NEMSignTx_NEMProvisionNamespace v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasProvisionNamespace() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearProvisionNamespace() => clearField(5);
+  @$pb.TagNumber(5)
+  NEMSignTx_NEMProvisionNamespace ensureProvisionNamespace() => $_ensure(4);
+
+  @$pb.TagNumber(6)
+  NEMSignTx_NEMMosaicCreation get mosaicCreation => $_getN(5);
+  @$pb.TagNumber(6)
+  set mosaicCreation(NEMSignTx_NEMMosaicCreation v) { setField(6, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasMosaicCreation() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearMosaicCreation() => clearField(6);
+  @$pb.TagNumber(6)
+  NEMSignTx_NEMMosaicCreation ensureMosaicCreation() => $_ensure(5);
+
+  @$pb.TagNumber(7)
+  NEMSignTx_NEMMosaicSupplyChange get supplyChange => $_getN(6);
+  @$pb.TagNumber(7)
+  set supplyChange(NEMSignTx_NEMMosaicSupplyChange v) { setField(7, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasSupplyChange() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearSupplyChange() => clearField(7);
+  @$pb.TagNumber(7)
+  NEMSignTx_NEMMosaicSupplyChange ensureSupplyChange() => $_ensure(6);
+
+  @$pb.TagNumber(8)
+  NEMSignTx_NEMAggregateModification get aggregateModification => $_getN(7);
+  @$pb.TagNumber(8)
+  set aggregateModification(NEMSignTx_NEMAggregateModification v) { setField(8, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasAggregateModification() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearAggregateModification() => clearField(8);
+  @$pb.TagNumber(8)
+  NEMSignTx_NEMAggregateModification ensureAggregateModification() => $_ensure(7);
+
+  @$pb.TagNumber(9)
+  NEMSignTx_NEMImportanceTransfer get importanceTransfer => $_getN(8);
+  @$pb.TagNumber(9)
+  set importanceTransfer(NEMSignTx_NEMImportanceTransfer v) { setField(9, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasImportanceTransfer() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearImportanceTransfer() => clearField(9);
+  @$pb.TagNumber(9)
+  NEMSignTx_NEMImportanceTransfer ensureImportanceTransfer() => $_ensure(8);
+
+  @$pb.TagNumber(10)
+  $core.bool get chunkify => $_getBF(9);
+  @$pb.TagNumber(10)
+  set chunkify($core.bool v) { $_setBool(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasChunkify() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearChunkify() => clearField(10);
+}
+
+/// *
+///  Response: Contains NEM transaction data and signature
+///  @end
+class NEMSignedTx extends $pb.GeneratedMessage {
+  factory NEMSignedTx({
+    $core.List<$core.int>? data,
+    $core.List<$core.int>? signature,
+  }) {
+    final $result = create();
+    if (data != null) {
+      $result.data = data;
+    }
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    return $result;
+  }
+  NEMSignedTx._() : super();
+  factory NEMSignedTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMSignedTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMSignedTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'data', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMSignedTx clone() => NEMSignedTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMSignedTx copyWith(void Function(NEMSignedTx) updates) => super.copyWith((message) => updates(message as NEMSignedTx)) as NEMSignedTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMSignedTx create() => NEMSignedTx._();
+  NEMSignedTx createEmptyInstance() => create();
+  static $pb.PbList<NEMSignedTx> createRepeated() => $pb.PbList<NEMSignedTx>();
+  @$core.pragma('dart2js:noInline')
+  static NEMSignedTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMSignedTx>(create);
+  static NEMSignedTx? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get data => $_getN(0);
+  @$pb.TagNumber(1)
+  set data($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasData() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearData() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get signature => $_getN(1);
+  @$pb.TagNumber(2)
+  set signature($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSignature() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSignature() => clearField(2);
+}
+
+/// *
+///  Request: Ask device to decrypt NEM transaction payload
+///  @start
+///  @next NEMDecryptedMessage
+///  @next Failure
+class NEMDecryptMessage extends $pb.GeneratedMessage {
+  factory NEMDecryptMessage({
+    $core.Iterable<$core.int>? addressN,
+    $core.int? network,
+    $core.List<$core.int>? publicKey,
+    $core.List<$core.int>? payload,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (network != null) {
+      $result.network = network;
+    }
+    if (publicKey != null) {
+      $result.publicKey = publicKey;
+    }
+    if (payload != null) {
+      $result.payload = payload;
+    }
+    return $result;
+  }
+  NEMDecryptMessage._() : super();
+  factory NEMDecryptMessage.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMDecryptMessage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMDecryptMessage', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'network', $pb.PbFieldType.OU3)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'publicKey', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'payload', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMDecryptMessage clone() => NEMDecryptMessage()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMDecryptMessage copyWith(void Function(NEMDecryptMessage) updates) => super.copyWith((message) => updates(message as NEMDecryptMessage)) as NEMDecryptMessage;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMDecryptMessage create() => NEMDecryptMessage._();
+  NEMDecryptMessage createEmptyInstance() => create();
+  static $pb.PbList<NEMDecryptMessage> createRepeated() => $pb.PbList<NEMDecryptMessage>();
+  @$core.pragma('dart2js:noInline')
+  static NEMDecryptMessage getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMDecryptMessage>(create);
+  static NEMDecryptMessage? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.int get network => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set network($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasNetwork() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNetwork() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get publicKey => $_getN(2);
+  @$pb.TagNumber(3)
+  set publicKey($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasPublicKey() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearPublicKey() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.int> get payload => $_getN(3);
+  @$pb.TagNumber(4)
+  set payload($core.List<$core.int> v) { $_setBytes(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasPayload() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearPayload() => clearField(4);
+}
+
+/// *
+///  Response: Contains decrypted NEM transaction payload
+///  @end
+class NEMDecryptedMessage extends $pb.GeneratedMessage {
+  factory NEMDecryptedMessage({
+    $core.List<$core.int>? payload,
+  }) {
+    final $result = create();
+    if (payload != null) {
+      $result.payload = payload;
+    }
+    return $result;
+  }
+  NEMDecryptedMessage._() : super();
+  factory NEMDecryptedMessage.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NEMDecryptedMessage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'NEMDecryptedMessage', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.nem'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'payload', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NEMDecryptedMessage clone() => NEMDecryptedMessage()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NEMDecryptedMessage copyWith(void Function(NEMDecryptedMessage) updates) => super.copyWith((message) => updates(message as NEMDecryptedMessage)) as NEMDecryptedMessage;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static NEMDecryptedMessage create() => NEMDecryptedMessage._();
+  NEMDecryptedMessage createEmptyInstance() => create();
+  static $pb.PbList<NEMDecryptedMessage> createRepeated() => $pb.PbList<NEMDecryptedMessage>();
+  @$core.pragma('dart2js:noInline')
+  static NEMDecryptedMessage getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NEMDecryptedMessage>(create);
+  static NEMDecryptedMessage? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get payload => $_getN(0);
+  @$pb.TagNumber(1)
+  set payload($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPayload() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPayload() => clearField(1);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-nem.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-nem.pbenum.dart
@@ -1,0 +1,85 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-nem.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+/// *
+///  Type of levy which will be used for mosaic
+class NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy extends $pb.ProtobufEnum {
+  static const NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy MosaicLevy_Absolute = NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy._(1, _omitEnumNames ? '' : 'MosaicLevy_Absolute');
+  static const NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy MosaicLevy_Percentile = NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy._(2, _omitEnumNames ? '' : 'MosaicLevy_Percentile');
+
+  static const $core.List<NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy> values = <NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy> [
+    MosaicLevy_Absolute,
+    MosaicLevy_Percentile,
+  ];
+
+  static final $core.Map<$core.int, NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy? valueOf($core.int value) => _byValue[value];
+
+  const NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Type of supply change which will be applied to mosaic
+class NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType extends $pb.ProtobufEnum {
+  static const NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType SupplyChange_Increase = NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType._(1, _omitEnumNames ? '' : 'SupplyChange_Increase');
+  static const NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType SupplyChange_Decrease = NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType._(2, _omitEnumNames ? '' : 'SupplyChange_Decrease');
+
+  static const $core.List<NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType> values = <NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType> [
+    SupplyChange_Increase,
+    SupplyChange_Decrease,
+  ];
+
+  static final $core.Map<$core.int, NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType? valueOf($core.int value) => _byValue[value];
+
+  const NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Type of cosignatory modification
+class NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType extends $pb.ProtobufEnum {
+  static const NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType CosignatoryModification_Add = NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType._(1, _omitEnumNames ? '' : 'CosignatoryModification_Add');
+  static const NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType CosignatoryModification_Delete = NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType._(2, _omitEnumNames ? '' : 'CosignatoryModification_Delete');
+
+  static const $core.List<NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType> values = <NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType> [
+    CosignatoryModification_Add,
+    CosignatoryModification_Delete,
+  ];
+
+  static final $core.Map<$core.int, NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType? valueOf($core.int value) => _byValue[value];
+
+  const NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType._($core.int v, $core.String n) : super(v, n);
+}
+
+/// *
+///  Mode of importance transfer
+class NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode extends $pb.ProtobufEnum {
+  static const NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode ImportanceTransfer_Activate = NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode._(1, _omitEnumNames ? '' : 'ImportanceTransfer_Activate');
+  static const NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode ImportanceTransfer_Deactivate = NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode._(2, _omitEnumNames ? '' : 'ImportanceTransfer_Deactivate');
+
+  static const $core.List<NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode> values = <NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode> [
+    ImportanceTransfer_Activate,
+    ImportanceTransfer_Deactivate,
+  ];
+
+  static final $core.Map<$core.int, NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode? valueOf($core.int value) => _byValue[value];
+
+  const NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode._($core.int v, $core.String n) : super(v, n);
+}
+
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-nem.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-nem.pbjson.dart
@@ -1,0 +1,326 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-nem.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use nEMGetAddressDescriptor instead')
+const NEMGetAddress$json = {
+  '1': 'NEMGetAddress',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'network', '3': 2, '4': 1, '5': 13, '7': '104', '10': 'network'},
+    {'1': 'show_display', '3': 3, '4': 1, '5': 8, '10': 'showDisplay'},
+    {'1': 'chunkify', '3': 4, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `NEMGetAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List nEMGetAddressDescriptor = $convert.base64Decode(
+    'Cg1ORU1HZXRBZGRyZXNzEhsKCWFkZHJlc3NfbhgBIAMoDVIIYWRkcmVzc04SHQoHbmV0d29yax'
+    'gCIAEoDToDMTA0UgduZXR3b3JrEiEKDHNob3dfZGlzcGxheRgDIAEoCFILc2hvd0Rpc3BsYXkS'
+    'GgoIY2h1bmtpZnkYBCABKAhSCGNodW5raWZ5');
+
+@$core.Deprecated('Use nEMAddressDescriptor instead')
+const NEMAddress$json = {
+  '1': 'NEMAddress',
+  '2': [
+    {'1': 'address', '3': 1, '4': 2, '5': 9, '10': 'address'},
+  ],
+};
+
+/// Descriptor for `NEMAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List nEMAddressDescriptor = $convert.base64Decode(
+    'CgpORU1BZGRyZXNzEhgKB2FkZHJlc3MYASACKAlSB2FkZHJlc3M=');
+
+@$core.Deprecated('Use nEMSignTxDescriptor instead')
+const NEMSignTx$json = {
+  '1': 'NEMSignTx',
+  '2': [
+    {'1': 'transaction', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.nem.NEMSignTx.NEMTransactionCommon', '10': 'transaction'},
+    {'1': 'multisig', '3': 2, '4': 1, '5': 11, '6': '.hw.trezor.messages.nem.NEMSignTx.NEMTransactionCommon', '10': 'multisig'},
+    {'1': 'transfer', '3': 3, '4': 1, '5': 11, '6': '.hw.trezor.messages.nem.NEMSignTx.NEMTransfer', '10': 'transfer'},
+    {'1': 'cosigning', '3': 4, '4': 1, '5': 8, '10': 'cosigning'},
+    {'1': 'provision_namespace', '3': 5, '4': 1, '5': 11, '6': '.hw.trezor.messages.nem.NEMSignTx.NEMProvisionNamespace', '10': 'provisionNamespace'},
+    {'1': 'mosaic_creation', '3': 6, '4': 1, '5': 11, '6': '.hw.trezor.messages.nem.NEMSignTx.NEMMosaicCreation', '10': 'mosaicCreation'},
+    {'1': 'supply_change', '3': 7, '4': 1, '5': 11, '6': '.hw.trezor.messages.nem.NEMSignTx.NEMMosaicSupplyChange', '10': 'supplyChange'},
+    {'1': 'aggregate_modification', '3': 8, '4': 1, '5': 11, '6': '.hw.trezor.messages.nem.NEMSignTx.NEMAggregateModification', '10': 'aggregateModification'},
+    {'1': 'importance_transfer', '3': 9, '4': 1, '5': 11, '6': '.hw.trezor.messages.nem.NEMSignTx.NEMImportanceTransfer', '10': 'importanceTransfer'},
+    {'1': 'chunkify', '3': 10, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+  '3': [NEMSignTx_NEMTransactionCommon$json, NEMSignTx_NEMTransfer$json, NEMSignTx_NEMProvisionNamespace$json, NEMSignTx_NEMMosaicCreation$json, NEMSignTx_NEMMosaicSupplyChange$json, NEMSignTx_NEMAggregateModification$json, NEMSignTx_NEMImportanceTransfer$json],
+};
+
+@$core.Deprecated('Use nEMSignTxDescriptor instead')
+const NEMSignTx_NEMTransactionCommon$json = {
+  '1': 'NEMTransactionCommon',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'network', '3': 2, '4': 1, '5': 13, '7': '104', '10': 'network'},
+    {'1': 'timestamp', '3': 3, '4': 2, '5': 13, '10': 'timestamp'},
+    {'1': 'fee', '3': 4, '4': 2, '5': 4, '10': 'fee'},
+    {'1': 'deadline', '3': 5, '4': 2, '5': 13, '10': 'deadline'},
+    {'1': 'signer', '3': 6, '4': 1, '5': 12, '10': 'signer'},
+  ],
+};
+
+@$core.Deprecated('Use nEMSignTxDescriptor instead')
+const NEMSignTx_NEMTransfer$json = {
+  '1': 'NEMTransfer',
+  '2': [
+    {'1': 'recipient', '3': 1, '4': 2, '5': 9, '10': 'recipient'},
+    {'1': 'amount', '3': 2, '4': 2, '5': 4, '10': 'amount'},
+    {'1': 'payload', '3': 3, '4': 1, '5': 12, '10': 'payload'},
+    {'1': 'public_key', '3': 4, '4': 1, '5': 12, '10': 'publicKey'},
+    {'1': 'mosaics', '3': 5, '4': 3, '5': 11, '6': '.hw.trezor.messages.nem.NEMSignTx.NEMTransfer.NEMMosaic', '10': 'mosaics'},
+  ],
+  '3': [NEMSignTx_NEMTransfer_NEMMosaic$json],
+};
+
+@$core.Deprecated('Use nEMSignTxDescriptor instead')
+const NEMSignTx_NEMTransfer_NEMMosaic$json = {
+  '1': 'NEMMosaic',
+  '2': [
+    {'1': 'namespace', '3': 1, '4': 2, '5': 9, '10': 'namespace'},
+    {'1': 'mosaic', '3': 2, '4': 2, '5': 9, '10': 'mosaic'},
+    {'1': 'quantity', '3': 3, '4': 2, '5': 4, '10': 'quantity'},
+  ],
+};
+
+@$core.Deprecated('Use nEMSignTxDescriptor instead')
+const NEMSignTx_NEMProvisionNamespace$json = {
+  '1': 'NEMProvisionNamespace',
+  '2': [
+    {'1': 'namespace', '3': 1, '4': 2, '5': 9, '10': 'namespace'},
+    {'1': 'parent', '3': 2, '4': 1, '5': 9, '10': 'parent'},
+    {'1': 'sink', '3': 3, '4': 2, '5': 9, '10': 'sink'},
+    {'1': 'fee', '3': 4, '4': 2, '5': 4, '10': 'fee'},
+  ],
+};
+
+@$core.Deprecated('Use nEMSignTxDescriptor instead')
+const NEMSignTx_NEMMosaicCreation$json = {
+  '1': 'NEMMosaicCreation',
+  '2': [
+    {'1': 'definition', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.nem.NEMSignTx.NEMMosaicCreation.NEMMosaicDefinition', '10': 'definition'},
+    {'1': 'sink', '3': 2, '4': 2, '5': 9, '10': 'sink'},
+    {'1': 'fee', '3': 3, '4': 2, '5': 4, '10': 'fee'},
+  ],
+  '3': [NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition$json],
+};
+
+@$core.Deprecated('Use nEMSignTxDescriptor instead')
+const NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition$json = {
+  '1': 'NEMMosaicDefinition',
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'ticker', '3': 2, '4': 1, '5': 9, '10': 'ticker'},
+    {'1': 'namespace', '3': 3, '4': 2, '5': 9, '10': 'namespace'},
+    {'1': 'mosaic', '3': 4, '4': 2, '5': 9, '10': 'mosaic'},
+    {'1': 'divisibility', '3': 5, '4': 1, '5': 13, '10': 'divisibility'},
+    {'1': 'levy', '3': 6, '4': 1, '5': 14, '6': '.hw.trezor.messages.nem.NEMSignTx.NEMMosaicCreation.NEMMosaicDefinition.NEMMosaicLevy', '10': 'levy'},
+    {'1': 'fee', '3': 7, '4': 1, '5': 4, '10': 'fee'},
+    {'1': 'levy_address', '3': 8, '4': 1, '5': 9, '10': 'levyAddress'},
+    {'1': 'levy_namespace', '3': 9, '4': 1, '5': 9, '10': 'levyNamespace'},
+    {'1': 'levy_mosaic', '3': 10, '4': 1, '5': 9, '10': 'levyMosaic'},
+    {'1': 'supply', '3': 11, '4': 1, '5': 4, '10': 'supply'},
+    {'1': 'mutable_supply', '3': 12, '4': 1, '5': 8, '10': 'mutableSupply'},
+    {'1': 'transferable', '3': 13, '4': 1, '5': 8, '10': 'transferable'},
+    {'1': 'description', '3': 14, '4': 2, '5': 9, '10': 'description'},
+    {'1': 'networks', '3': 15, '4': 3, '5': 13, '10': 'networks'},
+  ],
+  '4': [NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy$json],
+};
+
+@$core.Deprecated('Use nEMSignTxDescriptor instead')
+const NEMSignTx_NEMMosaicCreation_NEMMosaicDefinition_NEMMosaicLevy$json = {
+  '1': 'NEMMosaicLevy',
+  '2': [
+    {'1': 'MosaicLevy_Absolute', '2': 1},
+    {'1': 'MosaicLevy_Percentile', '2': 2},
+  ],
+};
+
+@$core.Deprecated('Use nEMSignTxDescriptor instead')
+const NEMSignTx_NEMMosaicSupplyChange$json = {
+  '1': 'NEMMosaicSupplyChange',
+  '2': [
+    {'1': 'namespace', '3': 1, '4': 2, '5': 9, '10': 'namespace'},
+    {'1': 'mosaic', '3': 2, '4': 2, '5': 9, '10': 'mosaic'},
+    {'1': 'type', '3': 3, '4': 2, '5': 14, '6': '.hw.trezor.messages.nem.NEMSignTx.NEMMosaicSupplyChange.NEMSupplyChangeType', '10': 'type'},
+    {'1': 'delta', '3': 4, '4': 2, '5': 4, '10': 'delta'},
+  ],
+  '4': [NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType$json],
+};
+
+@$core.Deprecated('Use nEMSignTxDescriptor instead')
+const NEMSignTx_NEMMosaicSupplyChange_NEMSupplyChangeType$json = {
+  '1': 'NEMSupplyChangeType',
+  '2': [
+    {'1': 'SupplyChange_Increase', '2': 1},
+    {'1': 'SupplyChange_Decrease', '2': 2},
+  ],
+};
+
+@$core.Deprecated('Use nEMSignTxDescriptor instead')
+const NEMSignTx_NEMAggregateModification$json = {
+  '1': 'NEMAggregateModification',
+  '2': [
+    {'1': 'modifications', '3': 1, '4': 3, '5': 11, '6': '.hw.trezor.messages.nem.NEMSignTx.NEMAggregateModification.NEMCosignatoryModification', '10': 'modifications'},
+    {'1': 'relative_change', '3': 2, '4': 1, '5': 17, '10': 'relativeChange'},
+  ],
+  '3': [NEMSignTx_NEMAggregateModification_NEMCosignatoryModification$json],
+};
+
+@$core.Deprecated('Use nEMSignTxDescriptor instead')
+const NEMSignTx_NEMAggregateModification_NEMCosignatoryModification$json = {
+  '1': 'NEMCosignatoryModification',
+  '2': [
+    {'1': 'type', '3': 1, '4': 2, '5': 14, '6': '.hw.trezor.messages.nem.NEMSignTx.NEMAggregateModification.NEMCosignatoryModification.NEMModificationType', '10': 'type'},
+    {'1': 'public_key', '3': 2, '4': 2, '5': 12, '10': 'publicKey'},
+  ],
+  '4': [NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType$json],
+};
+
+@$core.Deprecated('Use nEMSignTxDescriptor instead')
+const NEMSignTx_NEMAggregateModification_NEMCosignatoryModification_NEMModificationType$json = {
+  '1': 'NEMModificationType',
+  '2': [
+    {'1': 'CosignatoryModification_Add', '2': 1},
+    {'1': 'CosignatoryModification_Delete', '2': 2},
+  ],
+};
+
+@$core.Deprecated('Use nEMSignTxDescriptor instead')
+const NEMSignTx_NEMImportanceTransfer$json = {
+  '1': 'NEMImportanceTransfer',
+  '2': [
+    {'1': 'mode', '3': 1, '4': 2, '5': 14, '6': '.hw.trezor.messages.nem.NEMSignTx.NEMImportanceTransfer.NEMImportanceTransferMode', '10': 'mode'},
+    {'1': 'public_key', '3': 2, '4': 2, '5': 12, '10': 'publicKey'},
+  ],
+  '4': [NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode$json],
+};
+
+@$core.Deprecated('Use nEMSignTxDescriptor instead')
+const NEMSignTx_NEMImportanceTransfer_NEMImportanceTransferMode$json = {
+  '1': 'NEMImportanceTransferMode',
+  '2': [
+    {'1': 'ImportanceTransfer_Activate', '2': 1},
+    {'1': 'ImportanceTransfer_Deactivate', '2': 2},
+  ],
+};
+
+/// Descriptor for `NEMSignTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List nEMSignTxDescriptor = $convert.base64Decode(
+    'CglORU1TaWduVHgSWAoLdHJhbnNhY3Rpb24YASACKAsyNi5ody50cmV6b3IubWVzc2FnZXMubm'
+    'VtLk5FTVNpZ25UeC5ORU1UcmFuc2FjdGlvbkNvbW1vblILdHJhbnNhY3Rpb24SUgoIbXVsdGlz'
+    'aWcYAiABKAsyNi5ody50cmV6b3IubWVzc2FnZXMubmVtLk5FTVNpZ25UeC5ORU1UcmFuc2FjdG'
+    'lvbkNvbW1vblIIbXVsdGlzaWcSSQoIdHJhbnNmZXIYAyABKAsyLS5ody50cmV6b3IubWVzc2Fn'
+    'ZXMubmVtLk5FTVNpZ25UeC5ORU1UcmFuc2ZlclIIdHJhbnNmZXISHAoJY29zaWduaW5nGAQgAS'
+    'gIUgljb3NpZ25pbmcSaAoTcHJvdmlzaW9uX25hbWVzcGFjZRgFIAEoCzI3Lmh3LnRyZXpvci5t'
+    'ZXNzYWdlcy5uZW0uTkVNU2lnblR4Lk5FTVByb3Zpc2lvbk5hbWVzcGFjZVIScHJvdmlzaW9uTm'
+    'FtZXNwYWNlElwKD21vc2FpY19jcmVhdGlvbhgGIAEoCzIzLmh3LnRyZXpvci5tZXNzYWdlcy5u'
+    'ZW0uTkVNU2lnblR4Lk5FTU1vc2FpY0NyZWF0aW9uUg5tb3NhaWNDcmVhdGlvbhJcCg1zdXBwbH'
+    'lfY2hhbmdlGAcgASgLMjcuaHcudHJlem9yLm1lc3NhZ2VzLm5lbS5ORU1TaWduVHguTkVNTW9z'
+    'YWljU3VwcGx5Q2hhbmdlUgxzdXBwbHlDaGFuZ2UScQoWYWdncmVnYXRlX21vZGlmaWNhdGlvbh'
+    'gIIAEoCzI6Lmh3LnRyZXpvci5tZXNzYWdlcy5uZW0uTkVNU2lnblR4Lk5FTUFnZ3JlZ2F0ZU1v'
+    'ZGlmaWNhdGlvblIVYWdncmVnYXRlTW9kaWZpY2F0aW9uEmgKE2ltcG9ydGFuY2VfdHJhbnNmZX'
+    'IYCSABKAsyNy5ody50cmV6b3IubWVzc2FnZXMubmVtLk5FTVNpZ25UeC5ORU1JbXBvcnRhbmNl'
+    'VHJhbnNmZXJSEmltcG9ydGFuY2VUcmFuc2ZlchIaCghjaHVua2lmeRgKIAEoCFIIY2h1bmtpZn'
+    'katgEKFE5FTVRyYW5zYWN0aW9uQ29tbW9uEhsKCWFkZHJlc3NfbhgBIAMoDVIIYWRkcmVzc04S'
+    'HQoHbmV0d29yaxgCIAEoDToDMTA0UgduZXR3b3JrEhwKCXRpbWVzdGFtcBgDIAIoDVIJdGltZX'
+    'N0YW1wEhAKA2ZlZRgEIAIoBFIDZmVlEhoKCGRlYWRsaW5lGAUgAigNUghkZWFkbGluZRIWCgZz'
+    'aWduZXIYBiABKAxSBnNpZ25lchquAgoLTkVNVHJhbnNmZXISHAoJcmVjaXBpZW50GAEgAigJUg'
+    'lyZWNpcGllbnQSFgoGYW1vdW50GAIgAigEUgZhbW91bnQSGAoHcGF5bG9hZBgDIAEoDFIHcGF5'
+    'bG9hZBIdCgpwdWJsaWNfa2V5GAQgASgMUglwdWJsaWNLZXkSUQoHbW9zYWljcxgFIAMoCzI3Lm'
+    'h3LnRyZXpvci5tZXNzYWdlcy5uZW0uTkVNU2lnblR4Lk5FTVRyYW5zZmVyLk5FTU1vc2FpY1IH'
+    'bW9zYWljcxpdCglORU1Nb3NhaWMSHAoJbmFtZXNwYWNlGAEgAigJUgluYW1lc3BhY2USFgoGbW'
+    '9zYWljGAIgAigJUgZtb3NhaWMSGgoIcXVhbnRpdHkYAyACKARSCHF1YW50aXR5GnMKFU5FTVBy'
+    'b3Zpc2lvbk5hbWVzcGFjZRIcCgluYW1lc3BhY2UYASACKAlSCW5hbWVzcGFjZRIWCgZwYXJlbn'
+    'QYAiABKAlSBnBhcmVudBISCgRzaW5rGAMgAigJUgRzaW5rEhAKA2ZlZRgEIAIoBFIDZmVlGo4G'
+    'ChFORU1Nb3NhaWNDcmVhdGlvbhJnCgpkZWZpbml0aW9uGAEgAigLMkcuaHcudHJlem9yLm1lc3'
+    'NhZ2VzLm5lbS5ORU1TaWduVHguTkVNTW9zYWljQ3JlYXRpb24uTkVNTW9zYWljRGVmaW5pdGlv'
+    'blIKZGVmaW5pdGlvbhISCgRzaW5rGAIgAigJUgRzaW5rEhAKA2ZlZRgDIAIoBFIDZmVlGukECh'
+    'NORU1Nb3NhaWNEZWZpbml0aW9uEhIKBG5hbWUYASABKAlSBG5hbWUSFgoGdGlja2VyGAIgASgJ'
+    'UgZ0aWNrZXISHAoJbmFtZXNwYWNlGAMgAigJUgluYW1lc3BhY2USFgoGbW9zYWljGAQgAigJUg'
+    'Ztb3NhaWMSIgoMZGl2aXNpYmlsaXR5GAUgASgNUgxkaXZpc2liaWxpdHkSaQoEbGV2eRgGIAEo'
+    'DjJVLmh3LnRyZXpvci5tZXNzYWdlcy5uZW0uTkVNU2lnblR4Lk5FTU1vc2FpY0NyZWF0aW9uLk'
+    '5FTU1vc2FpY0RlZmluaXRpb24uTkVNTW9zYWljTGV2eVIEbGV2eRIQCgNmZWUYByABKARSA2Zl'
+    'ZRIhCgxsZXZ5X2FkZHJlc3MYCCABKAlSC2xldnlBZGRyZXNzEiUKDmxldnlfbmFtZXNwYWNlGA'
+    'kgASgJUg1sZXZ5TmFtZXNwYWNlEh8KC2xldnlfbW9zYWljGAogASgJUgpsZXZ5TW9zYWljEhYK'
+    'BnN1cHBseRgLIAEoBFIGc3VwcGx5EiUKDm11dGFibGVfc3VwcGx5GAwgASgIUg1tdXRhYmxlU3'
+    'VwcGx5EiIKDHRyYW5zZmVyYWJsZRgNIAEoCFIMdHJhbnNmZXJhYmxlEiAKC2Rlc2NyaXB0aW9u'
+    'GA4gAigJUgtkZXNjcmlwdGlvbhIaCghuZXR3b3JrcxgPIAMoDVIIbmV0d29ya3MiQwoNTkVNTW'
+    '9zYWljTGV2eRIXChNNb3NhaWNMZXZ5X0Fic29sdXRlEAESGQoVTW9zYWljTGV2eV9QZXJjZW50'
+    'aWxlEAIakQIKFU5FTU1vc2FpY1N1cHBseUNoYW5nZRIcCgluYW1lc3BhY2UYASACKAlSCW5hbW'
+    'VzcGFjZRIWCgZtb3NhaWMYAiACKAlSBm1vc2FpYxJfCgR0eXBlGAMgAigOMksuaHcudHJlem9y'
+    'Lm1lc3NhZ2VzLm5lbS5ORU1TaWduVHguTkVNTW9zYWljU3VwcGx5Q2hhbmdlLk5FTVN1cHBseU'
+    'NoYW5nZVR5cGVSBHR5cGUSFAoFZGVsdGEYBCACKARSBWRlbHRhIksKE05FTVN1cHBseUNoYW5n'
+    'ZVR5cGUSGQoVU3VwcGx5Q2hhbmdlX0luY3JlYXNlEAESGQoVU3VwcGx5Q2hhbmdlX0RlY3JlYX'
+    'NlEAIa2QMKGE5FTUFnZ3JlZ2F0ZU1vZGlmaWNhdGlvbhJ7Cg1tb2RpZmljYXRpb25zGAEgAygL'
+    'MlUuaHcudHJlem9yLm1lc3NhZ2VzLm5lbS5ORU1TaWduVHguTkVNQWdncmVnYXRlTW9kaWZpY2'
+    'F0aW9uLk5FTUNvc2lnbmF0b3J5TW9kaWZpY2F0aW9uUg1tb2RpZmljYXRpb25zEicKD3JlbGF0'
+    'aXZlX2NoYW5nZRgCIAEoEVIOcmVsYXRpdmVDaGFuZ2UalgIKGk5FTUNvc2lnbmF0b3J5TW9kaW'
+    'ZpY2F0aW9uEn0KBHR5cGUYASACKA4yaS5ody50cmV6b3IubWVzc2FnZXMubmVtLk5FTVNpZ25U'
+    'eC5ORU1BZ2dyZWdhdGVNb2RpZmljYXRpb24uTkVNQ29zaWduYXRvcnlNb2RpZmljYXRpb24uTk'
+    'VNTW9kaWZpY2F0aW9uVHlwZVIEdHlwZRIdCgpwdWJsaWNfa2V5GAIgAigMUglwdWJsaWNLZXki'
+    'WgoTTkVNTW9kaWZpY2F0aW9uVHlwZRIfChtDb3NpZ25hdG9yeU1vZGlmaWNhdGlvbl9BZGQQAR'
+    'IiCh5Db3NpZ25hdG9yeU1vZGlmaWNhdGlvbl9EZWxldGUQAhr+AQoVTkVNSW1wb3J0YW5jZVRy'
+    'YW5zZmVyEmUKBG1vZGUYASACKA4yUS5ody50cmV6b3IubWVzc2FnZXMubmVtLk5FTVNpZ25UeC'
+    '5ORU1JbXBvcnRhbmNlVHJhbnNmZXIuTkVNSW1wb3J0YW5jZVRyYW5zZmVyTW9kZVIEbW9kZRId'
+    'CgpwdWJsaWNfa2V5GAIgAigMUglwdWJsaWNLZXkiXwoZTkVNSW1wb3J0YW5jZVRyYW5zZmVyTW'
+    '9kZRIfChtJbXBvcnRhbmNlVHJhbnNmZXJfQWN0aXZhdGUQARIhCh1JbXBvcnRhbmNlVHJhbnNm'
+    'ZXJfRGVhY3RpdmF0ZRAC');
+
+@$core.Deprecated('Use nEMSignedTxDescriptor instead')
+const NEMSignedTx$json = {
+  '1': 'NEMSignedTx',
+  '2': [
+    {'1': 'data', '3': 1, '4': 2, '5': 12, '10': 'data'},
+    {'1': 'signature', '3': 2, '4': 2, '5': 12, '10': 'signature'},
+  ],
+};
+
+/// Descriptor for `NEMSignedTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List nEMSignedTxDescriptor = $convert.base64Decode(
+    'CgtORU1TaWduZWRUeBISCgRkYXRhGAEgAigMUgRkYXRhEhwKCXNpZ25hdHVyZRgCIAIoDFIJc2'
+    'lnbmF0dXJl');
+
+@$core.Deprecated('Use nEMDecryptMessageDescriptor instead')
+const NEMDecryptMessage$json = {
+  '1': 'NEMDecryptMessage',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'network', '3': 2, '4': 1, '5': 13, '10': 'network'},
+    {'1': 'public_key', '3': 3, '4': 1, '5': 12, '10': 'publicKey'},
+    {'1': 'payload', '3': 4, '4': 1, '5': 12, '10': 'payload'},
+  ],
+};
+
+/// Descriptor for `NEMDecryptMessage`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List nEMDecryptMessageDescriptor = $convert.base64Decode(
+    'ChFORU1EZWNyeXB0TWVzc2FnZRIbCglhZGRyZXNzX24YASADKA1SCGFkZHJlc3NOEhgKB25ldH'
+    'dvcmsYAiABKA1SB25ldHdvcmsSHQoKcHVibGljX2tleRgDIAEoDFIJcHVibGljS2V5EhgKB3Bh'
+    'eWxvYWQYBCABKAxSB3BheWxvYWQ=');
+
+@$core.Deprecated('Use nEMDecryptedMessageDescriptor instead')
+const NEMDecryptedMessage$json = {
+  '1': 'NEMDecryptedMessage',
+  '2': [
+    {'1': 'payload', '3': 1, '4': 2, '5': 12, '10': 'payload'},
+  ],
+};
+
+/// Descriptor for `NEMDecryptedMessage`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List nEMDecryptedMessageDescriptor = $convert.base64Decode(
+    'ChNORU1EZWNyeXB0ZWRNZXNzYWdlEhgKB3BheWxvYWQYASACKAxSB3BheWxvYWQ=');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-nem.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-nem.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-nem.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-nem.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ripple.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ripple.pb.dart
@@ -1,0 +1,428 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ripple.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+/// *
+///  Request: Address at the specified index
+///  @start
+///  @next RippleAddress
+class RippleGetAddress extends $pb.GeneratedMessage {
+  factory RippleGetAddress({
+    $core.Iterable<$core.int>? addressN,
+    $core.bool? showDisplay,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  RippleGetAddress._() : super();
+  factory RippleGetAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RippleGetAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RippleGetAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ripple'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aOB(2, _omitFieldNames ? '' : 'showDisplay')
+    ..aOB(3, _omitFieldNames ? '' : 'chunkify')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  RippleGetAddress clone() => RippleGetAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RippleGetAddress copyWith(void Function(RippleGetAddress) updates) => super.copyWith((message) => updates(message as RippleGetAddress)) as RippleGetAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static RippleGetAddress create() => RippleGetAddress._();
+  RippleGetAddress createEmptyInstance() => create();
+  static $pb.PbList<RippleGetAddress> createRepeated() => $pb.PbList<RippleGetAddress>();
+  @$core.pragma('dart2js:noInline')
+  static RippleGetAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RippleGetAddress>(create);
+  static RippleGetAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.bool get showDisplay => $_getBF(1);
+  @$pb.TagNumber(2)
+  set showDisplay($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasShowDisplay() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearShowDisplay() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get chunkify => $_getBF(2);
+  @$pb.TagNumber(3)
+  set chunkify($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasChunkify() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearChunkify() => clearField(3);
+}
+
+/// *
+///  Response: Address for the given index
+///  @end
+class RippleAddress extends $pb.GeneratedMessage {
+  factory RippleAddress({
+    $core.String? address,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    return $result;
+  }
+  RippleAddress._() : super();
+  factory RippleAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RippleAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RippleAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ripple'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'address')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  RippleAddress clone() => RippleAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RippleAddress copyWith(void Function(RippleAddress) updates) => super.copyWith((message) => updates(message as RippleAddress)) as RippleAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static RippleAddress create() => RippleAddress._();
+  RippleAddress createEmptyInstance() => create();
+  static $pb.PbList<RippleAddress> createRepeated() => $pb.PbList<RippleAddress>();
+  @$core.pragma('dart2js:noInline')
+  static RippleAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RippleAddress>(create);
+  static RippleAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+}
+
+/// *
+///  Payment transaction type
+///  - simple A sends money to B
+///  - only a subset of fields is supported
+///  - see https://developers.ripple.com/payment.html
+class RippleSignTx_RipplePayment extends $pb.GeneratedMessage {
+  factory RippleSignTx_RipplePayment({
+    $fixnum.Int64? amount,
+    $core.String? destination,
+    $core.int? destinationTag,
+  }) {
+    final $result = create();
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (destination != null) {
+      $result.destination = destination;
+    }
+    if (destinationTag != null) {
+      $result.destinationTag = destinationTag;
+    }
+    return $result;
+  }
+  RippleSignTx_RipplePayment._() : super();
+  factory RippleSignTx_RipplePayment.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RippleSignTx_RipplePayment.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RippleSignTx.RipplePayment', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ripple'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aQS(2, _omitFieldNames ? '' : 'destination')
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'destinationTag', $pb.PbFieldType.OU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  RippleSignTx_RipplePayment clone() => RippleSignTx_RipplePayment()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RippleSignTx_RipplePayment copyWith(void Function(RippleSignTx_RipplePayment) updates) => super.copyWith((message) => updates(message as RippleSignTx_RipplePayment)) as RippleSignTx_RipplePayment;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static RippleSignTx_RipplePayment create() => RippleSignTx_RipplePayment._();
+  RippleSignTx_RipplePayment createEmptyInstance() => create();
+  static $pb.PbList<RippleSignTx_RipplePayment> createRepeated() => $pb.PbList<RippleSignTx_RipplePayment>();
+  @$core.pragma('dart2js:noInline')
+  static RippleSignTx_RipplePayment getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RippleSignTx_RipplePayment>(create);
+  static RippleSignTx_RipplePayment? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get amount => $_getI64(0);
+  @$pb.TagNumber(1)
+  set amount($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAmount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAmount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get destination => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set destination($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasDestination() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearDestination() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get destinationTag => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set destinationTag($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasDestinationTag() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearDestinationTag() => clearField(3);
+}
+
+/// *
+///  Request: ask device to sign Ripple transaction
+///  @start
+///  @next RippleSignedTx
+class RippleSignTx extends $pb.GeneratedMessage {
+  factory RippleSignTx({
+    $core.Iterable<$core.int>? addressN,
+    $fixnum.Int64? fee,
+    $core.int? flags,
+    $core.int? sequence,
+    $core.int? lastLedgerSequence,
+    RippleSignTx_RipplePayment? payment,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (fee != null) {
+      $result.fee = fee;
+    }
+    if (flags != null) {
+      $result.flags = flags;
+    }
+    if (sequence != null) {
+      $result.sequence = sequence;
+    }
+    if (lastLedgerSequence != null) {
+      $result.lastLedgerSequence = lastLedgerSequence;
+    }
+    if (payment != null) {
+      $result.payment = payment;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  RippleSignTx._() : super();
+  factory RippleSignTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RippleSignTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RippleSignTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ripple'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'flags', $pb.PbFieldType.OU3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'sequence', $pb.PbFieldType.QU3)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'lastLedgerSequence', $pb.PbFieldType.OU3)
+    ..aQM<RippleSignTx_RipplePayment>(6, _omitFieldNames ? '' : 'payment', subBuilder: RippleSignTx_RipplePayment.create)
+    ..aOB(7, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  RippleSignTx clone() => RippleSignTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RippleSignTx copyWith(void Function(RippleSignTx) updates) => super.copyWith((message) => updates(message as RippleSignTx)) as RippleSignTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static RippleSignTx create() => RippleSignTx._();
+  RippleSignTx createEmptyInstance() => create();
+  static $pb.PbList<RippleSignTx> createRepeated() => $pb.PbList<RippleSignTx>();
+  @$core.pragma('dart2js:noInline')
+  static RippleSignTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RippleSignTx>(create);
+  static RippleSignTx? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get fee => $_getI64(1);
+  @$pb.TagNumber(2)
+  set fee($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasFee() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearFee() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get flags => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set flags($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasFlags() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearFlags() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get sequence => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set sequence($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasSequence() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearSequence() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get lastLedgerSequence => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set lastLedgerSequence($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasLastLedgerSequence() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearLastLedgerSequence() => clearField(5);
+
+  @$pb.TagNumber(6)
+  RippleSignTx_RipplePayment get payment => $_getN(5);
+  @$pb.TagNumber(6)
+  set payment(RippleSignTx_RipplePayment v) { setField(6, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasPayment() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearPayment() => clearField(6);
+  @$pb.TagNumber(6)
+  RippleSignTx_RipplePayment ensurePayment() => $_ensure(5);
+
+  @$pb.TagNumber(7)
+  $core.bool get chunkify => $_getBF(6);
+  @$pb.TagNumber(7)
+  set chunkify($core.bool v) { $_setBool(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasChunkify() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearChunkify() => clearField(7);
+}
+
+/// *
+///  Response: signature for transaction
+///  @end
+class RippleSignedTx extends $pb.GeneratedMessage {
+  factory RippleSignedTx({
+    $core.List<$core.int>? signature,
+    $core.List<$core.int>? serializedTx,
+  }) {
+    final $result = create();
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    if (serializedTx != null) {
+      $result.serializedTx = serializedTx;
+    }
+    return $result;
+  }
+  RippleSignedTx._() : super();
+  factory RippleSignedTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RippleSignedTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RippleSignedTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.ripple'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'serializedTx', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  RippleSignedTx clone() => RippleSignedTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RippleSignedTx copyWith(void Function(RippleSignedTx) updates) => super.copyWith((message) => updates(message as RippleSignedTx)) as RippleSignedTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static RippleSignedTx create() => RippleSignedTx._();
+  RippleSignedTx createEmptyInstance() => create();
+  static $pb.PbList<RippleSignedTx> createRepeated() => $pb.PbList<RippleSignedTx>();
+  @$core.pragma('dart2js:noInline')
+  static RippleSignedTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RippleSignedTx>(create);
+  static RippleSignedTx? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get signature => $_getN(0);
+  @$pb.TagNumber(1)
+  set signature($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSignature() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSignature() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get serializedTx => $_getN(1);
+  @$pb.TagNumber(2)
+  set serializedTx($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSerializedTx() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSerializedTx() => clearField(2);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ripple.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ripple.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ripple.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ripple.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ripple.pbjson.dart
@@ -1,0 +1,92 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ripple.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use rippleGetAddressDescriptor instead')
+const RippleGetAddress$json = {
+  '1': 'RippleGetAddress',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'show_display', '3': 2, '4': 1, '5': 8, '10': 'showDisplay'},
+    {'1': 'chunkify', '3': 3, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `RippleGetAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List rippleGetAddressDescriptor = $convert.base64Decode(
+    'ChBSaXBwbGVHZXRBZGRyZXNzEhsKCWFkZHJlc3NfbhgBIAMoDVIIYWRkcmVzc04SIQoMc2hvd1'
+    '9kaXNwbGF5GAIgASgIUgtzaG93RGlzcGxheRIaCghjaHVua2lmeRgDIAEoCFIIY2h1bmtpZnk=');
+
+@$core.Deprecated('Use rippleAddressDescriptor instead')
+const RippleAddress$json = {
+  '1': 'RippleAddress',
+  '2': [
+    {'1': 'address', '3': 1, '4': 2, '5': 9, '10': 'address'},
+  ],
+};
+
+/// Descriptor for `RippleAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List rippleAddressDescriptor = $convert.base64Decode(
+    'Cg1SaXBwbGVBZGRyZXNzEhgKB2FkZHJlc3MYASACKAlSB2FkZHJlc3M=');
+
+@$core.Deprecated('Use rippleSignTxDescriptor instead')
+const RippleSignTx$json = {
+  '1': 'RippleSignTx',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'fee', '3': 2, '4': 2, '5': 4, '10': 'fee'},
+    {'1': 'flags', '3': 3, '4': 1, '5': 13, '7': '0', '10': 'flags'},
+    {'1': 'sequence', '3': 4, '4': 2, '5': 13, '10': 'sequence'},
+    {'1': 'last_ledger_sequence', '3': 5, '4': 1, '5': 13, '10': 'lastLedgerSequence'},
+    {'1': 'payment', '3': 6, '4': 2, '5': 11, '6': '.hw.trezor.messages.ripple.RippleSignTx.RipplePayment', '10': 'payment'},
+    {'1': 'chunkify', '3': 7, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+  '3': [RippleSignTx_RipplePayment$json],
+};
+
+@$core.Deprecated('Use rippleSignTxDescriptor instead')
+const RippleSignTx_RipplePayment$json = {
+  '1': 'RipplePayment',
+  '2': [
+    {'1': 'amount', '3': 1, '4': 2, '5': 4, '10': 'amount'},
+    {'1': 'destination', '3': 2, '4': 2, '5': 9, '10': 'destination'},
+    {'1': 'destination_tag', '3': 3, '4': 1, '5': 13, '10': 'destinationTag'},
+  ],
+};
+
+/// Descriptor for `RippleSignTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List rippleSignTxDescriptor = $convert.base64Decode(
+    'CgxSaXBwbGVTaWduVHgSGwoJYWRkcmVzc19uGAEgAygNUghhZGRyZXNzThIQCgNmZWUYAiACKA'
+    'RSA2ZlZRIXCgVmbGFncxgDIAEoDToBMFIFZmxhZ3MSGgoIc2VxdWVuY2UYBCACKA1SCHNlcXVl'
+    'bmNlEjAKFGxhc3RfbGVkZ2VyX3NlcXVlbmNlGAUgASgNUhJsYXN0TGVkZ2VyU2VxdWVuY2USTw'
+    'oHcGF5bWVudBgGIAIoCzI1Lmh3LnRyZXpvci5tZXNzYWdlcy5yaXBwbGUuUmlwcGxlU2lnblR4'
+    'LlJpcHBsZVBheW1lbnRSB3BheW1lbnQSGgoIY2h1bmtpZnkYByABKAhSCGNodW5raWZ5GnIKDV'
+    'JpcHBsZVBheW1lbnQSFgoGYW1vdW50GAEgAigEUgZhbW91bnQSIAoLZGVzdGluYXRpb24YAiAC'
+    'KAlSC2Rlc3RpbmF0aW9uEicKD2Rlc3RpbmF0aW9uX3RhZxgDIAEoDVIOZGVzdGluYXRpb25UYW'
+    'c=');
+
+@$core.Deprecated('Use rippleSignedTxDescriptor instead')
+const RippleSignedTx$json = {
+  '1': 'RippleSignedTx',
+  '2': [
+    {'1': 'signature', '3': 1, '4': 2, '5': 12, '10': 'signature'},
+    {'1': 'serialized_tx', '3': 2, '4': 2, '5': 12, '10': 'serializedTx'},
+  ],
+};
+
+/// Descriptor for `RippleSignedTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List rippleSignedTxDescriptor = $convert.base64Decode(
+    'Cg5SaXBwbGVTaWduZWRUeBIcCglzaWduYXR1cmUYASACKAxSCXNpZ25hdHVyZRIjCg1zZXJpYW'
+    'xpemVkX3R4GAIgAigMUgxzZXJpYWxpemVkVHg=');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ripple.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-ripple.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-ripple.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-ripple.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-solana.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-solana.pb.dart
@@ -1,0 +1,530 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-solana.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+/// *
+///  Request: Ask device for public key corresponding to address_n path
+///  @start
+///  @next SolanaPublicKey
+///  @next Failure
+class SolanaGetPublicKey extends $pb.GeneratedMessage {
+  factory SolanaGetPublicKey({
+    $core.Iterable<$core.int>? addressN,
+    $core.bool? showDisplay,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    return $result;
+  }
+  SolanaGetPublicKey._() : super();
+  factory SolanaGetPublicKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SolanaGetPublicKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SolanaGetPublicKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.solana'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aOB(2, _omitFieldNames ? '' : 'showDisplay')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SolanaGetPublicKey clone() => SolanaGetPublicKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SolanaGetPublicKey copyWith(void Function(SolanaGetPublicKey) updates) => super.copyWith((message) => updates(message as SolanaGetPublicKey)) as SolanaGetPublicKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SolanaGetPublicKey create() => SolanaGetPublicKey._();
+  SolanaGetPublicKey createEmptyInstance() => create();
+  static $pb.PbList<SolanaGetPublicKey> createRepeated() => $pb.PbList<SolanaGetPublicKey>();
+  @$core.pragma('dart2js:noInline')
+  static SolanaGetPublicKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SolanaGetPublicKey>(create);
+  static SolanaGetPublicKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.bool get showDisplay => $_getBF(1);
+  @$pb.TagNumber(2)
+  set showDisplay($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasShowDisplay() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearShowDisplay() => clearField(2);
+}
+
+/// *
+///  Response: Contains public key derived from device private seed
+///  @end
+class SolanaPublicKey extends $pb.GeneratedMessage {
+  factory SolanaPublicKey({
+    $core.List<$core.int>? publicKey,
+  }) {
+    final $result = create();
+    if (publicKey != null) {
+      $result.publicKey = publicKey;
+    }
+    return $result;
+  }
+  SolanaPublicKey._() : super();
+  factory SolanaPublicKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SolanaPublicKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SolanaPublicKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.solana'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'publicKey', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SolanaPublicKey clone() => SolanaPublicKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SolanaPublicKey copyWith(void Function(SolanaPublicKey) updates) => super.copyWith((message) => updates(message as SolanaPublicKey)) as SolanaPublicKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SolanaPublicKey create() => SolanaPublicKey._();
+  SolanaPublicKey createEmptyInstance() => create();
+  static $pb.PbList<SolanaPublicKey> createRepeated() => $pb.PbList<SolanaPublicKey>();
+  @$core.pragma('dart2js:noInline')
+  static SolanaPublicKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SolanaPublicKey>(create);
+  static SolanaPublicKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get publicKey => $_getN(0);
+  @$pb.TagNumber(1)
+  set publicKey($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPublicKey() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPublicKey() => clearField(1);
+}
+
+/// *
+///  Request: Ask device for Solana address
+///  @start
+///  @next SolanaAddress
+///  @next Failure
+class SolanaGetAddress extends $pb.GeneratedMessage {
+  factory SolanaGetAddress({
+    $core.Iterable<$core.int>? addressN,
+    $core.bool? showDisplay,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  SolanaGetAddress._() : super();
+  factory SolanaGetAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SolanaGetAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SolanaGetAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.solana'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aOB(2, _omitFieldNames ? '' : 'showDisplay')
+    ..aOB(3, _omitFieldNames ? '' : 'chunkify')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SolanaGetAddress clone() => SolanaGetAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SolanaGetAddress copyWith(void Function(SolanaGetAddress) updates) => super.copyWith((message) => updates(message as SolanaGetAddress)) as SolanaGetAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SolanaGetAddress create() => SolanaGetAddress._();
+  SolanaGetAddress createEmptyInstance() => create();
+  static $pb.PbList<SolanaGetAddress> createRepeated() => $pb.PbList<SolanaGetAddress>();
+  @$core.pragma('dart2js:noInline')
+  static SolanaGetAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SolanaGetAddress>(create);
+  static SolanaGetAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.bool get showDisplay => $_getBF(1);
+  @$pb.TagNumber(2)
+  set showDisplay($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasShowDisplay() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearShowDisplay() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get chunkify => $_getBF(2);
+  @$pb.TagNumber(3)
+  set chunkify($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasChunkify() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearChunkify() => clearField(3);
+}
+
+/// *
+///  Response: Contains a Solana address derived from device private seed
+///  @end
+class SolanaAddress extends $pb.GeneratedMessage {
+  factory SolanaAddress({
+    $core.String? address,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    return $result;
+  }
+  SolanaAddress._() : super();
+  factory SolanaAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SolanaAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SolanaAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.solana'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'address')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SolanaAddress clone() => SolanaAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SolanaAddress copyWith(void Function(SolanaAddress) updates) => super.copyWith((message) => updates(message as SolanaAddress)) as SolanaAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SolanaAddress create() => SolanaAddress._();
+  SolanaAddress createEmptyInstance() => create();
+  static $pb.PbList<SolanaAddress> createRepeated() => $pb.PbList<SolanaAddress>();
+  @$core.pragma('dart2js:noInline')
+  static SolanaAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SolanaAddress>(create);
+  static SolanaAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+}
+
+/// *
+///  @embed
+class SolanaTxTokenAccountInfo extends $pb.GeneratedMessage {
+  factory SolanaTxTokenAccountInfo({
+    $core.String? baseAddress,
+    $core.String? tokenProgram,
+    $core.String? tokenMint,
+    $core.String? tokenAccount,
+  }) {
+    final $result = create();
+    if (baseAddress != null) {
+      $result.baseAddress = baseAddress;
+    }
+    if (tokenProgram != null) {
+      $result.tokenProgram = tokenProgram;
+    }
+    if (tokenMint != null) {
+      $result.tokenMint = tokenMint;
+    }
+    if (tokenAccount != null) {
+      $result.tokenAccount = tokenAccount;
+    }
+    return $result;
+  }
+  SolanaTxTokenAccountInfo._() : super();
+  factory SolanaTxTokenAccountInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SolanaTxTokenAccountInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SolanaTxTokenAccountInfo', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.solana'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'baseAddress')
+    ..aQS(2, _omitFieldNames ? '' : 'tokenProgram')
+    ..aQS(3, _omitFieldNames ? '' : 'tokenMint')
+    ..aQS(4, _omitFieldNames ? '' : 'tokenAccount')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SolanaTxTokenAccountInfo clone() => SolanaTxTokenAccountInfo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SolanaTxTokenAccountInfo copyWith(void Function(SolanaTxTokenAccountInfo) updates) => super.copyWith((message) => updates(message as SolanaTxTokenAccountInfo)) as SolanaTxTokenAccountInfo;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SolanaTxTokenAccountInfo create() => SolanaTxTokenAccountInfo._();
+  SolanaTxTokenAccountInfo createEmptyInstance() => create();
+  static $pb.PbList<SolanaTxTokenAccountInfo> createRepeated() => $pb.PbList<SolanaTxTokenAccountInfo>();
+  @$core.pragma('dart2js:noInline')
+  static SolanaTxTokenAccountInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SolanaTxTokenAccountInfo>(create);
+  static SolanaTxTokenAccountInfo? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get baseAddress => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set baseAddress($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasBaseAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearBaseAddress() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get tokenProgram => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set tokenProgram($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTokenProgram() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTokenProgram() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get tokenMint => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set tokenMint($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasTokenMint() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearTokenMint() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get tokenAccount => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set tokenAccount($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasTokenAccount() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearTokenAccount() => clearField(4);
+}
+
+/// *
+///  @embed
+class SolanaTxAdditionalInfo extends $pb.GeneratedMessage {
+  factory SolanaTxAdditionalInfo({
+    $core.Iterable<SolanaTxTokenAccountInfo>? tokenAccountsInfos,
+  }) {
+    final $result = create();
+    if (tokenAccountsInfos != null) {
+      $result.tokenAccountsInfos.addAll(tokenAccountsInfos);
+    }
+    return $result;
+  }
+  SolanaTxAdditionalInfo._() : super();
+  factory SolanaTxAdditionalInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SolanaTxAdditionalInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SolanaTxAdditionalInfo', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.solana'), createEmptyInstance: create)
+    ..pc<SolanaTxTokenAccountInfo>(1, _omitFieldNames ? '' : 'tokenAccountsInfos', $pb.PbFieldType.PM, subBuilder: SolanaTxTokenAccountInfo.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SolanaTxAdditionalInfo clone() => SolanaTxAdditionalInfo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SolanaTxAdditionalInfo copyWith(void Function(SolanaTxAdditionalInfo) updates) => super.copyWith((message) => updates(message as SolanaTxAdditionalInfo)) as SolanaTxAdditionalInfo;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SolanaTxAdditionalInfo create() => SolanaTxAdditionalInfo._();
+  SolanaTxAdditionalInfo createEmptyInstance() => create();
+  static $pb.PbList<SolanaTxAdditionalInfo> createRepeated() => $pb.PbList<SolanaTxAdditionalInfo>();
+  @$core.pragma('dart2js:noInline')
+  static SolanaTxAdditionalInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SolanaTxAdditionalInfo>(create);
+  static SolanaTxAdditionalInfo? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<SolanaTxTokenAccountInfo> get tokenAccountsInfos => $_getList(0);
+}
+
+/// *
+///  Request: Ask device to sign a Solana transaction
+///  @start
+///  @next SolanaTxSignature
+///  @next Failure
+class SolanaSignTx extends $pb.GeneratedMessage {
+  factory SolanaSignTx({
+    $core.Iterable<$core.int>? addressN,
+    $core.List<$core.int>? serializedTx,
+    SolanaTxAdditionalInfo? additionalInfo,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (serializedTx != null) {
+      $result.serializedTx = serializedTx;
+    }
+    if (additionalInfo != null) {
+      $result.additionalInfo = additionalInfo;
+    }
+    return $result;
+  }
+  SolanaSignTx._() : super();
+  factory SolanaSignTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SolanaSignTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SolanaSignTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.solana'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'serializedTx', $pb.PbFieldType.QY)
+    ..aOM<SolanaTxAdditionalInfo>(3, _omitFieldNames ? '' : 'additionalInfo', subBuilder: SolanaTxAdditionalInfo.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SolanaSignTx clone() => SolanaSignTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SolanaSignTx copyWith(void Function(SolanaSignTx) updates) => super.copyWith((message) => updates(message as SolanaSignTx)) as SolanaSignTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SolanaSignTx create() => SolanaSignTx._();
+  SolanaSignTx createEmptyInstance() => create();
+  static $pb.PbList<SolanaSignTx> createRepeated() => $pb.PbList<SolanaSignTx>();
+  @$core.pragma('dart2js:noInline')
+  static SolanaSignTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SolanaSignTx>(create);
+  static SolanaSignTx? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get serializedTx => $_getN(1);
+  @$pb.TagNumber(2)
+  set serializedTx($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSerializedTx() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSerializedTx() => clearField(2);
+
+  @$pb.TagNumber(3)
+  SolanaTxAdditionalInfo get additionalInfo => $_getN(2);
+  @$pb.TagNumber(3)
+  set additionalInfo(SolanaTxAdditionalInfo v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasAdditionalInfo() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearAdditionalInfo() => clearField(3);
+  @$pb.TagNumber(3)
+  SolanaTxAdditionalInfo ensureAdditionalInfo() => $_ensure(2);
+}
+
+/// *
+///  Response: Contains the transaction signature
+///  @end
+class SolanaTxSignature extends $pb.GeneratedMessage {
+  factory SolanaTxSignature({
+    $core.List<$core.int>? signature,
+  }) {
+    final $result = create();
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    return $result;
+  }
+  SolanaTxSignature._() : super();
+  factory SolanaTxSignature.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SolanaTxSignature.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SolanaTxSignature', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.solana'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SolanaTxSignature clone() => SolanaTxSignature()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SolanaTxSignature copyWith(void Function(SolanaTxSignature) updates) => super.copyWith((message) => updates(message as SolanaTxSignature)) as SolanaTxSignature;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SolanaTxSignature create() => SolanaTxSignature._();
+  SolanaTxSignature createEmptyInstance() => create();
+  static $pb.PbList<SolanaTxSignature> createRepeated() => $pb.PbList<SolanaTxSignature>();
+  @$core.pragma('dart2js:noInline')
+  static SolanaTxSignature getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SolanaTxSignature>(create);
+  static SolanaTxSignature? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get signature => $_getN(0);
+  @$pb.TagNumber(1)
+  set signature($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSignature() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSignature() => clearField(1);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-solana.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-solana.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-solana.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-solana.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-solana.pbjson.dart
@@ -1,0 +1,129 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-solana.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use solanaGetPublicKeyDescriptor instead')
+const SolanaGetPublicKey$json = {
+  '1': 'SolanaGetPublicKey',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'show_display', '3': 2, '4': 1, '5': 8, '10': 'showDisplay'},
+  ],
+};
+
+/// Descriptor for `SolanaGetPublicKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List solanaGetPublicKeyDescriptor = $convert.base64Decode(
+    'ChJTb2xhbmFHZXRQdWJsaWNLZXkSGwoJYWRkcmVzc19uGAEgAygNUghhZGRyZXNzThIhCgxzaG'
+    '93X2Rpc3BsYXkYAiABKAhSC3Nob3dEaXNwbGF5');
+
+@$core.Deprecated('Use solanaPublicKeyDescriptor instead')
+const SolanaPublicKey$json = {
+  '1': 'SolanaPublicKey',
+  '2': [
+    {'1': 'public_key', '3': 1, '4': 2, '5': 12, '10': 'publicKey'},
+  ],
+};
+
+/// Descriptor for `SolanaPublicKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List solanaPublicKeyDescriptor = $convert.base64Decode(
+    'Cg9Tb2xhbmFQdWJsaWNLZXkSHQoKcHVibGljX2tleRgBIAIoDFIJcHVibGljS2V5');
+
+@$core.Deprecated('Use solanaGetAddressDescriptor instead')
+const SolanaGetAddress$json = {
+  '1': 'SolanaGetAddress',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'show_display', '3': 2, '4': 1, '5': 8, '10': 'showDisplay'},
+    {'1': 'chunkify', '3': 3, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `SolanaGetAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List solanaGetAddressDescriptor = $convert.base64Decode(
+    'ChBTb2xhbmFHZXRBZGRyZXNzEhsKCWFkZHJlc3NfbhgBIAMoDVIIYWRkcmVzc04SIQoMc2hvd1'
+    '9kaXNwbGF5GAIgASgIUgtzaG93RGlzcGxheRIaCghjaHVua2lmeRgDIAEoCFIIY2h1bmtpZnk=');
+
+@$core.Deprecated('Use solanaAddressDescriptor instead')
+const SolanaAddress$json = {
+  '1': 'SolanaAddress',
+  '2': [
+    {'1': 'address', '3': 1, '4': 2, '5': 9, '10': 'address'},
+  ],
+};
+
+/// Descriptor for `SolanaAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List solanaAddressDescriptor = $convert.base64Decode(
+    'Cg1Tb2xhbmFBZGRyZXNzEhgKB2FkZHJlc3MYASACKAlSB2FkZHJlc3M=');
+
+@$core.Deprecated('Use solanaTxTokenAccountInfoDescriptor instead')
+const SolanaTxTokenAccountInfo$json = {
+  '1': 'SolanaTxTokenAccountInfo',
+  '2': [
+    {'1': 'base_address', '3': 1, '4': 2, '5': 9, '10': 'baseAddress'},
+    {'1': 'token_program', '3': 2, '4': 2, '5': 9, '10': 'tokenProgram'},
+    {'1': 'token_mint', '3': 3, '4': 2, '5': 9, '10': 'tokenMint'},
+    {'1': 'token_account', '3': 4, '4': 2, '5': 9, '10': 'tokenAccount'},
+  ],
+};
+
+/// Descriptor for `SolanaTxTokenAccountInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List solanaTxTokenAccountInfoDescriptor = $convert.base64Decode(
+    'ChhTb2xhbmFUeFRva2VuQWNjb3VudEluZm8SIQoMYmFzZV9hZGRyZXNzGAEgAigJUgtiYXNlQW'
+    'RkcmVzcxIjCg10b2tlbl9wcm9ncmFtGAIgAigJUgx0b2tlblByb2dyYW0SHQoKdG9rZW5fbWlu'
+    'dBgDIAIoCVIJdG9rZW5NaW50EiMKDXRva2VuX2FjY291bnQYBCACKAlSDHRva2VuQWNjb3VudA'
+    '==');
+
+@$core.Deprecated('Use solanaTxAdditionalInfoDescriptor instead')
+const SolanaTxAdditionalInfo$json = {
+  '1': 'SolanaTxAdditionalInfo',
+  '2': [
+    {'1': 'token_accounts_infos', '3': 1, '4': 3, '5': 11, '6': '.hw.trezor.messages.solana.SolanaTxTokenAccountInfo', '10': 'tokenAccountsInfos'},
+  ],
+};
+
+/// Descriptor for `SolanaTxAdditionalInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List solanaTxAdditionalInfoDescriptor = $convert.base64Decode(
+    'ChZTb2xhbmFUeEFkZGl0aW9uYWxJbmZvEmUKFHRva2VuX2FjY291bnRzX2luZm9zGAEgAygLMj'
+    'MuaHcudHJlem9yLm1lc3NhZ2VzLnNvbGFuYS5Tb2xhbmFUeFRva2VuQWNjb3VudEluZm9SEnRv'
+    'a2VuQWNjb3VudHNJbmZvcw==');
+
+@$core.Deprecated('Use solanaSignTxDescriptor instead')
+const SolanaSignTx$json = {
+  '1': 'SolanaSignTx',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'serialized_tx', '3': 2, '4': 2, '5': 12, '10': 'serializedTx'},
+    {'1': 'additional_info', '3': 3, '4': 1, '5': 11, '6': '.hw.trezor.messages.solana.SolanaTxAdditionalInfo', '10': 'additionalInfo'},
+  ],
+};
+
+/// Descriptor for `SolanaSignTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List solanaSignTxDescriptor = $convert.base64Decode(
+    'CgxTb2xhbmFTaWduVHgSGwoJYWRkcmVzc19uGAEgAygNUghhZGRyZXNzThIjCg1zZXJpYWxpem'
+    'VkX3R4GAIgAigMUgxzZXJpYWxpemVkVHgSWgoPYWRkaXRpb25hbF9pbmZvGAMgASgLMjEuaHcu'
+    'dHJlem9yLm1lc3NhZ2VzLnNvbGFuYS5Tb2xhbmFUeEFkZGl0aW9uYWxJbmZvUg5hZGRpdGlvbm'
+    'FsSW5mbw==');
+
+@$core.Deprecated('Use solanaTxSignatureDescriptor instead')
+const SolanaTxSignature$json = {
+  '1': 'SolanaTxSignature',
+  '2': [
+    {'1': 'signature', '3': 1, '4': 2, '5': 12, '10': 'signature'},
+  ],
+};
+
+/// Descriptor for `SolanaTxSignature`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List solanaTxSignatureDescriptor = $convert.base64Decode(
+    'ChFTb2xhbmFUeFNpZ25hdHVyZRIcCglzaWduYXR1cmUYASACKAxSCXNpZ25hdHVyZQ==');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-solana.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-solana.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-solana.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-solana.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-stellar.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-stellar.pb.dart
@@ -1,0 +1,2084 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-stellar.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'messages-stellar.pbenum.dart';
+
+export 'messages-stellar.pbenum.dart';
+
+/// *
+///  Describes a Stellar asset
+///  @embed
+class StellarAsset extends $pb.GeneratedMessage {
+  factory StellarAsset({
+    StellarAssetType? type,
+    $core.String? code,
+    $core.String? issuer,
+  }) {
+    final $result = create();
+    if (type != null) {
+      $result.type = type;
+    }
+    if (code != null) {
+      $result.code = code;
+    }
+    if (issuer != null) {
+      $result.issuer = issuer;
+    }
+    return $result;
+  }
+  StellarAsset._() : super();
+  factory StellarAsset.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarAsset.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarAsset', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..e<StellarAssetType>(1, _omitFieldNames ? '' : 'type', $pb.PbFieldType.QE, defaultOrMaker: StellarAssetType.NATIVE, valueOf: StellarAssetType.valueOf, enumValues: StellarAssetType.values)
+    ..aOS(2, _omitFieldNames ? '' : 'code')
+    ..aOS(3, _omitFieldNames ? '' : 'issuer')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarAsset clone() => StellarAsset()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarAsset copyWith(void Function(StellarAsset) updates) => super.copyWith((message) => updates(message as StellarAsset)) as StellarAsset;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarAsset create() => StellarAsset._();
+  StellarAsset createEmptyInstance() => create();
+  static $pb.PbList<StellarAsset> createRepeated() => $pb.PbList<StellarAsset>();
+  @$core.pragma('dart2js:noInline')
+  static StellarAsset getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarAsset>(create);
+  static StellarAsset? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  StellarAssetType get type => $_getN(0);
+  @$pb.TagNumber(1)
+  set type(StellarAssetType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearType() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get code => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set code($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasCode() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCode() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get issuer => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set issuer($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasIssuer() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearIssuer() => clearField(3);
+}
+
+/// *
+///  Request: Address at the specified index
+///  @start
+///  @next StellarAddress
+class StellarGetAddress extends $pb.GeneratedMessage {
+  factory StellarGetAddress({
+    $core.Iterable<$core.int>? addressN,
+    $core.bool? showDisplay,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  StellarGetAddress._() : super();
+  factory StellarGetAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarGetAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarGetAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aOB(2, _omitFieldNames ? '' : 'showDisplay')
+    ..aOB(3, _omitFieldNames ? '' : 'chunkify')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarGetAddress clone() => StellarGetAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarGetAddress copyWith(void Function(StellarGetAddress) updates) => super.copyWith((message) => updates(message as StellarGetAddress)) as StellarGetAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarGetAddress create() => StellarGetAddress._();
+  StellarGetAddress createEmptyInstance() => create();
+  static $pb.PbList<StellarGetAddress> createRepeated() => $pb.PbList<StellarGetAddress>();
+  @$core.pragma('dart2js:noInline')
+  static StellarGetAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarGetAddress>(create);
+  static StellarGetAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.bool get showDisplay => $_getBF(1);
+  @$pb.TagNumber(2)
+  set showDisplay($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasShowDisplay() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearShowDisplay() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get chunkify => $_getBF(2);
+  @$pb.TagNumber(3)
+  set chunkify($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasChunkify() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearChunkify() => clearField(3);
+}
+
+/// *
+///  Response: Address for the given index
+///  @end
+class StellarAddress extends $pb.GeneratedMessage {
+  factory StellarAddress({
+    $core.String? address,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    return $result;
+  }
+  StellarAddress._() : super();
+  factory StellarAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'address')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarAddress clone() => StellarAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarAddress copyWith(void Function(StellarAddress) updates) => super.copyWith((message) => updates(message as StellarAddress)) as StellarAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarAddress create() => StellarAddress._();
+  StellarAddress createEmptyInstance() => create();
+  static $pb.PbList<StellarAddress> createRepeated() => $pb.PbList<StellarAddress>();
+  @$core.pragma('dart2js:noInline')
+  static StellarAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarAddress>(create);
+  static StellarAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+}
+
+/// *
+///  Request: ask device to sign Stellar transaction
+///  @start
+///  @next StellarTxOpRequest
+class StellarSignTx extends $pb.GeneratedMessage {
+  factory StellarSignTx({
+    $core.Iterable<$core.int>? addressN,
+    $core.String? networkPassphrase,
+    $core.String? sourceAccount,
+    $core.int? fee,
+    $fixnum.Int64? sequenceNumber,
+    $core.int? timeboundsStart,
+    $core.int? timeboundsEnd,
+    StellarSignTx_StellarMemoType? memoType,
+    $core.String? memoText,
+    $fixnum.Int64? memoId,
+    $core.List<$core.int>? memoHash,
+    $core.int? numOperations,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (networkPassphrase != null) {
+      $result.networkPassphrase = networkPassphrase;
+    }
+    if (sourceAccount != null) {
+      $result.sourceAccount = sourceAccount;
+    }
+    if (fee != null) {
+      $result.fee = fee;
+    }
+    if (sequenceNumber != null) {
+      $result.sequenceNumber = sequenceNumber;
+    }
+    if (timeboundsStart != null) {
+      $result.timeboundsStart = timeboundsStart;
+    }
+    if (timeboundsEnd != null) {
+      $result.timeboundsEnd = timeboundsEnd;
+    }
+    if (memoType != null) {
+      $result.memoType = memoType;
+    }
+    if (memoText != null) {
+      $result.memoText = memoText;
+    }
+    if (memoId != null) {
+      $result.memoId = memoId;
+    }
+    if (memoHash != null) {
+      $result.memoHash = memoHash;
+    }
+    if (numOperations != null) {
+      $result.numOperations = numOperations;
+    }
+    return $result;
+  }
+  StellarSignTx._() : super();
+  factory StellarSignTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarSignTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarSignTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..p<$core.int>(2, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aQS(3, _omitFieldNames ? '' : 'networkPassphrase')
+    ..aQS(4, _omitFieldNames ? '' : 'sourceAccount')
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.QU3)
+    ..a<$fixnum.Int64>(6, _omitFieldNames ? '' : 'sequenceNumber', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(8, _omitFieldNames ? '' : 'timeboundsStart', $pb.PbFieldType.QU3)
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'timeboundsEnd', $pb.PbFieldType.QU3)
+    ..e<StellarSignTx_StellarMemoType>(10, _omitFieldNames ? '' : 'memoType', $pb.PbFieldType.QE, defaultOrMaker: StellarSignTx_StellarMemoType.NONE, valueOf: StellarSignTx_StellarMemoType.valueOf, enumValues: StellarSignTx_StellarMemoType.values)
+    ..aOS(11, _omitFieldNames ? '' : 'memoText')
+    ..a<$fixnum.Int64>(12, _omitFieldNames ? '' : 'memoId', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.List<$core.int>>(13, _omitFieldNames ? '' : 'memoHash', $pb.PbFieldType.OY)
+    ..a<$core.int>(14, _omitFieldNames ? '' : 'numOperations', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarSignTx clone() => StellarSignTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarSignTx copyWith(void Function(StellarSignTx) updates) => super.copyWith((message) => updates(message as StellarSignTx)) as StellarSignTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarSignTx create() => StellarSignTx._();
+  StellarSignTx createEmptyInstance() => create();
+  static $pb.PbList<StellarSignTx> createRepeated() => $pb.PbList<StellarSignTx>();
+  @$core.pragma('dart2js:noInline')
+  static StellarSignTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarSignTx>(create);
+  static StellarSignTx? _defaultInstance;
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(3)
+  $core.String get networkPassphrase => $_getSZ(1);
+  @$pb.TagNumber(3)
+  set networkPassphrase($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasNetworkPassphrase() => $_has(1);
+  @$pb.TagNumber(3)
+  void clearNetworkPassphrase() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get sourceAccount => $_getSZ(2);
+  @$pb.TagNumber(4)
+  set sourceAccount($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasSourceAccount() => $_has(2);
+  @$pb.TagNumber(4)
+  void clearSourceAccount() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get fee => $_getIZ(3);
+  @$pb.TagNumber(5)
+  set fee($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasFee() => $_has(3);
+  @$pb.TagNumber(5)
+  void clearFee() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $fixnum.Int64 get sequenceNumber => $_getI64(4);
+  @$pb.TagNumber(6)
+  set sequenceNumber($fixnum.Int64 v) { $_setInt64(4, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasSequenceNumber() => $_has(4);
+  @$pb.TagNumber(6)
+  void clearSequenceNumber() => clearField(6);
+
+  @$pb.TagNumber(8)
+  $core.int get timeboundsStart => $_getIZ(5);
+  @$pb.TagNumber(8)
+  set timeboundsStart($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasTimeboundsStart() => $_has(5);
+  @$pb.TagNumber(8)
+  void clearTimeboundsStart() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.int get timeboundsEnd => $_getIZ(6);
+  @$pb.TagNumber(9)
+  set timeboundsEnd($core.int v) { $_setUnsignedInt32(6, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasTimeboundsEnd() => $_has(6);
+  @$pb.TagNumber(9)
+  void clearTimeboundsEnd() => clearField(9);
+
+  @$pb.TagNumber(10)
+  StellarSignTx_StellarMemoType get memoType => $_getN(7);
+  @$pb.TagNumber(10)
+  set memoType(StellarSignTx_StellarMemoType v) { setField(10, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasMemoType() => $_has(7);
+  @$pb.TagNumber(10)
+  void clearMemoType() => clearField(10);
+
+  @$pb.TagNumber(11)
+  $core.String get memoText => $_getSZ(8);
+  @$pb.TagNumber(11)
+  set memoText($core.String v) { $_setString(8, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasMemoText() => $_has(8);
+  @$pb.TagNumber(11)
+  void clearMemoText() => clearField(11);
+
+  @$pb.TagNumber(12)
+  $fixnum.Int64 get memoId => $_getI64(9);
+  @$pb.TagNumber(12)
+  set memoId($fixnum.Int64 v) { $_setInt64(9, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasMemoId() => $_has(9);
+  @$pb.TagNumber(12)
+  void clearMemoId() => clearField(12);
+
+  @$pb.TagNumber(13)
+  $core.List<$core.int> get memoHash => $_getN(10);
+  @$pb.TagNumber(13)
+  set memoHash($core.List<$core.int> v) { $_setBytes(10, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasMemoHash() => $_has(10);
+  @$pb.TagNumber(13)
+  void clearMemoHash() => clearField(13);
+
+  @$pb.TagNumber(14)
+  $core.int get numOperations => $_getIZ(11);
+  @$pb.TagNumber(14)
+  set numOperations($core.int v) { $_setUnsignedInt32(11, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasNumOperations() => $_has(11);
+  @$pb.TagNumber(14)
+  void clearNumOperations() => clearField(14);
+}
+
+/// *
+///  Response: device is ready for client to send the next operation
+///  @next StellarPaymentOp
+///  @next StellarCreateAccountOp
+///  @next StellarPathPaymentStrictReceiveOp
+///  @next StellarPathPaymentStrictSendOp
+///  @next StellarManageSellOfferOp
+///  @next StellarManageBuyOfferOp
+///  @next StellarCreatePassiveSellOfferOp
+///  @next StellarSetOptionsOp
+///  @next StellarChangeTrustOp
+///  @next StellarAllowTrustOp
+///  @next StellarAccountMergeOp
+///  @next StellarManageDataOp
+///  @next StellarBumpSequenceOp
+class StellarTxOpRequest extends $pb.GeneratedMessage {
+  factory StellarTxOpRequest() => create();
+  StellarTxOpRequest._() : super();
+  factory StellarTxOpRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarTxOpRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarTxOpRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarTxOpRequest clone() => StellarTxOpRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarTxOpRequest copyWith(void Function(StellarTxOpRequest) updates) => super.copyWith((message) => updates(message as StellarTxOpRequest)) as StellarTxOpRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarTxOpRequest create() => StellarTxOpRequest._();
+  StellarTxOpRequest createEmptyInstance() => create();
+  static $pb.PbList<StellarTxOpRequest> createRepeated() => $pb.PbList<StellarTxOpRequest>();
+  @$core.pragma('dart2js:noInline')
+  static StellarTxOpRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarTxOpRequest>(create);
+  static StellarTxOpRequest? _defaultInstance;
+}
+
+/// *
+///  Request: ask device to confirm this operation type
+///  @next StellarTxOpRequest
+///  @next StellarSignedTx
+class StellarPaymentOp extends $pb.GeneratedMessage {
+  factory StellarPaymentOp({
+    $core.String? sourceAccount,
+    $core.String? destinationAccount,
+    StellarAsset? asset,
+    $fixnum.Int64? amount,
+  }) {
+    final $result = create();
+    if (sourceAccount != null) {
+      $result.sourceAccount = sourceAccount;
+    }
+    if (destinationAccount != null) {
+      $result.destinationAccount = destinationAccount;
+    }
+    if (asset != null) {
+      $result.asset = asset;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    return $result;
+  }
+  StellarPaymentOp._() : super();
+  factory StellarPaymentOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarPaymentOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarPaymentOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sourceAccount')
+    ..aQS(2, _omitFieldNames ? '' : 'destinationAccount')
+    ..aQM<StellarAsset>(3, _omitFieldNames ? '' : 'asset', subBuilder: StellarAsset.create)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarPaymentOp clone() => StellarPaymentOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarPaymentOp copyWith(void Function(StellarPaymentOp) updates) => super.copyWith((message) => updates(message as StellarPaymentOp)) as StellarPaymentOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarPaymentOp create() => StellarPaymentOp._();
+  StellarPaymentOp createEmptyInstance() => create();
+  static $pb.PbList<StellarPaymentOp> createRepeated() => $pb.PbList<StellarPaymentOp>();
+  @$core.pragma('dart2js:noInline')
+  static StellarPaymentOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarPaymentOp>(create);
+  static StellarPaymentOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sourceAccount => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sourceAccount($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSourceAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSourceAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get destinationAccount => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set destinationAccount($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasDestinationAccount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearDestinationAccount() => clearField(2);
+
+  @$pb.TagNumber(3)
+  StellarAsset get asset => $_getN(2);
+  @$pb.TagNumber(3)
+  set asset(StellarAsset v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasAsset() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearAsset() => clearField(3);
+  @$pb.TagNumber(3)
+  StellarAsset ensureAsset() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get amount => $_getI64(3);
+  @$pb.TagNumber(4)
+  set amount($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasAmount() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearAmount() => clearField(4);
+}
+
+/// *
+///  Request: ask device to confirm this operation type
+///  @next StellarTxOpRequest
+///  @next StellarSignedTx
+class StellarCreateAccountOp extends $pb.GeneratedMessage {
+  factory StellarCreateAccountOp({
+    $core.String? sourceAccount,
+    $core.String? newAccount,
+    $fixnum.Int64? startingBalance,
+  }) {
+    final $result = create();
+    if (sourceAccount != null) {
+      $result.sourceAccount = sourceAccount;
+    }
+    if (newAccount != null) {
+      $result.newAccount = newAccount;
+    }
+    if (startingBalance != null) {
+      $result.startingBalance = startingBalance;
+    }
+    return $result;
+  }
+  StellarCreateAccountOp._() : super();
+  factory StellarCreateAccountOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarCreateAccountOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarCreateAccountOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sourceAccount')
+    ..aQS(2, _omitFieldNames ? '' : 'newAccount')
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'startingBalance', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarCreateAccountOp clone() => StellarCreateAccountOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarCreateAccountOp copyWith(void Function(StellarCreateAccountOp) updates) => super.copyWith((message) => updates(message as StellarCreateAccountOp)) as StellarCreateAccountOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarCreateAccountOp create() => StellarCreateAccountOp._();
+  StellarCreateAccountOp createEmptyInstance() => create();
+  static $pb.PbList<StellarCreateAccountOp> createRepeated() => $pb.PbList<StellarCreateAccountOp>();
+  @$core.pragma('dart2js:noInline')
+  static StellarCreateAccountOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarCreateAccountOp>(create);
+  static StellarCreateAccountOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sourceAccount => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sourceAccount($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSourceAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSourceAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get newAccount => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set newAccount($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasNewAccount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNewAccount() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get startingBalance => $_getI64(2);
+  @$pb.TagNumber(3)
+  set startingBalance($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasStartingBalance() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearStartingBalance() => clearField(3);
+}
+
+/// *
+///  Request: ask device to confirm this operation type
+///  @next StellarTxOpRequest
+///  @next StellarSignedTx
+class StellarPathPaymentStrictReceiveOp extends $pb.GeneratedMessage {
+  factory StellarPathPaymentStrictReceiveOp({
+    $core.String? sourceAccount,
+    StellarAsset? sendAsset,
+    $fixnum.Int64? sendMax,
+    $core.String? destinationAccount,
+    StellarAsset? destinationAsset,
+    $fixnum.Int64? destinationAmount,
+    $core.Iterable<StellarAsset>? paths,
+  }) {
+    final $result = create();
+    if (sourceAccount != null) {
+      $result.sourceAccount = sourceAccount;
+    }
+    if (sendAsset != null) {
+      $result.sendAsset = sendAsset;
+    }
+    if (sendMax != null) {
+      $result.sendMax = sendMax;
+    }
+    if (destinationAccount != null) {
+      $result.destinationAccount = destinationAccount;
+    }
+    if (destinationAsset != null) {
+      $result.destinationAsset = destinationAsset;
+    }
+    if (destinationAmount != null) {
+      $result.destinationAmount = destinationAmount;
+    }
+    if (paths != null) {
+      $result.paths.addAll(paths);
+    }
+    return $result;
+  }
+  StellarPathPaymentStrictReceiveOp._() : super();
+  factory StellarPathPaymentStrictReceiveOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarPathPaymentStrictReceiveOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarPathPaymentStrictReceiveOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sourceAccount')
+    ..aQM<StellarAsset>(2, _omitFieldNames ? '' : 'sendAsset', subBuilder: StellarAsset.create)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'sendMax', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aQS(4, _omitFieldNames ? '' : 'destinationAccount')
+    ..aQM<StellarAsset>(5, _omitFieldNames ? '' : 'destinationAsset', subBuilder: StellarAsset.create)
+    ..a<$fixnum.Int64>(6, _omitFieldNames ? '' : 'destinationAmount', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..pc<StellarAsset>(7, _omitFieldNames ? '' : 'paths', $pb.PbFieldType.PM, subBuilder: StellarAsset.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarPathPaymentStrictReceiveOp clone() => StellarPathPaymentStrictReceiveOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarPathPaymentStrictReceiveOp copyWith(void Function(StellarPathPaymentStrictReceiveOp) updates) => super.copyWith((message) => updates(message as StellarPathPaymentStrictReceiveOp)) as StellarPathPaymentStrictReceiveOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarPathPaymentStrictReceiveOp create() => StellarPathPaymentStrictReceiveOp._();
+  StellarPathPaymentStrictReceiveOp createEmptyInstance() => create();
+  static $pb.PbList<StellarPathPaymentStrictReceiveOp> createRepeated() => $pb.PbList<StellarPathPaymentStrictReceiveOp>();
+  @$core.pragma('dart2js:noInline')
+  static StellarPathPaymentStrictReceiveOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarPathPaymentStrictReceiveOp>(create);
+  static StellarPathPaymentStrictReceiveOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sourceAccount => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sourceAccount($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSourceAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSourceAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  StellarAsset get sendAsset => $_getN(1);
+  @$pb.TagNumber(2)
+  set sendAsset(StellarAsset v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSendAsset() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSendAsset() => clearField(2);
+  @$pb.TagNumber(2)
+  StellarAsset ensureSendAsset() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get sendMax => $_getI64(2);
+  @$pb.TagNumber(3)
+  set sendMax($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSendMax() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSendMax() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get destinationAccount => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set destinationAccount($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasDestinationAccount() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearDestinationAccount() => clearField(4);
+
+  @$pb.TagNumber(5)
+  StellarAsset get destinationAsset => $_getN(4);
+  @$pb.TagNumber(5)
+  set destinationAsset(StellarAsset v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasDestinationAsset() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearDestinationAsset() => clearField(5);
+  @$pb.TagNumber(5)
+  StellarAsset ensureDestinationAsset() => $_ensure(4);
+
+  @$pb.TagNumber(6)
+  $fixnum.Int64 get destinationAmount => $_getI64(5);
+  @$pb.TagNumber(6)
+  set destinationAmount($fixnum.Int64 v) { $_setInt64(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasDestinationAmount() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearDestinationAmount() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.List<StellarAsset> get paths => $_getList(6);
+}
+
+/// *
+///  Request: ask device to confirm this operation type
+///  @next StellarTxOpRequest
+///  @next StellarSignedTx
+class StellarPathPaymentStrictSendOp extends $pb.GeneratedMessage {
+  factory StellarPathPaymentStrictSendOp({
+    $core.String? sourceAccount,
+    StellarAsset? sendAsset,
+    $fixnum.Int64? sendAmount,
+    $core.String? destinationAccount,
+    StellarAsset? destinationAsset,
+    $fixnum.Int64? destinationMin,
+    $core.Iterable<StellarAsset>? paths,
+  }) {
+    final $result = create();
+    if (sourceAccount != null) {
+      $result.sourceAccount = sourceAccount;
+    }
+    if (sendAsset != null) {
+      $result.sendAsset = sendAsset;
+    }
+    if (sendAmount != null) {
+      $result.sendAmount = sendAmount;
+    }
+    if (destinationAccount != null) {
+      $result.destinationAccount = destinationAccount;
+    }
+    if (destinationAsset != null) {
+      $result.destinationAsset = destinationAsset;
+    }
+    if (destinationMin != null) {
+      $result.destinationMin = destinationMin;
+    }
+    if (paths != null) {
+      $result.paths.addAll(paths);
+    }
+    return $result;
+  }
+  StellarPathPaymentStrictSendOp._() : super();
+  factory StellarPathPaymentStrictSendOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarPathPaymentStrictSendOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarPathPaymentStrictSendOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sourceAccount')
+    ..aQM<StellarAsset>(2, _omitFieldNames ? '' : 'sendAsset', subBuilder: StellarAsset.create)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'sendAmount', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aQS(4, _omitFieldNames ? '' : 'destinationAccount')
+    ..aQM<StellarAsset>(5, _omitFieldNames ? '' : 'destinationAsset', subBuilder: StellarAsset.create)
+    ..a<$fixnum.Int64>(6, _omitFieldNames ? '' : 'destinationMin', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..pc<StellarAsset>(7, _omitFieldNames ? '' : 'paths', $pb.PbFieldType.PM, subBuilder: StellarAsset.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarPathPaymentStrictSendOp clone() => StellarPathPaymentStrictSendOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarPathPaymentStrictSendOp copyWith(void Function(StellarPathPaymentStrictSendOp) updates) => super.copyWith((message) => updates(message as StellarPathPaymentStrictSendOp)) as StellarPathPaymentStrictSendOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarPathPaymentStrictSendOp create() => StellarPathPaymentStrictSendOp._();
+  StellarPathPaymentStrictSendOp createEmptyInstance() => create();
+  static $pb.PbList<StellarPathPaymentStrictSendOp> createRepeated() => $pb.PbList<StellarPathPaymentStrictSendOp>();
+  @$core.pragma('dart2js:noInline')
+  static StellarPathPaymentStrictSendOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarPathPaymentStrictSendOp>(create);
+  static StellarPathPaymentStrictSendOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sourceAccount => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sourceAccount($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSourceAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSourceAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  StellarAsset get sendAsset => $_getN(1);
+  @$pb.TagNumber(2)
+  set sendAsset(StellarAsset v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSendAsset() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSendAsset() => clearField(2);
+  @$pb.TagNumber(2)
+  StellarAsset ensureSendAsset() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get sendAmount => $_getI64(2);
+  @$pb.TagNumber(3)
+  set sendAmount($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSendAmount() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSendAmount() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get destinationAccount => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set destinationAccount($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasDestinationAccount() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearDestinationAccount() => clearField(4);
+
+  @$pb.TagNumber(5)
+  StellarAsset get destinationAsset => $_getN(4);
+  @$pb.TagNumber(5)
+  set destinationAsset(StellarAsset v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasDestinationAsset() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearDestinationAsset() => clearField(5);
+  @$pb.TagNumber(5)
+  StellarAsset ensureDestinationAsset() => $_ensure(4);
+
+  @$pb.TagNumber(6)
+  $fixnum.Int64 get destinationMin => $_getI64(5);
+  @$pb.TagNumber(6)
+  set destinationMin($fixnum.Int64 v) { $_setInt64(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasDestinationMin() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearDestinationMin() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.List<StellarAsset> get paths => $_getList(6);
+}
+
+/// *
+///  Request: ask device to confirm this operation type
+///  @next StellarTxOpRequest
+///  @next StellarSignedTx
+class StellarManageSellOfferOp extends $pb.GeneratedMessage {
+  factory StellarManageSellOfferOp({
+    $core.String? sourceAccount,
+    StellarAsset? sellingAsset,
+    StellarAsset? buyingAsset,
+    $fixnum.Int64? amount,
+    $core.int? priceN,
+    $core.int? priceD,
+    $fixnum.Int64? offerId,
+  }) {
+    final $result = create();
+    if (sourceAccount != null) {
+      $result.sourceAccount = sourceAccount;
+    }
+    if (sellingAsset != null) {
+      $result.sellingAsset = sellingAsset;
+    }
+    if (buyingAsset != null) {
+      $result.buyingAsset = buyingAsset;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (priceN != null) {
+      $result.priceN = priceN;
+    }
+    if (priceD != null) {
+      $result.priceD = priceD;
+    }
+    if (offerId != null) {
+      $result.offerId = offerId;
+    }
+    return $result;
+  }
+  StellarManageSellOfferOp._() : super();
+  factory StellarManageSellOfferOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarManageSellOfferOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarManageSellOfferOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sourceAccount')
+    ..aQM<StellarAsset>(2, _omitFieldNames ? '' : 'sellingAsset', subBuilder: StellarAsset.create)
+    ..aQM<StellarAsset>(3, _omitFieldNames ? '' : 'buyingAsset', subBuilder: StellarAsset.create)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'priceN', $pb.PbFieldType.QU3)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'priceD', $pb.PbFieldType.QU3)
+    ..a<$fixnum.Int64>(7, _omitFieldNames ? '' : 'offerId', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarManageSellOfferOp clone() => StellarManageSellOfferOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarManageSellOfferOp copyWith(void Function(StellarManageSellOfferOp) updates) => super.copyWith((message) => updates(message as StellarManageSellOfferOp)) as StellarManageSellOfferOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarManageSellOfferOp create() => StellarManageSellOfferOp._();
+  StellarManageSellOfferOp createEmptyInstance() => create();
+  static $pb.PbList<StellarManageSellOfferOp> createRepeated() => $pb.PbList<StellarManageSellOfferOp>();
+  @$core.pragma('dart2js:noInline')
+  static StellarManageSellOfferOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarManageSellOfferOp>(create);
+  static StellarManageSellOfferOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sourceAccount => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sourceAccount($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSourceAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSourceAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  StellarAsset get sellingAsset => $_getN(1);
+  @$pb.TagNumber(2)
+  set sellingAsset(StellarAsset v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSellingAsset() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSellingAsset() => clearField(2);
+  @$pb.TagNumber(2)
+  StellarAsset ensureSellingAsset() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  StellarAsset get buyingAsset => $_getN(2);
+  @$pb.TagNumber(3)
+  set buyingAsset(StellarAsset v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasBuyingAsset() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearBuyingAsset() => clearField(3);
+  @$pb.TagNumber(3)
+  StellarAsset ensureBuyingAsset() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get amount => $_getI64(3);
+  @$pb.TagNumber(4)
+  set amount($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasAmount() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearAmount() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get priceN => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set priceN($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasPriceN() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearPriceN() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.int get priceD => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set priceD($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasPriceD() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearPriceD() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $fixnum.Int64 get offerId => $_getI64(6);
+  @$pb.TagNumber(7)
+  set offerId($fixnum.Int64 v) { $_setInt64(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasOfferId() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearOfferId() => clearField(7);
+}
+
+/// *
+///  Request: ask device to confirm this operation type
+///  @next StellarTxOpRequest
+///  @next StellarSignedTx
+class StellarManageBuyOfferOp extends $pb.GeneratedMessage {
+  factory StellarManageBuyOfferOp({
+    $core.String? sourceAccount,
+    StellarAsset? sellingAsset,
+    StellarAsset? buyingAsset,
+    $fixnum.Int64? amount,
+    $core.int? priceN,
+    $core.int? priceD,
+    $fixnum.Int64? offerId,
+  }) {
+    final $result = create();
+    if (sourceAccount != null) {
+      $result.sourceAccount = sourceAccount;
+    }
+    if (sellingAsset != null) {
+      $result.sellingAsset = sellingAsset;
+    }
+    if (buyingAsset != null) {
+      $result.buyingAsset = buyingAsset;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (priceN != null) {
+      $result.priceN = priceN;
+    }
+    if (priceD != null) {
+      $result.priceD = priceD;
+    }
+    if (offerId != null) {
+      $result.offerId = offerId;
+    }
+    return $result;
+  }
+  StellarManageBuyOfferOp._() : super();
+  factory StellarManageBuyOfferOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarManageBuyOfferOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarManageBuyOfferOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sourceAccount')
+    ..aQM<StellarAsset>(2, _omitFieldNames ? '' : 'sellingAsset', subBuilder: StellarAsset.create)
+    ..aQM<StellarAsset>(3, _omitFieldNames ? '' : 'buyingAsset', subBuilder: StellarAsset.create)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'priceN', $pb.PbFieldType.QU3)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'priceD', $pb.PbFieldType.QU3)
+    ..a<$fixnum.Int64>(7, _omitFieldNames ? '' : 'offerId', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarManageBuyOfferOp clone() => StellarManageBuyOfferOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarManageBuyOfferOp copyWith(void Function(StellarManageBuyOfferOp) updates) => super.copyWith((message) => updates(message as StellarManageBuyOfferOp)) as StellarManageBuyOfferOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarManageBuyOfferOp create() => StellarManageBuyOfferOp._();
+  StellarManageBuyOfferOp createEmptyInstance() => create();
+  static $pb.PbList<StellarManageBuyOfferOp> createRepeated() => $pb.PbList<StellarManageBuyOfferOp>();
+  @$core.pragma('dart2js:noInline')
+  static StellarManageBuyOfferOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarManageBuyOfferOp>(create);
+  static StellarManageBuyOfferOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sourceAccount => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sourceAccount($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSourceAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSourceAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  StellarAsset get sellingAsset => $_getN(1);
+  @$pb.TagNumber(2)
+  set sellingAsset(StellarAsset v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSellingAsset() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSellingAsset() => clearField(2);
+  @$pb.TagNumber(2)
+  StellarAsset ensureSellingAsset() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  StellarAsset get buyingAsset => $_getN(2);
+  @$pb.TagNumber(3)
+  set buyingAsset(StellarAsset v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasBuyingAsset() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearBuyingAsset() => clearField(3);
+  @$pb.TagNumber(3)
+  StellarAsset ensureBuyingAsset() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get amount => $_getI64(3);
+  @$pb.TagNumber(4)
+  set amount($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasAmount() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearAmount() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get priceN => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set priceN($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasPriceN() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearPriceN() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.int get priceD => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set priceD($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasPriceD() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearPriceD() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $fixnum.Int64 get offerId => $_getI64(6);
+  @$pb.TagNumber(7)
+  set offerId($fixnum.Int64 v) { $_setInt64(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasOfferId() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearOfferId() => clearField(7);
+}
+
+/// *
+///  Request: ask device to confirm this operation type
+///  @next StellarTxOpRequest
+///  @next StellarSignedTx
+class StellarCreatePassiveSellOfferOp extends $pb.GeneratedMessage {
+  factory StellarCreatePassiveSellOfferOp({
+    $core.String? sourceAccount,
+    StellarAsset? sellingAsset,
+    StellarAsset? buyingAsset,
+    $fixnum.Int64? amount,
+    $core.int? priceN,
+    $core.int? priceD,
+  }) {
+    final $result = create();
+    if (sourceAccount != null) {
+      $result.sourceAccount = sourceAccount;
+    }
+    if (sellingAsset != null) {
+      $result.sellingAsset = sellingAsset;
+    }
+    if (buyingAsset != null) {
+      $result.buyingAsset = buyingAsset;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (priceN != null) {
+      $result.priceN = priceN;
+    }
+    if (priceD != null) {
+      $result.priceD = priceD;
+    }
+    return $result;
+  }
+  StellarCreatePassiveSellOfferOp._() : super();
+  factory StellarCreatePassiveSellOfferOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarCreatePassiveSellOfferOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarCreatePassiveSellOfferOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sourceAccount')
+    ..aQM<StellarAsset>(2, _omitFieldNames ? '' : 'sellingAsset', subBuilder: StellarAsset.create)
+    ..aQM<StellarAsset>(3, _omitFieldNames ? '' : 'buyingAsset', subBuilder: StellarAsset.create)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QS6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'priceN', $pb.PbFieldType.QU3)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'priceD', $pb.PbFieldType.QU3)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarCreatePassiveSellOfferOp clone() => StellarCreatePassiveSellOfferOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarCreatePassiveSellOfferOp copyWith(void Function(StellarCreatePassiveSellOfferOp) updates) => super.copyWith((message) => updates(message as StellarCreatePassiveSellOfferOp)) as StellarCreatePassiveSellOfferOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarCreatePassiveSellOfferOp create() => StellarCreatePassiveSellOfferOp._();
+  StellarCreatePassiveSellOfferOp createEmptyInstance() => create();
+  static $pb.PbList<StellarCreatePassiveSellOfferOp> createRepeated() => $pb.PbList<StellarCreatePassiveSellOfferOp>();
+  @$core.pragma('dart2js:noInline')
+  static StellarCreatePassiveSellOfferOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarCreatePassiveSellOfferOp>(create);
+  static StellarCreatePassiveSellOfferOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sourceAccount => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sourceAccount($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSourceAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSourceAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  StellarAsset get sellingAsset => $_getN(1);
+  @$pb.TagNumber(2)
+  set sellingAsset(StellarAsset v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSellingAsset() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSellingAsset() => clearField(2);
+  @$pb.TagNumber(2)
+  StellarAsset ensureSellingAsset() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  StellarAsset get buyingAsset => $_getN(2);
+  @$pb.TagNumber(3)
+  set buyingAsset(StellarAsset v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasBuyingAsset() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearBuyingAsset() => clearField(3);
+  @$pb.TagNumber(3)
+  StellarAsset ensureBuyingAsset() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get amount => $_getI64(3);
+  @$pb.TagNumber(4)
+  set amount($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasAmount() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearAmount() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get priceN => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set priceN($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasPriceN() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearPriceN() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.int get priceD => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set priceD($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasPriceD() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearPriceD() => clearField(6);
+}
+
+/// *
+///  Request: ask device to confirm this operation type
+///  @next StellarTxOpRequest
+///  @next StellarSignedTx
+class StellarSetOptionsOp extends $pb.GeneratedMessage {
+  factory StellarSetOptionsOp({
+    $core.String? sourceAccount,
+    $core.String? inflationDestinationAccount,
+    $core.int? clearFlags,
+    $core.int? setFlags,
+    $core.int? masterWeight,
+    $core.int? lowThreshold,
+    $core.int? mediumThreshold,
+    $core.int? highThreshold,
+    $core.String? homeDomain,
+    StellarSetOptionsOp_StellarSignerType? signerType,
+    $core.List<$core.int>? signerKey,
+    $core.int? signerWeight,
+  }) {
+    final $result = create();
+    if (sourceAccount != null) {
+      $result.sourceAccount = sourceAccount;
+    }
+    if (inflationDestinationAccount != null) {
+      $result.inflationDestinationAccount = inflationDestinationAccount;
+    }
+    if (clearFlags != null) {
+      $result.clearFlags = clearFlags;
+    }
+    if (setFlags != null) {
+      $result.setFlags = setFlags;
+    }
+    if (masterWeight != null) {
+      $result.masterWeight = masterWeight;
+    }
+    if (lowThreshold != null) {
+      $result.lowThreshold = lowThreshold;
+    }
+    if (mediumThreshold != null) {
+      $result.mediumThreshold = mediumThreshold;
+    }
+    if (highThreshold != null) {
+      $result.highThreshold = highThreshold;
+    }
+    if (homeDomain != null) {
+      $result.homeDomain = homeDomain;
+    }
+    if (signerType != null) {
+      $result.signerType = signerType;
+    }
+    if (signerKey != null) {
+      $result.signerKey = signerKey;
+    }
+    if (signerWeight != null) {
+      $result.signerWeight = signerWeight;
+    }
+    return $result;
+  }
+  StellarSetOptionsOp._() : super();
+  factory StellarSetOptionsOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarSetOptionsOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarSetOptionsOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sourceAccount')
+    ..aOS(2, _omitFieldNames ? '' : 'inflationDestinationAccount')
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'clearFlags', $pb.PbFieldType.OU3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'setFlags', $pb.PbFieldType.OU3)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'masterWeight', $pb.PbFieldType.OU3)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'lowThreshold', $pb.PbFieldType.OU3)
+    ..a<$core.int>(7, _omitFieldNames ? '' : 'mediumThreshold', $pb.PbFieldType.OU3)
+    ..a<$core.int>(8, _omitFieldNames ? '' : 'highThreshold', $pb.PbFieldType.OU3)
+    ..aOS(9, _omitFieldNames ? '' : 'homeDomain')
+    ..e<StellarSetOptionsOp_StellarSignerType>(10, _omitFieldNames ? '' : 'signerType', $pb.PbFieldType.OE, defaultOrMaker: StellarSetOptionsOp_StellarSignerType.ACCOUNT, valueOf: StellarSetOptionsOp_StellarSignerType.valueOf, enumValues: StellarSetOptionsOp_StellarSignerType.values)
+    ..a<$core.List<$core.int>>(11, _omitFieldNames ? '' : 'signerKey', $pb.PbFieldType.OY)
+    ..a<$core.int>(12, _omitFieldNames ? '' : 'signerWeight', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarSetOptionsOp clone() => StellarSetOptionsOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarSetOptionsOp copyWith(void Function(StellarSetOptionsOp) updates) => super.copyWith((message) => updates(message as StellarSetOptionsOp)) as StellarSetOptionsOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarSetOptionsOp create() => StellarSetOptionsOp._();
+  StellarSetOptionsOp createEmptyInstance() => create();
+  static $pb.PbList<StellarSetOptionsOp> createRepeated() => $pb.PbList<StellarSetOptionsOp>();
+  @$core.pragma('dart2js:noInline')
+  static StellarSetOptionsOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarSetOptionsOp>(create);
+  static StellarSetOptionsOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sourceAccount => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sourceAccount($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSourceAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSourceAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get inflationDestinationAccount => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set inflationDestinationAccount($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasInflationDestinationAccount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearInflationDestinationAccount() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get clearFlags => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set clearFlags($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasClearFlags() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearClearFlags() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get setFlags => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set setFlags($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasSetFlags() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearSetFlags() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get masterWeight => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set masterWeight($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasMasterWeight() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearMasterWeight() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.int get lowThreshold => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set lowThreshold($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasLowThreshold() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearLowThreshold() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.int get mediumThreshold => $_getIZ(6);
+  @$pb.TagNumber(7)
+  set mediumThreshold($core.int v) { $_setUnsignedInt32(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasMediumThreshold() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearMediumThreshold() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.int get highThreshold => $_getIZ(7);
+  @$pb.TagNumber(8)
+  set highThreshold($core.int v) { $_setUnsignedInt32(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasHighThreshold() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearHighThreshold() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.String get homeDomain => $_getSZ(8);
+  @$pb.TagNumber(9)
+  set homeDomain($core.String v) { $_setString(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasHomeDomain() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearHomeDomain() => clearField(9);
+
+  @$pb.TagNumber(10)
+  StellarSetOptionsOp_StellarSignerType get signerType => $_getN(9);
+  @$pb.TagNumber(10)
+  set signerType(StellarSetOptionsOp_StellarSignerType v) { setField(10, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasSignerType() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearSignerType() => clearField(10);
+
+  @$pb.TagNumber(11)
+  $core.List<$core.int> get signerKey => $_getN(10);
+  @$pb.TagNumber(11)
+  set signerKey($core.List<$core.int> v) { $_setBytes(10, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasSignerKey() => $_has(10);
+  @$pb.TagNumber(11)
+  void clearSignerKey() => clearField(11);
+
+  @$pb.TagNumber(12)
+  $core.int get signerWeight => $_getIZ(11);
+  @$pb.TagNumber(12)
+  set signerWeight($core.int v) { $_setUnsignedInt32(11, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasSignerWeight() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearSignerWeight() => clearField(12);
+}
+
+/// *
+///  Request: ask device to confirm this operation type
+///  @next StellarTxOpRequest
+///  @next StellarSignedTx
+class StellarChangeTrustOp extends $pb.GeneratedMessage {
+  factory StellarChangeTrustOp({
+    $core.String? sourceAccount,
+    StellarAsset? asset,
+    $fixnum.Int64? limit,
+  }) {
+    final $result = create();
+    if (sourceAccount != null) {
+      $result.sourceAccount = sourceAccount;
+    }
+    if (asset != null) {
+      $result.asset = asset;
+    }
+    if (limit != null) {
+      $result.limit = limit;
+    }
+    return $result;
+  }
+  StellarChangeTrustOp._() : super();
+  factory StellarChangeTrustOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarChangeTrustOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarChangeTrustOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sourceAccount')
+    ..aQM<StellarAsset>(2, _omitFieldNames ? '' : 'asset', subBuilder: StellarAsset.create)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'limit', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarChangeTrustOp clone() => StellarChangeTrustOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarChangeTrustOp copyWith(void Function(StellarChangeTrustOp) updates) => super.copyWith((message) => updates(message as StellarChangeTrustOp)) as StellarChangeTrustOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarChangeTrustOp create() => StellarChangeTrustOp._();
+  StellarChangeTrustOp createEmptyInstance() => create();
+  static $pb.PbList<StellarChangeTrustOp> createRepeated() => $pb.PbList<StellarChangeTrustOp>();
+  @$core.pragma('dart2js:noInline')
+  static StellarChangeTrustOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarChangeTrustOp>(create);
+  static StellarChangeTrustOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sourceAccount => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sourceAccount($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSourceAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSourceAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  StellarAsset get asset => $_getN(1);
+  @$pb.TagNumber(2)
+  set asset(StellarAsset v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAsset() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAsset() => clearField(2);
+  @$pb.TagNumber(2)
+  StellarAsset ensureAsset() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get limit => $_getI64(2);
+  @$pb.TagNumber(3)
+  set limit($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasLimit() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearLimit() => clearField(3);
+}
+
+/// *
+///  Request: ask device to confirm this operation type
+///  @next StellarTxOpRequest
+///  @next StellarSignedTx
+class StellarAllowTrustOp extends $pb.GeneratedMessage {
+  factory StellarAllowTrustOp({
+    $core.String? sourceAccount,
+    $core.String? trustedAccount,
+    StellarAssetType? assetType,
+    $core.String? assetCode,
+    $core.bool? isAuthorized,
+  }) {
+    final $result = create();
+    if (sourceAccount != null) {
+      $result.sourceAccount = sourceAccount;
+    }
+    if (trustedAccount != null) {
+      $result.trustedAccount = trustedAccount;
+    }
+    if (assetType != null) {
+      $result.assetType = assetType;
+    }
+    if (assetCode != null) {
+      $result.assetCode = assetCode;
+    }
+    if (isAuthorized != null) {
+      $result.isAuthorized = isAuthorized;
+    }
+    return $result;
+  }
+  StellarAllowTrustOp._() : super();
+  factory StellarAllowTrustOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarAllowTrustOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarAllowTrustOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sourceAccount')
+    ..aQS(2, _omitFieldNames ? '' : 'trustedAccount')
+    ..e<StellarAssetType>(3, _omitFieldNames ? '' : 'assetType', $pb.PbFieldType.QE, defaultOrMaker: StellarAssetType.NATIVE, valueOf: StellarAssetType.valueOf, enumValues: StellarAssetType.values)
+    ..aOS(4, _omitFieldNames ? '' : 'assetCode')
+    ..a<$core.bool>(5, _omitFieldNames ? '' : 'isAuthorized', $pb.PbFieldType.QB)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarAllowTrustOp clone() => StellarAllowTrustOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarAllowTrustOp copyWith(void Function(StellarAllowTrustOp) updates) => super.copyWith((message) => updates(message as StellarAllowTrustOp)) as StellarAllowTrustOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarAllowTrustOp create() => StellarAllowTrustOp._();
+  StellarAllowTrustOp createEmptyInstance() => create();
+  static $pb.PbList<StellarAllowTrustOp> createRepeated() => $pb.PbList<StellarAllowTrustOp>();
+  @$core.pragma('dart2js:noInline')
+  static StellarAllowTrustOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarAllowTrustOp>(create);
+  static StellarAllowTrustOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sourceAccount => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sourceAccount($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSourceAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSourceAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get trustedAccount => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set trustedAccount($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTrustedAccount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTrustedAccount() => clearField(2);
+
+  @$pb.TagNumber(3)
+  StellarAssetType get assetType => $_getN(2);
+  @$pb.TagNumber(3)
+  set assetType(StellarAssetType v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasAssetType() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearAssetType() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get assetCode => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set assetCode($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasAssetCode() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearAssetCode() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.bool get isAuthorized => $_getBF(4);
+  @$pb.TagNumber(5)
+  set isAuthorized($core.bool v) { $_setBool(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasIsAuthorized() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearIsAuthorized() => clearField(5);
+}
+
+/// *
+///  Request: ask device to confirm this operation type
+///  @next StellarTxOpRequest
+///  @next StellarSignedTx
+class StellarAccountMergeOp extends $pb.GeneratedMessage {
+  factory StellarAccountMergeOp({
+    $core.String? sourceAccount,
+    $core.String? destinationAccount,
+  }) {
+    final $result = create();
+    if (sourceAccount != null) {
+      $result.sourceAccount = sourceAccount;
+    }
+    if (destinationAccount != null) {
+      $result.destinationAccount = destinationAccount;
+    }
+    return $result;
+  }
+  StellarAccountMergeOp._() : super();
+  factory StellarAccountMergeOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarAccountMergeOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarAccountMergeOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sourceAccount')
+    ..aQS(2, _omitFieldNames ? '' : 'destinationAccount')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarAccountMergeOp clone() => StellarAccountMergeOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarAccountMergeOp copyWith(void Function(StellarAccountMergeOp) updates) => super.copyWith((message) => updates(message as StellarAccountMergeOp)) as StellarAccountMergeOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarAccountMergeOp create() => StellarAccountMergeOp._();
+  StellarAccountMergeOp createEmptyInstance() => create();
+  static $pb.PbList<StellarAccountMergeOp> createRepeated() => $pb.PbList<StellarAccountMergeOp>();
+  @$core.pragma('dart2js:noInline')
+  static StellarAccountMergeOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarAccountMergeOp>(create);
+  static StellarAccountMergeOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sourceAccount => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sourceAccount($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSourceAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSourceAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get destinationAccount => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set destinationAccount($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasDestinationAccount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearDestinationAccount() => clearField(2);
+}
+
+/// *
+///  Request: ask device to confirm this operation type
+///  @next StellarTxOpRequest
+///  @next StellarSignedTx
+class StellarManageDataOp extends $pb.GeneratedMessage {
+  factory StellarManageDataOp({
+    $core.String? sourceAccount,
+    $core.String? key,
+    $core.List<$core.int>? value,
+  }) {
+    final $result = create();
+    if (sourceAccount != null) {
+      $result.sourceAccount = sourceAccount;
+    }
+    if (key != null) {
+      $result.key = key;
+    }
+    if (value != null) {
+      $result.value = value;
+    }
+    return $result;
+  }
+  StellarManageDataOp._() : super();
+  factory StellarManageDataOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarManageDataOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarManageDataOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sourceAccount')
+    ..aQS(2, _omitFieldNames ? '' : 'key')
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarManageDataOp clone() => StellarManageDataOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarManageDataOp copyWith(void Function(StellarManageDataOp) updates) => super.copyWith((message) => updates(message as StellarManageDataOp)) as StellarManageDataOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarManageDataOp create() => StellarManageDataOp._();
+  StellarManageDataOp createEmptyInstance() => create();
+  static $pb.PbList<StellarManageDataOp> createRepeated() => $pb.PbList<StellarManageDataOp>();
+  @$core.pragma('dart2js:noInline')
+  static StellarManageDataOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarManageDataOp>(create);
+  static StellarManageDataOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sourceAccount => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sourceAccount($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSourceAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSourceAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get key => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set key($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasKey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearKey() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get value => $_getN(2);
+  @$pb.TagNumber(3)
+  set value($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasValue() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearValue() => clearField(3);
+}
+
+/// *
+///  Request: ask device to confirm this operation type
+///  @next StellarTxOpRequest
+///  @next StellarSignedTx
+class StellarBumpSequenceOp extends $pb.GeneratedMessage {
+  factory StellarBumpSequenceOp({
+    $core.String? sourceAccount,
+    $fixnum.Int64? bumpTo,
+  }) {
+    final $result = create();
+    if (sourceAccount != null) {
+      $result.sourceAccount = sourceAccount;
+    }
+    if (bumpTo != null) {
+      $result.bumpTo = bumpTo;
+    }
+    return $result;
+  }
+  StellarBumpSequenceOp._() : super();
+  factory StellarBumpSequenceOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarBumpSequenceOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarBumpSequenceOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sourceAccount')
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'bumpTo', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarBumpSequenceOp clone() => StellarBumpSequenceOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarBumpSequenceOp copyWith(void Function(StellarBumpSequenceOp) updates) => super.copyWith((message) => updates(message as StellarBumpSequenceOp)) as StellarBumpSequenceOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarBumpSequenceOp create() => StellarBumpSequenceOp._();
+  StellarBumpSequenceOp createEmptyInstance() => create();
+  static $pb.PbList<StellarBumpSequenceOp> createRepeated() => $pb.PbList<StellarBumpSequenceOp>();
+  @$core.pragma('dart2js:noInline')
+  static StellarBumpSequenceOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarBumpSequenceOp>(create);
+  static StellarBumpSequenceOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sourceAccount => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sourceAccount($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSourceAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSourceAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get bumpTo => $_getI64(1);
+  @$pb.TagNumber(2)
+  set bumpTo($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasBumpTo() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearBumpTo() => clearField(2);
+}
+
+/// *
+///  Request: ask device to confirm this operation type
+///  @next StellarTxOpRequest
+///  @next StellarSignedTx
+class StellarClaimClaimableBalanceOp extends $pb.GeneratedMessage {
+  factory StellarClaimClaimableBalanceOp({
+    $core.String? sourceAccount,
+    $core.List<$core.int>? balanceId,
+  }) {
+    final $result = create();
+    if (sourceAccount != null) {
+      $result.sourceAccount = sourceAccount;
+    }
+    if (balanceId != null) {
+      $result.balanceId = balanceId;
+    }
+    return $result;
+  }
+  StellarClaimClaimableBalanceOp._() : super();
+  factory StellarClaimClaimableBalanceOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarClaimClaimableBalanceOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarClaimClaimableBalanceOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sourceAccount')
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'balanceId', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarClaimClaimableBalanceOp clone() => StellarClaimClaimableBalanceOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarClaimClaimableBalanceOp copyWith(void Function(StellarClaimClaimableBalanceOp) updates) => super.copyWith((message) => updates(message as StellarClaimClaimableBalanceOp)) as StellarClaimClaimableBalanceOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarClaimClaimableBalanceOp create() => StellarClaimClaimableBalanceOp._();
+  StellarClaimClaimableBalanceOp createEmptyInstance() => create();
+  static $pb.PbList<StellarClaimClaimableBalanceOp> createRepeated() => $pb.PbList<StellarClaimClaimableBalanceOp>();
+  @$core.pragma('dart2js:noInline')
+  static StellarClaimClaimableBalanceOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarClaimClaimableBalanceOp>(create);
+  static StellarClaimClaimableBalanceOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sourceAccount => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sourceAccount($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSourceAccount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSourceAccount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get balanceId => $_getN(1);
+  @$pb.TagNumber(2)
+  set balanceId($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasBalanceId() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearBalanceId() => clearField(2);
+}
+
+/// *
+///  Response: signature for transaction
+///  @end
+class StellarSignedTx extends $pb.GeneratedMessage {
+  factory StellarSignedTx({
+    $core.List<$core.int>? publicKey,
+    $core.List<$core.int>? signature,
+  }) {
+    final $result = create();
+    if (publicKey != null) {
+      $result.publicKey = publicKey;
+    }
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    return $result;
+  }
+  StellarSignedTx._() : super();
+  factory StellarSignedTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StellarSignedTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StellarSignedTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.stellar'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'publicKey', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'signature', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StellarSignedTx clone() => StellarSignedTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StellarSignedTx copyWith(void Function(StellarSignedTx) updates) => super.copyWith((message) => updates(message as StellarSignedTx)) as StellarSignedTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StellarSignedTx create() => StellarSignedTx._();
+  StellarSignedTx createEmptyInstance() => create();
+  static $pb.PbList<StellarSignedTx> createRepeated() => $pb.PbList<StellarSignedTx>();
+  @$core.pragma('dart2js:noInline')
+  static StellarSignedTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StellarSignedTx>(create);
+  static StellarSignedTx? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get publicKey => $_getN(0);
+  @$pb.TagNumber(1)
+  set publicKey($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPublicKey() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPublicKey() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get signature => $_getN(1);
+  @$pb.TagNumber(2)
+  set signature($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSignature() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSignature() => clearField(2);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-stellar.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-stellar.pbenum.dart
@@ -1,0 +1,75 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-stellar.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+/// https://github.com/stellar/stellar-core/blob/02d26858069de7c0eefe065056fb0a19bf72ea56/src/xdr/Stellar-ledger-entries.x#L25-L31
+class StellarAssetType extends $pb.ProtobufEnum {
+  static const StellarAssetType NATIVE = StellarAssetType._(0, _omitEnumNames ? '' : 'NATIVE');
+  static const StellarAssetType ALPHANUM4 = StellarAssetType._(1, _omitEnumNames ? '' : 'ALPHANUM4');
+  static const StellarAssetType ALPHANUM12 = StellarAssetType._(2, _omitEnumNames ? '' : 'ALPHANUM12');
+
+  static const $core.List<StellarAssetType> values = <StellarAssetType> [
+    NATIVE,
+    ALPHANUM4,
+    ALPHANUM12,
+  ];
+
+  static final $core.Map<$core.int, StellarAssetType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static StellarAssetType? valueOf($core.int value) => _byValue[value];
+
+  const StellarAssetType._($core.int v, $core.String n) : super(v, n);
+}
+
+/// https://github.com/stellar/stellar-core/blob/02d26858069de7c0eefe065056fb0a19bf72ea56/src/xdr/Stellar-transaction.x#L506-L513
+class StellarSignTx_StellarMemoType extends $pb.ProtobufEnum {
+  static const StellarSignTx_StellarMemoType NONE = StellarSignTx_StellarMemoType._(0, _omitEnumNames ? '' : 'NONE');
+  static const StellarSignTx_StellarMemoType TEXT = StellarSignTx_StellarMemoType._(1, _omitEnumNames ? '' : 'TEXT');
+  static const StellarSignTx_StellarMemoType ID = StellarSignTx_StellarMemoType._(2, _omitEnumNames ? '' : 'ID');
+  static const StellarSignTx_StellarMemoType HASH = StellarSignTx_StellarMemoType._(3, _omitEnumNames ? '' : 'HASH');
+  static const StellarSignTx_StellarMemoType RETURN = StellarSignTx_StellarMemoType._(4, _omitEnumNames ? '' : 'RETURN');
+
+  static const $core.List<StellarSignTx_StellarMemoType> values = <StellarSignTx_StellarMemoType> [
+    NONE,
+    TEXT,
+    ID,
+    HASH,
+    RETURN,
+  ];
+
+  static final $core.Map<$core.int, StellarSignTx_StellarMemoType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static StellarSignTx_StellarMemoType? valueOf($core.int value) => _byValue[value];
+
+  const StellarSignTx_StellarMemoType._($core.int v, $core.String n) : super(v, n);
+}
+
+/// https://github.com/stellar/stellar-core/blob/02d26858069de7c0eefe065056fb0a19bf72ea56/src/xdr/Stellar-types.x#L32-L37
+class StellarSetOptionsOp_StellarSignerType extends $pb.ProtobufEnum {
+  static const StellarSetOptionsOp_StellarSignerType ACCOUNT = StellarSetOptionsOp_StellarSignerType._(0, _omitEnumNames ? '' : 'ACCOUNT');
+  static const StellarSetOptionsOp_StellarSignerType PRE_AUTH = StellarSetOptionsOp_StellarSignerType._(1, _omitEnumNames ? '' : 'PRE_AUTH');
+  static const StellarSetOptionsOp_StellarSignerType HASH = StellarSetOptionsOp_StellarSignerType._(2, _omitEnumNames ? '' : 'HASH');
+
+  static const $core.List<StellarSetOptionsOp_StellarSignerType> values = <StellarSetOptionsOp_StellarSignerType> [
+    ACCOUNT,
+    PRE_AUTH,
+    HASH,
+  ];
+
+  static final $core.Map<$core.int, StellarSetOptionsOp_StellarSignerType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static StellarSetOptionsOp_StellarSignerType? valueOf($core.int value) => _byValue[value];
+
+  const StellarSetOptionsOp_StellarSignerType._($core.int v, $core.String n) : super(v, n);
+}
+
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-stellar.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-stellar.pbjson.dart
@@ -1,0 +1,430 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-stellar.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use stellarAssetTypeDescriptor instead')
+const StellarAssetType$json = {
+  '1': 'StellarAssetType',
+  '2': [
+    {'1': 'NATIVE', '2': 0},
+    {'1': 'ALPHANUM4', '2': 1},
+    {'1': 'ALPHANUM12', '2': 2},
+  ],
+};
+
+/// Descriptor for `StellarAssetType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List stellarAssetTypeDescriptor = $convert.base64Decode(
+    'ChBTdGVsbGFyQXNzZXRUeXBlEgoKBk5BVElWRRAAEg0KCUFMUEhBTlVNNBABEg4KCkFMUEhBTl'
+    'VNMTIQAg==');
+
+@$core.Deprecated('Use stellarAssetDescriptor instead')
+const StellarAsset$json = {
+  '1': 'StellarAsset',
+  '2': [
+    {'1': 'type', '3': 1, '4': 2, '5': 14, '6': '.hw.trezor.messages.stellar.StellarAssetType', '10': 'type'},
+    {'1': 'code', '3': 2, '4': 1, '5': 9, '10': 'code'},
+    {'1': 'issuer', '3': 3, '4': 1, '5': 9, '10': 'issuer'},
+  ],
+};
+
+/// Descriptor for `StellarAsset`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarAssetDescriptor = $convert.base64Decode(
+    'CgxTdGVsbGFyQXNzZXQSQAoEdHlwZRgBIAIoDjIsLmh3LnRyZXpvci5tZXNzYWdlcy5zdGVsbG'
+    'FyLlN0ZWxsYXJBc3NldFR5cGVSBHR5cGUSEgoEY29kZRgCIAEoCVIEY29kZRIWCgZpc3N1ZXIY'
+    'AyABKAlSBmlzc3Vlcg==');
+
+@$core.Deprecated('Use stellarGetAddressDescriptor instead')
+const StellarGetAddress$json = {
+  '1': 'StellarGetAddress',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'show_display', '3': 2, '4': 1, '5': 8, '10': 'showDisplay'},
+    {'1': 'chunkify', '3': 3, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `StellarGetAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarGetAddressDescriptor = $convert.base64Decode(
+    'ChFTdGVsbGFyR2V0QWRkcmVzcxIbCglhZGRyZXNzX24YASADKA1SCGFkZHJlc3NOEiEKDHNob3'
+    'dfZGlzcGxheRgCIAEoCFILc2hvd0Rpc3BsYXkSGgoIY2h1bmtpZnkYAyABKAhSCGNodW5raWZ5');
+
+@$core.Deprecated('Use stellarAddressDescriptor instead')
+const StellarAddress$json = {
+  '1': 'StellarAddress',
+  '2': [
+    {'1': 'address', '3': 1, '4': 2, '5': 9, '10': 'address'},
+  ],
+};
+
+/// Descriptor for `StellarAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarAddressDescriptor = $convert.base64Decode(
+    'Cg5TdGVsbGFyQWRkcmVzcxIYCgdhZGRyZXNzGAEgAigJUgdhZGRyZXNz');
+
+@$core.Deprecated('Use stellarSignTxDescriptor instead')
+const StellarSignTx$json = {
+  '1': 'StellarSignTx',
+  '2': [
+    {'1': 'address_n', '3': 2, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'network_passphrase', '3': 3, '4': 2, '5': 9, '10': 'networkPassphrase'},
+    {'1': 'source_account', '3': 4, '4': 2, '5': 9, '10': 'sourceAccount'},
+    {'1': 'fee', '3': 5, '4': 2, '5': 13, '10': 'fee'},
+    {'1': 'sequence_number', '3': 6, '4': 2, '5': 4, '10': 'sequenceNumber'},
+    {'1': 'timebounds_start', '3': 8, '4': 2, '5': 13, '10': 'timeboundsStart'},
+    {'1': 'timebounds_end', '3': 9, '4': 2, '5': 13, '10': 'timeboundsEnd'},
+    {'1': 'memo_type', '3': 10, '4': 2, '5': 14, '6': '.hw.trezor.messages.stellar.StellarSignTx.StellarMemoType', '10': 'memoType'},
+    {'1': 'memo_text', '3': 11, '4': 1, '5': 9, '10': 'memoText'},
+    {'1': 'memo_id', '3': 12, '4': 1, '5': 4, '10': 'memoId'},
+    {'1': 'memo_hash', '3': 13, '4': 1, '5': 12, '10': 'memoHash'},
+    {'1': 'num_operations', '3': 14, '4': 2, '5': 13, '10': 'numOperations'},
+  ],
+  '4': [StellarSignTx_StellarMemoType$json],
+};
+
+@$core.Deprecated('Use stellarSignTxDescriptor instead')
+const StellarSignTx_StellarMemoType$json = {
+  '1': 'StellarMemoType',
+  '2': [
+    {'1': 'NONE', '2': 0},
+    {'1': 'TEXT', '2': 1},
+    {'1': 'ID', '2': 2},
+    {'1': 'HASH', '2': 3},
+    {'1': 'RETURN', '2': 4},
+  ],
+};
+
+/// Descriptor for `StellarSignTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarSignTxDescriptor = $convert.base64Decode(
+    'Cg1TdGVsbGFyU2lnblR4EhsKCWFkZHJlc3NfbhgCIAMoDVIIYWRkcmVzc04SLQoSbmV0d29ya1'
+    '9wYXNzcGhyYXNlGAMgAigJUhFuZXR3b3JrUGFzc3BocmFzZRIlCg5zb3VyY2VfYWNjb3VudBgE'
+    'IAIoCVINc291cmNlQWNjb3VudBIQCgNmZWUYBSACKA1SA2ZlZRInCg9zZXF1ZW5jZV9udW1iZX'
+    'IYBiACKARSDnNlcXVlbmNlTnVtYmVyEikKEHRpbWVib3VuZHNfc3RhcnQYCCACKA1SD3RpbWVi'
+    'b3VuZHNTdGFydBIlCg50aW1lYm91bmRzX2VuZBgJIAIoDVINdGltZWJvdW5kc0VuZBJWCgltZW'
+    '1vX3R5cGUYCiACKA4yOS5ody50cmV6b3IubWVzc2FnZXMuc3RlbGxhci5TdGVsbGFyU2lnblR4'
+    'LlN0ZWxsYXJNZW1vVHlwZVIIbWVtb1R5cGUSGwoJbWVtb190ZXh0GAsgASgJUghtZW1vVGV4dB'
+    'IXCgdtZW1vX2lkGAwgASgEUgZtZW1vSWQSGwoJbWVtb19oYXNoGA0gASgMUghtZW1vSGFzaBIl'
+    'Cg5udW1fb3BlcmF0aW9ucxgOIAIoDVINbnVtT3BlcmF0aW9ucyJDCg9TdGVsbGFyTWVtb1R5cG'
+    'USCAoETk9ORRAAEggKBFRFWFQQARIGCgJJRBACEggKBEhBU0gQAxIKCgZSRVRVUk4QBA==');
+
+@$core.Deprecated('Use stellarTxOpRequestDescriptor instead')
+const StellarTxOpRequest$json = {
+  '1': 'StellarTxOpRequest',
+};
+
+/// Descriptor for `StellarTxOpRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarTxOpRequestDescriptor = $convert.base64Decode(
+    'ChJTdGVsbGFyVHhPcFJlcXVlc3Q=');
+
+@$core.Deprecated('Use stellarPaymentOpDescriptor instead')
+const StellarPaymentOp$json = {
+  '1': 'StellarPaymentOp',
+  '2': [
+    {'1': 'source_account', '3': 1, '4': 1, '5': 9, '10': 'sourceAccount'},
+    {'1': 'destination_account', '3': 2, '4': 2, '5': 9, '10': 'destinationAccount'},
+    {'1': 'asset', '3': 3, '4': 2, '5': 11, '6': '.hw.trezor.messages.stellar.StellarAsset', '10': 'asset'},
+    {'1': 'amount', '3': 4, '4': 2, '5': 18, '10': 'amount'},
+  ],
+};
+
+/// Descriptor for `StellarPaymentOp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarPaymentOpDescriptor = $convert.base64Decode(
+    'ChBTdGVsbGFyUGF5bWVudE9wEiUKDnNvdXJjZV9hY2NvdW50GAEgASgJUg1zb3VyY2VBY2NvdW'
+    '50Ei8KE2Rlc3RpbmF0aW9uX2FjY291bnQYAiACKAlSEmRlc3RpbmF0aW9uQWNjb3VudBI+CgVh'
+    'c3NldBgDIAIoCzIoLmh3LnRyZXpvci5tZXNzYWdlcy5zdGVsbGFyLlN0ZWxsYXJBc3NldFIFYX'
+    'NzZXQSFgoGYW1vdW50GAQgAigSUgZhbW91bnQ=');
+
+@$core.Deprecated('Use stellarCreateAccountOpDescriptor instead')
+const StellarCreateAccountOp$json = {
+  '1': 'StellarCreateAccountOp',
+  '2': [
+    {'1': 'source_account', '3': 1, '4': 1, '5': 9, '10': 'sourceAccount'},
+    {'1': 'new_account', '3': 2, '4': 2, '5': 9, '10': 'newAccount'},
+    {'1': 'starting_balance', '3': 3, '4': 2, '5': 18, '10': 'startingBalance'},
+  ],
+};
+
+/// Descriptor for `StellarCreateAccountOp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarCreateAccountOpDescriptor = $convert.base64Decode(
+    'ChZTdGVsbGFyQ3JlYXRlQWNjb3VudE9wEiUKDnNvdXJjZV9hY2NvdW50GAEgASgJUg1zb3VyY2'
+    'VBY2NvdW50Eh8KC25ld19hY2NvdW50GAIgAigJUgpuZXdBY2NvdW50EikKEHN0YXJ0aW5nX2Jh'
+    'bGFuY2UYAyACKBJSD3N0YXJ0aW5nQmFsYW5jZQ==');
+
+@$core.Deprecated('Use stellarPathPaymentStrictReceiveOpDescriptor instead')
+const StellarPathPaymentStrictReceiveOp$json = {
+  '1': 'StellarPathPaymentStrictReceiveOp',
+  '2': [
+    {'1': 'source_account', '3': 1, '4': 1, '5': 9, '10': 'sourceAccount'},
+    {'1': 'send_asset', '3': 2, '4': 2, '5': 11, '6': '.hw.trezor.messages.stellar.StellarAsset', '10': 'sendAsset'},
+    {'1': 'send_max', '3': 3, '4': 2, '5': 18, '10': 'sendMax'},
+    {'1': 'destination_account', '3': 4, '4': 2, '5': 9, '10': 'destinationAccount'},
+    {'1': 'destination_asset', '3': 5, '4': 2, '5': 11, '6': '.hw.trezor.messages.stellar.StellarAsset', '10': 'destinationAsset'},
+    {'1': 'destination_amount', '3': 6, '4': 2, '5': 18, '10': 'destinationAmount'},
+    {'1': 'paths', '3': 7, '4': 3, '5': 11, '6': '.hw.trezor.messages.stellar.StellarAsset', '10': 'paths'},
+  ],
+};
+
+/// Descriptor for `StellarPathPaymentStrictReceiveOp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarPathPaymentStrictReceiveOpDescriptor = $convert.base64Decode(
+    'CiFTdGVsbGFyUGF0aFBheW1lbnRTdHJpY3RSZWNlaXZlT3ASJQoOc291cmNlX2FjY291bnQYAS'
+    'ABKAlSDXNvdXJjZUFjY291bnQSRwoKc2VuZF9hc3NldBgCIAIoCzIoLmh3LnRyZXpvci5tZXNz'
+    'YWdlcy5zdGVsbGFyLlN0ZWxsYXJBc3NldFIJc2VuZEFzc2V0EhkKCHNlbmRfbWF4GAMgAigSUg'
+    'dzZW5kTWF4Ei8KE2Rlc3RpbmF0aW9uX2FjY291bnQYBCACKAlSEmRlc3RpbmF0aW9uQWNjb3Vu'
+    'dBJVChFkZXN0aW5hdGlvbl9hc3NldBgFIAIoCzIoLmh3LnRyZXpvci5tZXNzYWdlcy5zdGVsbG'
+    'FyLlN0ZWxsYXJBc3NldFIQZGVzdGluYXRpb25Bc3NldBItChJkZXN0aW5hdGlvbl9hbW91bnQY'
+    'BiACKBJSEWRlc3RpbmF0aW9uQW1vdW50Ej4KBXBhdGhzGAcgAygLMiguaHcudHJlem9yLm1lc3'
+    'NhZ2VzLnN0ZWxsYXIuU3RlbGxhckFzc2V0UgVwYXRocw==');
+
+@$core.Deprecated('Use stellarPathPaymentStrictSendOpDescriptor instead')
+const StellarPathPaymentStrictSendOp$json = {
+  '1': 'StellarPathPaymentStrictSendOp',
+  '2': [
+    {'1': 'source_account', '3': 1, '4': 1, '5': 9, '10': 'sourceAccount'},
+    {'1': 'send_asset', '3': 2, '4': 2, '5': 11, '6': '.hw.trezor.messages.stellar.StellarAsset', '10': 'sendAsset'},
+    {'1': 'send_amount', '3': 3, '4': 2, '5': 18, '10': 'sendAmount'},
+    {'1': 'destination_account', '3': 4, '4': 2, '5': 9, '10': 'destinationAccount'},
+    {'1': 'destination_asset', '3': 5, '4': 2, '5': 11, '6': '.hw.trezor.messages.stellar.StellarAsset', '10': 'destinationAsset'},
+    {'1': 'destination_min', '3': 6, '4': 2, '5': 18, '10': 'destinationMin'},
+    {'1': 'paths', '3': 7, '4': 3, '5': 11, '6': '.hw.trezor.messages.stellar.StellarAsset', '10': 'paths'},
+  ],
+};
+
+/// Descriptor for `StellarPathPaymentStrictSendOp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarPathPaymentStrictSendOpDescriptor = $convert.base64Decode(
+    'Ch5TdGVsbGFyUGF0aFBheW1lbnRTdHJpY3RTZW5kT3ASJQoOc291cmNlX2FjY291bnQYASABKA'
+    'lSDXNvdXJjZUFjY291bnQSRwoKc2VuZF9hc3NldBgCIAIoCzIoLmh3LnRyZXpvci5tZXNzYWdl'
+    'cy5zdGVsbGFyLlN0ZWxsYXJBc3NldFIJc2VuZEFzc2V0Eh8KC3NlbmRfYW1vdW50GAMgAigSUg'
+    'pzZW5kQW1vdW50Ei8KE2Rlc3RpbmF0aW9uX2FjY291bnQYBCACKAlSEmRlc3RpbmF0aW9uQWNj'
+    'b3VudBJVChFkZXN0aW5hdGlvbl9hc3NldBgFIAIoCzIoLmh3LnRyZXpvci5tZXNzYWdlcy5zdG'
+    'VsbGFyLlN0ZWxsYXJBc3NldFIQZGVzdGluYXRpb25Bc3NldBInCg9kZXN0aW5hdGlvbl9taW4Y'
+    'BiACKBJSDmRlc3RpbmF0aW9uTWluEj4KBXBhdGhzGAcgAygLMiguaHcudHJlem9yLm1lc3NhZ2'
+    'VzLnN0ZWxsYXIuU3RlbGxhckFzc2V0UgVwYXRocw==');
+
+@$core.Deprecated('Use stellarManageSellOfferOpDescriptor instead')
+const StellarManageSellOfferOp$json = {
+  '1': 'StellarManageSellOfferOp',
+  '2': [
+    {'1': 'source_account', '3': 1, '4': 1, '5': 9, '10': 'sourceAccount'},
+    {'1': 'selling_asset', '3': 2, '4': 2, '5': 11, '6': '.hw.trezor.messages.stellar.StellarAsset', '10': 'sellingAsset'},
+    {'1': 'buying_asset', '3': 3, '4': 2, '5': 11, '6': '.hw.trezor.messages.stellar.StellarAsset', '10': 'buyingAsset'},
+    {'1': 'amount', '3': 4, '4': 2, '5': 18, '10': 'amount'},
+    {'1': 'price_n', '3': 5, '4': 2, '5': 13, '10': 'priceN'},
+    {'1': 'price_d', '3': 6, '4': 2, '5': 13, '10': 'priceD'},
+    {'1': 'offer_id', '3': 7, '4': 2, '5': 4, '10': 'offerId'},
+  ],
+};
+
+/// Descriptor for `StellarManageSellOfferOp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarManageSellOfferOpDescriptor = $convert.base64Decode(
+    'ChhTdGVsbGFyTWFuYWdlU2VsbE9mZmVyT3ASJQoOc291cmNlX2FjY291bnQYASABKAlSDXNvdX'
+    'JjZUFjY291bnQSTQoNc2VsbGluZ19hc3NldBgCIAIoCzIoLmh3LnRyZXpvci5tZXNzYWdlcy5z'
+    'dGVsbGFyLlN0ZWxsYXJBc3NldFIMc2VsbGluZ0Fzc2V0EksKDGJ1eWluZ19hc3NldBgDIAIoCz'
+    'IoLmh3LnRyZXpvci5tZXNzYWdlcy5zdGVsbGFyLlN0ZWxsYXJBc3NldFILYnV5aW5nQXNzZXQS'
+    'FgoGYW1vdW50GAQgAigSUgZhbW91bnQSFwoHcHJpY2VfbhgFIAIoDVIGcHJpY2VOEhcKB3ByaW'
+    'NlX2QYBiACKA1SBnByaWNlRBIZCghvZmZlcl9pZBgHIAIoBFIHb2ZmZXJJZA==');
+
+@$core.Deprecated('Use stellarManageBuyOfferOpDescriptor instead')
+const StellarManageBuyOfferOp$json = {
+  '1': 'StellarManageBuyOfferOp',
+  '2': [
+    {'1': 'source_account', '3': 1, '4': 1, '5': 9, '10': 'sourceAccount'},
+    {'1': 'selling_asset', '3': 2, '4': 2, '5': 11, '6': '.hw.trezor.messages.stellar.StellarAsset', '10': 'sellingAsset'},
+    {'1': 'buying_asset', '3': 3, '4': 2, '5': 11, '6': '.hw.trezor.messages.stellar.StellarAsset', '10': 'buyingAsset'},
+    {'1': 'amount', '3': 4, '4': 2, '5': 18, '10': 'amount'},
+    {'1': 'price_n', '3': 5, '4': 2, '5': 13, '10': 'priceN'},
+    {'1': 'price_d', '3': 6, '4': 2, '5': 13, '10': 'priceD'},
+    {'1': 'offer_id', '3': 7, '4': 2, '5': 4, '10': 'offerId'},
+  ],
+};
+
+/// Descriptor for `StellarManageBuyOfferOp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarManageBuyOfferOpDescriptor = $convert.base64Decode(
+    'ChdTdGVsbGFyTWFuYWdlQnV5T2ZmZXJPcBIlCg5zb3VyY2VfYWNjb3VudBgBIAEoCVINc291cm'
+    'NlQWNjb3VudBJNCg1zZWxsaW5nX2Fzc2V0GAIgAigLMiguaHcudHJlem9yLm1lc3NhZ2VzLnN0'
+    'ZWxsYXIuU3RlbGxhckFzc2V0UgxzZWxsaW5nQXNzZXQSSwoMYnV5aW5nX2Fzc2V0GAMgAigLMi'
+    'guaHcudHJlem9yLm1lc3NhZ2VzLnN0ZWxsYXIuU3RlbGxhckFzc2V0UgtidXlpbmdBc3NldBIW'
+    'CgZhbW91bnQYBCACKBJSBmFtb3VudBIXCgdwcmljZV9uGAUgAigNUgZwcmljZU4SFwoHcHJpY2'
+    'VfZBgGIAIoDVIGcHJpY2VEEhkKCG9mZmVyX2lkGAcgAigEUgdvZmZlcklk');
+
+@$core.Deprecated('Use stellarCreatePassiveSellOfferOpDescriptor instead')
+const StellarCreatePassiveSellOfferOp$json = {
+  '1': 'StellarCreatePassiveSellOfferOp',
+  '2': [
+    {'1': 'source_account', '3': 1, '4': 1, '5': 9, '10': 'sourceAccount'},
+    {'1': 'selling_asset', '3': 2, '4': 2, '5': 11, '6': '.hw.trezor.messages.stellar.StellarAsset', '10': 'sellingAsset'},
+    {'1': 'buying_asset', '3': 3, '4': 2, '5': 11, '6': '.hw.trezor.messages.stellar.StellarAsset', '10': 'buyingAsset'},
+    {'1': 'amount', '3': 4, '4': 2, '5': 18, '10': 'amount'},
+    {'1': 'price_n', '3': 5, '4': 2, '5': 13, '10': 'priceN'},
+    {'1': 'price_d', '3': 6, '4': 2, '5': 13, '10': 'priceD'},
+  ],
+};
+
+/// Descriptor for `StellarCreatePassiveSellOfferOp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarCreatePassiveSellOfferOpDescriptor = $convert.base64Decode(
+    'Ch9TdGVsbGFyQ3JlYXRlUGFzc2l2ZVNlbGxPZmZlck9wEiUKDnNvdXJjZV9hY2NvdW50GAEgAS'
+    'gJUg1zb3VyY2VBY2NvdW50Ek0KDXNlbGxpbmdfYXNzZXQYAiACKAsyKC5ody50cmV6b3IubWVz'
+    'c2FnZXMuc3RlbGxhci5TdGVsbGFyQXNzZXRSDHNlbGxpbmdBc3NldBJLCgxidXlpbmdfYXNzZX'
+    'QYAyACKAsyKC5ody50cmV6b3IubWVzc2FnZXMuc3RlbGxhci5TdGVsbGFyQXNzZXRSC2J1eWlu'
+    'Z0Fzc2V0EhYKBmFtb3VudBgEIAIoElIGYW1vdW50EhcKB3ByaWNlX24YBSACKA1SBnByaWNlTh'
+    'IXCgdwcmljZV9kGAYgAigNUgZwcmljZUQ=');
+
+@$core.Deprecated('Use stellarSetOptionsOpDescriptor instead')
+const StellarSetOptionsOp$json = {
+  '1': 'StellarSetOptionsOp',
+  '2': [
+    {'1': 'source_account', '3': 1, '4': 1, '5': 9, '10': 'sourceAccount'},
+    {'1': 'inflation_destination_account', '3': 2, '4': 1, '5': 9, '10': 'inflationDestinationAccount'},
+    {'1': 'clear_flags', '3': 3, '4': 1, '5': 13, '10': 'clearFlags'},
+    {'1': 'set_flags', '3': 4, '4': 1, '5': 13, '10': 'setFlags'},
+    {'1': 'master_weight', '3': 5, '4': 1, '5': 13, '10': 'masterWeight'},
+    {'1': 'low_threshold', '3': 6, '4': 1, '5': 13, '10': 'lowThreshold'},
+    {'1': 'medium_threshold', '3': 7, '4': 1, '5': 13, '10': 'mediumThreshold'},
+    {'1': 'high_threshold', '3': 8, '4': 1, '5': 13, '10': 'highThreshold'},
+    {'1': 'home_domain', '3': 9, '4': 1, '5': 9, '10': 'homeDomain'},
+    {'1': 'signer_type', '3': 10, '4': 1, '5': 14, '6': '.hw.trezor.messages.stellar.StellarSetOptionsOp.StellarSignerType', '10': 'signerType'},
+    {'1': 'signer_key', '3': 11, '4': 1, '5': 12, '10': 'signerKey'},
+    {'1': 'signer_weight', '3': 12, '4': 1, '5': 13, '10': 'signerWeight'},
+  ],
+  '4': [StellarSetOptionsOp_StellarSignerType$json],
+};
+
+@$core.Deprecated('Use stellarSetOptionsOpDescriptor instead')
+const StellarSetOptionsOp_StellarSignerType$json = {
+  '1': 'StellarSignerType',
+  '2': [
+    {'1': 'ACCOUNT', '2': 0},
+    {'1': 'PRE_AUTH', '2': 1},
+    {'1': 'HASH', '2': 2},
+  ],
+};
+
+/// Descriptor for `StellarSetOptionsOp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarSetOptionsOpDescriptor = $convert.base64Decode(
+    'ChNTdGVsbGFyU2V0T3B0aW9uc09wEiUKDnNvdXJjZV9hY2NvdW50GAEgASgJUg1zb3VyY2VBY2'
+    'NvdW50EkIKHWluZmxhdGlvbl9kZXN0aW5hdGlvbl9hY2NvdW50GAIgASgJUhtpbmZsYXRpb25E'
+    'ZXN0aW5hdGlvbkFjY291bnQSHwoLY2xlYXJfZmxhZ3MYAyABKA1SCmNsZWFyRmxhZ3MSGwoJc2'
+    'V0X2ZsYWdzGAQgASgNUghzZXRGbGFncxIjCg1tYXN0ZXJfd2VpZ2h0GAUgASgNUgxtYXN0ZXJX'
+    'ZWlnaHQSIwoNbG93X3RocmVzaG9sZBgGIAEoDVIMbG93VGhyZXNob2xkEikKEG1lZGl1bV90aH'
+    'Jlc2hvbGQYByABKA1SD21lZGl1bVRocmVzaG9sZBIlCg5oaWdoX3RocmVzaG9sZBgIIAEoDVIN'
+    'aGlnaFRocmVzaG9sZBIfCgtob21lX2RvbWFpbhgJIAEoCVIKaG9tZURvbWFpbhJiCgtzaWduZX'
+    'JfdHlwZRgKIAEoDjJBLmh3LnRyZXpvci5tZXNzYWdlcy5zdGVsbGFyLlN0ZWxsYXJTZXRPcHRp'
+    'b25zT3AuU3RlbGxhclNpZ25lclR5cGVSCnNpZ25lclR5cGUSHQoKc2lnbmVyX2tleRgLIAEoDF'
+    'IJc2lnbmVyS2V5EiMKDXNpZ25lcl93ZWlnaHQYDCABKA1SDHNpZ25lcldlaWdodCI4ChFTdGVs'
+    'bGFyU2lnbmVyVHlwZRILCgdBQ0NPVU5UEAASDAoIUFJFX0FVVEgQARIICgRIQVNIEAI=');
+
+@$core.Deprecated('Use stellarChangeTrustOpDescriptor instead')
+const StellarChangeTrustOp$json = {
+  '1': 'StellarChangeTrustOp',
+  '2': [
+    {'1': 'source_account', '3': 1, '4': 1, '5': 9, '10': 'sourceAccount'},
+    {'1': 'asset', '3': 2, '4': 2, '5': 11, '6': '.hw.trezor.messages.stellar.StellarAsset', '10': 'asset'},
+    {'1': 'limit', '3': 3, '4': 2, '5': 4, '10': 'limit'},
+  ],
+};
+
+/// Descriptor for `StellarChangeTrustOp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarChangeTrustOpDescriptor = $convert.base64Decode(
+    'ChRTdGVsbGFyQ2hhbmdlVHJ1c3RPcBIlCg5zb3VyY2VfYWNjb3VudBgBIAEoCVINc291cmNlQW'
+    'Njb3VudBI+CgVhc3NldBgCIAIoCzIoLmh3LnRyZXpvci5tZXNzYWdlcy5zdGVsbGFyLlN0ZWxs'
+    'YXJBc3NldFIFYXNzZXQSFAoFbGltaXQYAyACKARSBWxpbWl0');
+
+@$core.Deprecated('Use stellarAllowTrustOpDescriptor instead')
+const StellarAllowTrustOp$json = {
+  '1': 'StellarAllowTrustOp',
+  '2': [
+    {'1': 'source_account', '3': 1, '4': 1, '5': 9, '10': 'sourceAccount'},
+    {'1': 'trusted_account', '3': 2, '4': 2, '5': 9, '10': 'trustedAccount'},
+    {'1': 'asset_type', '3': 3, '4': 2, '5': 14, '6': '.hw.trezor.messages.stellar.StellarAssetType', '10': 'assetType'},
+    {'1': 'asset_code', '3': 4, '4': 1, '5': 9, '10': 'assetCode'},
+    {'1': 'is_authorized', '3': 5, '4': 2, '5': 8, '10': 'isAuthorized'},
+  ],
+};
+
+/// Descriptor for `StellarAllowTrustOp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarAllowTrustOpDescriptor = $convert.base64Decode(
+    'ChNTdGVsbGFyQWxsb3dUcnVzdE9wEiUKDnNvdXJjZV9hY2NvdW50GAEgASgJUg1zb3VyY2VBY2'
+    'NvdW50EicKD3RydXN0ZWRfYWNjb3VudBgCIAIoCVIOdHJ1c3RlZEFjY291bnQSSwoKYXNzZXRf'
+    'dHlwZRgDIAIoDjIsLmh3LnRyZXpvci5tZXNzYWdlcy5zdGVsbGFyLlN0ZWxsYXJBc3NldFR5cG'
+    'VSCWFzc2V0VHlwZRIdCgphc3NldF9jb2RlGAQgASgJUglhc3NldENvZGUSIwoNaXNfYXV0aG9y'
+    'aXplZBgFIAIoCFIMaXNBdXRob3JpemVk');
+
+@$core.Deprecated('Use stellarAccountMergeOpDescriptor instead')
+const StellarAccountMergeOp$json = {
+  '1': 'StellarAccountMergeOp',
+  '2': [
+    {'1': 'source_account', '3': 1, '4': 1, '5': 9, '10': 'sourceAccount'},
+    {'1': 'destination_account', '3': 2, '4': 2, '5': 9, '10': 'destinationAccount'},
+  ],
+};
+
+/// Descriptor for `StellarAccountMergeOp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarAccountMergeOpDescriptor = $convert.base64Decode(
+    'ChVTdGVsbGFyQWNjb3VudE1lcmdlT3ASJQoOc291cmNlX2FjY291bnQYASABKAlSDXNvdXJjZU'
+    'FjY291bnQSLwoTZGVzdGluYXRpb25fYWNjb3VudBgCIAIoCVISZGVzdGluYXRpb25BY2NvdW50');
+
+@$core.Deprecated('Use stellarManageDataOpDescriptor instead')
+const StellarManageDataOp$json = {
+  '1': 'StellarManageDataOp',
+  '2': [
+    {'1': 'source_account', '3': 1, '4': 1, '5': 9, '10': 'sourceAccount'},
+    {'1': 'key', '3': 2, '4': 2, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 3, '4': 1, '5': 12, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `StellarManageDataOp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarManageDataOpDescriptor = $convert.base64Decode(
+    'ChNTdGVsbGFyTWFuYWdlRGF0YU9wEiUKDnNvdXJjZV9hY2NvdW50GAEgASgJUg1zb3VyY2VBY2'
+    'NvdW50EhAKA2tleRgCIAIoCVIDa2V5EhQKBXZhbHVlGAMgASgMUgV2YWx1ZQ==');
+
+@$core.Deprecated('Use stellarBumpSequenceOpDescriptor instead')
+const StellarBumpSequenceOp$json = {
+  '1': 'StellarBumpSequenceOp',
+  '2': [
+    {'1': 'source_account', '3': 1, '4': 1, '5': 9, '10': 'sourceAccount'},
+    {'1': 'bump_to', '3': 2, '4': 2, '5': 4, '10': 'bumpTo'},
+  ],
+};
+
+/// Descriptor for `StellarBumpSequenceOp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarBumpSequenceOpDescriptor = $convert.base64Decode(
+    'ChVTdGVsbGFyQnVtcFNlcXVlbmNlT3ASJQoOc291cmNlX2FjY291bnQYASABKAlSDXNvdXJjZU'
+    'FjY291bnQSFwoHYnVtcF90bxgCIAIoBFIGYnVtcFRv');
+
+@$core.Deprecated('Use stellarClaimClaimableBalanceOpDescriptor instead')
+const StellarClaimClaimableBalanceOp$json = {
+  '1': 'StellarClaimClaimableBalanceOp',
+  '2': [
+    {'1': 'source_account', '3': 1, '4': 1, '5': 9, '10': 'sourceAccount'},
+    {'1': 'balance_id', '3': 2, '4': 2, '5': 12, '10': 'balanceId'},
+  ],
+};
+
+/// Descriptor for `StellarClaimClaimableBalanceOp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarClaimClaimableBalanceOpDescriptor = $convert.base64Decode(
+    'Ch5TdGVsbGFyQ2xhaW1DbGFpbWFibGVCYWxhbmNlT3ASJQoOc291cmNlX2FjY291bnQYASABKA'
+    'lSDXNvdXJjZUFjY291bnQSHQoKYmFsYW5jZV9pZBgCIAIoDFIJYmFsYW5jZUlk');
+
+@$core.Deprecated('Use stellarSignedTxDescriptor instead')
+const StellarSignedTx$json = {
+  '1': 'StellarSignedTx',
+  '2': [
+    {'1': 'public_key', '3': 1, '4': 2, '5': 12, '10': 'publicKey'},
+    {'1': 'signature', '3': 2, '4': 2, '5': 12, '10': 'signature'},
+  ],
+};
+
+/// Descriptor for `StellarSignedTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stellarSignedTxDescriptor = $convert.base64Decode(
+    'Cg9TdGVsbGFyU2lnbmVkVHgSHQoKcHVibGljX2tleRgBIAIoDFIJcHVibGljS2V5EhwKCXNpZ2'
+    '5hdHVyZRgCIAIoDFIJc2lnbmF0dXJl');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-stellar.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-stellar.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-stellar.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-stellar.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-tezos.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-tezos.pb.dart
@@ -1,0 +1,1506 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-tezos.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'messages-tezos.pbenum.dart';
+
+export 'messages-tezos.pbenum.dart';
+
+/// *
+///  Request: Ask device for Tezos address corresponding to address_n path
+///  @start
+///  @next TezosAddress
+///  @next Failure
+class TezosGetAddress extends $pb.GeneratedMessage {
+  factory TezosGetAddress({
+    $core.Iterable<$core.int>? addressN,
+    $core.bool? showDisplay,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  TezosGetAddress._() : super();
+  factory TezosGetAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TezosGetAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TezosGetAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.tezos'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aOB(2, _omitFieldNames ? '' : 'showDisplay')
+    ..aOB(3, _omitFieldNames ? '' : 'chunkify')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TezosGetAddress clone() => TezosGetAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TezosGetAddress copyWith(void Function(TezosGetAddress) updates) => super.copyWith((message) => updates(message as TezosGetAddress)) as TezosGetAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TezosGetAddress create() => TezosGetAddress._();
+  TezosGetAddress createEmptyInstance() => create();
+  static $pb.PbList<TezosGetAddress> createRepeated() => $pb.PbList<TezosGetAddress>();
+  @$core.pragma('dart2js:noInline')
+  static TezosGetAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TezosGetAddress>(create);
+  static TezosGetAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.bool get showDisplay => $_getBF(1);
+  @$pb.TagNumber(2)
+  set showDisplay($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasShowDisplay() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearShowDisplay() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get chunkify => $_getBF(2);
+  @$pb.TagNumber(3)
+  set chunkify($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasChunkify() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearChunkify() => clearField(3);
+}
+
+/// *
+///  Response: Contains Tezos address derived from device private seed
+///  @end
+class TezosAddress extends $pb.GeneratedMessage {
+  factory TezosAddress({
+    $core.String? address,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    return $result;
+  }
+  TezosAddress._() : super();
+  factory TezosAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TezosAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TezosAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.tezos'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'address')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TezosAddress clone() => TezosAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TezosAddress copyWith(void Function(TezosAddress) updates) => super.copyWith((message) => updates(message as TezosAddress)) as TezosAddress;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TezosAddress create() => TezosAddress._();
+  TezosAddress createEmptyInstance() => create();
+  static $pb.PbList<TezosAddress> createRepeated() => $pb.PbList<TezosAddress>();
+  @$core.pragma('dart2js:noInline')
+  static TezosAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TezosAddress>(create);
+  static TezosAddress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+}
+
+/// *
+///  Request: Ask device for Tezos public key corresponding to address_n path
+///  @start
+///  @next TezosPublicKey
+class TezosGetPublicKey extends $pb.GeneratedMessage {
+  factory TezosGetPublicKey({
+    $core.Iterable<$core.int>? addressN,
+    $core.bool? showDisplay,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (showDisplay != null) {
+      $result.showDisplay = showDisplay;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  TezosGetPublicKey._() : super();
+  factory TezosGetPublicKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TezosGetPublicKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TezosGetPublicKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.tezos'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..aOB(2, _omitFieldNames ? '' : 'showDisplay')
+    ..aOB(3, _omitFieldNames ? '' : 'chunkify')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TezosGetPublicKey clone() => TezosGetPublicKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TezosGetPublicKey copyWith(void Function(TezosGetPublicKey) updates) => super.copyWith((message) => updates(message as TezosGetPublicKey)) as TezosGetPublicKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TezosGetPublicKey create() => TezosGetPublicKey._();
+  TezosGetPublicKey createEmptyInstance() => create();
+  static $pb.PbList<TezosGetPublicKey> createRepeated() => $pb.PbList<TezosGetPublicKey>();
+  @$core.pragma('dart2js:noInline')
+  static TezosGetPublicKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TezosGetPublicKey>(create);
+  static TezosGetPublicKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.bool get showDisplay => $_getBF(1);
+  @$pb.TagNumber(2)
+  set showDisplay($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasShowDisplay() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearShowDisplay() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get chunkify => $_getBF(2);
+  @$pb.TagNumber(3)
+  set chunkify($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasChunkify() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearChunkify() => clearField(3);
+}
+
+/// *
+///  Response: Contains Tezos public key derived from device private seed
+///  @end
+class TezosPublicKey extends $pb.GeneratedMessage {
+  factory TezosPublicKey({
+    $core.String? publicKey,
+  }) {
+    final $result = create();
+    if (publicKey != null) {
+      $result.publicKey = publicKey;
+    }
+    return $result;
+  }
+  TezosPublicKey._() : super();
+  factory TezosPublicKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TezosPublicKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TezosPublicKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.tezos'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'publicKey')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TezosPublicKey clone() => TezosPublicKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TezosPublicKey copyWith(void Function(TezosPublicKey) updates) => super.copyWith((message) => updates(message as TezosPublicKey)) as TezosPublicKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TezosPublicKey create() => TezosPublicKey._();
+  TezosPublicKey createEmptyInstance() => create();
+  static $pb.PbList<TezosPublicKey> createRepeated() => $pb.PbList<TezosPublicKey>();
+  @$core.pragma('dart2js:noInline')
+  static TezosPublicKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TezosPublicKey>(create);
+  static TezosPublicKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get publicKey => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set publicKey($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPublicKey() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPublicKey() => clearField(1);
+}
+
+///
+///  Tezos contract ID
+class TezosSignTx_TezosContractID extends $pb.GeneratedMessage {
+  factory TezosSignTx_TezosContractID({
+    TezosSignTx_TezosContractID_TezosContractType? tag,
+    $core.List<$core.int>? hash,
+  }) {
+    final $result = create();
+    if (tag != null) {
+      $result.tag = tag;
+    }
+    if (hash != null) {
+      $result.hash = hash;
+    }
+    return $result;
+  }
+  TezosSignTx_TezosContractID._() : super();
+  factory TezosSignTx_TezosContractID.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TezosSignTx_TezosContractID.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TezosSignTx.TezosContractID', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.tezos'), createEmptyInstance: create)
+    ..e<TezosSignTx_TezosContractID_TezosContractType>(1, _omitFieldNames ? '' : 'tag', $pb.PbFieldType.QE, defaultOrMaker: TezosSignTx_TezosContractID_TezosContractType.Implicit, valueOf: TezosSignTx_TezosContractID_TezosContractType.valueOf, enumValues: TezosSignTx_TezosContractID_TezosContractType.values)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'hash', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosContractID clone() => TezosSignTx_TezosContractID()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosContractID copyWith(void Function(TezosSignTx_TezosContractID) updates) => super.copyWith((message) => updates(message as TezosSignTx_TezosContractID)) as TezosSignTx_TezosContractID;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosContractID create() => TezosSignTx_TezosContractID._();
+  TezosSignTx_TezosContractID createEmptyInstance() => create();
+  static $pb.PbList<TezosSignTx_TezosContractID> createRepeated() => $pb.PbList<TezosSignTx_TezosContractID>();
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosContractID getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TezosSignTx_TezosContractID>(create);
+  static TezosSignTx_TezosContractID? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  TezosSignTx_TezosContractID_TezosContractType get tag => $_getN(0);
+  @$pb.TagNumber(1)
+  set tag(TezosSignTx_TezosContractID_TezosContractType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTag() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTag() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get hash => $_getN(1);
+  @$pb.TagNumber(2)
+  set hash($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearHash() => clearField(2);
+}
+
+/// *
+///  Structure representing information for reveal
+class TezosSignTx_TezosRevealOp extends $pb.GeneratedMessage {
+  factory TezosSignTx_TezosRevealOp({
+    $fixnum.Int64? fee,
+    $fixnum.Int64? counter,
+    $fixnum.Int64? gasLimit,
+    $fixnum.Int64? storageLimit,
+    $core.List<$core.int>? publicKey,
+    $core.List<$core.int>? source,
+  }) {
+    final $result = create();
+    if (fee != null) {
+      $result.fee = fee;
+    }
+    if (counter != null) {
+      $result.counter = counter;
+    }
+    if (gasLimit != null) {
+      $result.gasLimit = gasLimit;
+    }
+    if (storageLimit != null) {
+      $result.storageLimit = storageLimit;
+    }
+    if (publicKey != null) {
+      $result.publicKey = publicKey;
+    }
+    if (source != null) {
+      $result.source = source;
+    }
+    return $result;
+  }
+  TezosSignTx_TezosRevealOp._() : super();
+  factory TezosSignTx_TezosRevealOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TezosSignTx_TezosRevealOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TezosSignTx.TezosRevealOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.tezos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'counter', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'gasLimit', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(5, _omitFieldNames ? '' : 'storageLimit', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'publicKey', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(7, _omitFieldNames ? '' : 'source', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosRevealOp clone() => TezosSignTx_TezosRevealOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosRevealOp copyWith(void Function(TezosSignTx_TezosRevealOp) updates) => super.copyWith((message) => updates(message as TezosSignTx_TezosRevealOp)) as TezosSignTx_TezosRevealOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosRevealOp create() => TezosSignTx_TezosRevealOp._();
+  TezosSignTx_TezosRevealOp createEmptyInstance() => create();
+  static $pb.PbList<TezosSignTx_TezosRevealOp> createRepeated() => $pb.PbList<TezosSignTx_TezosRevealOp>();
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosRevealOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TezosSignTx_TezosRevealOp>(create);
+  static TezosSignTx_TezosRevealOp? _defaultInstance;
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get fee => $_getI64(0);
+  @$pb.TagNumber(2)
+  set fee($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasFee() => $_has(0);
+  @$pb.TagNumber(2)
+  void clearFee() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get counter => $_getI64(1);
+  @$pb.TagNumber(3)
+  set counter($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasCounter() => $_has(1);
+  @$pb.TagNumber(3)
+  void clearCounter() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get gasLimit => $_getI64(2);
+  @$pb.TagNumber(4)
+  set gasLimit($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasGasLimit() => $_has(2);
+  @$pb.TagNumber(4)
+  void clearGasLimit() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $fixnum.Int64 get storageLimit => $_getI64(3);
+  @$pb.TagNumber(5)
+  set storageLimit($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasStorageLimit() => $_has(3);
+  @$pb.TagNumber(5)
+  void clearStorageLimit() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get publicKey => $_getN(4);
+  @$pb.TagNumber(6)
+  set publicKey($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasPublicKey() => $_has(4);
+  @$pb.TagNumber(6)
+  void clearPublicKey() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.List<$core.int> get source => $_getN(5);
+  @$pb.TagNumber(7)
+  set source($core.List<$core.int> v) { $_setBytes(5, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasSource() => $_has(5);
+  @$pb.TagNumber(7)
+  void clearSource() => clearField(7);
+}
+
+class TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer extends $pb.GeneratedMessage {
+  factory TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer({
+    TezosSignTx_TezosContractID? destination,
+    $fixnum.Int64? amount,
+  }) {
+    final $result = create();
+    if (destination != null) {
+      $result.destination = destination;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    return $result;
+  }
+  TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer._() : super();
+  factory TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TezosSignTx.TezosTransactionOp.TezosParametersManager.TezosManagerTransfer', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.tezos'), createEmptyInstance: create)
+    ..aQM<TezosSignTx_TezosContractID>(1, _omitFieldNames ? '' : 'destination', subBuilder: TezosSignTx_TezosContractID.create)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer clone() => TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer copyWith(void Function(TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer) updates) => super.copyWith((message) => updates(message as TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer)) as TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer create() => TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer._();
+  TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer createEmptyInstance() => create();
+  static $pb.PbList<TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer> createRepeated() => $pb.PbList<TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer>();
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer>(create);
+  static TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  TezosSignTx_TezosContractID get destination => $_getN(0);
+  @$pb.TagNumber(1)
+  set destination(TezosSignTx_TezosContractID v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDestination() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDestination() => clearField(1);
+  @$pb.TagNumber(1)
+  TezosSignTx_TezosContractID ensureDestination() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get amount => $_getI64(1);
+  @$pb.TagNumber(2)
+  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAmount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAmount() => clearField(2);
+}
+
+class TezosSignTx_TezosTransactionOp_TezosParametersManager extends $pb.GeneratedMessage {
+  factory TezosSignTx_TezosTransactionOp_TezosParametersManager({
+    $core.List<$core.int>? setDelegate,
+    $core.bool? cancelDelegate,
+    TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer? transfer,
+  }) {
+    final $result = create();
+    if (setDelegate != null) {
+      $result.setDelegate = setDelegate;
+    }
+    if (cancelDelegate != null) {
+      $result.cancelDelegate = cancelDelegate;
+    }
+    if (transfer != null) {
+      $result.transfer = transfer;
+    }
+    return $result;
+  }
+  TezosSignTx_TezosTransactionOp_TezosParametersManager._() : super();
+  factory TezosSignTx_TezosTransactionOp_TezosParametersManager.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TezosSignTx_TezosTransactionOp_TezosParametersManager.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TezosSignTx.TezosTransactionOp.TezosParametersManager', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.tezos'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'setDelegate', $pb.PbFieldType.OY)
+    ..aOB(2, _omitFieldNames ? '' : 'cancelDelegate')
+    ..aOM<TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer>(3, _omitFieldNames ? '' : 'transfer', subBuilder: TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosTransactionOp_TezosParametersManager clone() => TezosSignTx_TezosTransactionOp_TezosParametersManager()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosTransactionOp_TezosParametersManager copyWith(void Function(TezosSignTx_TezosTransactionOp_TezosParametersManager) updates) => super.copyWith((message) => updates(message as TezosSignTx_TezosTransactionOp_TezosParametersManager)) as TezosSignTx_TezosTransactionOp_TezosParametersManager;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosTransactionOp_TezosParametersManager create() => TezosSignTx_TezosTransactionOp_TezosParametersManager._();
+  TezosSignTx_TezosTransactionOp_TezosParametersManager createEmptyInstance() => create();
+  static $pb.PbList<TezosSignTx_TezosTransactionOp_TezosParametersManager> createRepeated() => $pb.PbList<TezosSignTx_TezosTransactionOp_TezosParametersManager>();
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosTransactionOp_TezosParametersManager getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TezosSignTx_TezosTransactionOp_TezosParametersManager>(create);
+  static TezosSignTx_TezosTransactionOp_TezosParametersManager? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get setDelegate => $_getN(0);
+  @$pb.TagNumber(1)
+  set setDelegate($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSetDelegate() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSetDelegate() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.bool get cancelDelegate => $_getBF(1);
+  @$pb.TagNumber(2)
+  set cancelDelegate($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasCancelDelegate() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCancelDelegate() => clearField(2);
+
+  @$pb.TagNumber(3)
+  TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer get transfer => $_getN(2);
+  @$pb.TagNumber(3)
+  set transfer(TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasTransfer() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearTransfer() => clearField(3);
+  @$pb.TagNumber(3)
+  TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer ensureTransfer() => $_ensure(2);
+}
+
+/// *
+///  Structure representing information for transaction
+class TezosSignTx_TezosTransactionOp extends $pb.GeneratedMessage {
+  factory TezosSignTx_TezosTransactionOp({
+    $fixnum.Int64? fee,
+    $fixnum.Int64? counter,
+    $fixnum.Int64? gasLimit,
+    $fixnum.Int64? storageLimit,
+    $fixnum.Int64? amount,
+    TezosSignTx_TezosContractID? destination,
+    $core.List<$core.int>? parameters,
+    $core.List<$core.int>? source,
+    TezosSignTx_TezosTransactionOp_TezosParametersManager? parametersManager,
+  }) {
+    final $result = create();
+    if (fee != null) {
+      $result.fee = fee;
+    }
+    if (counter != null) {
+      $result.counter = counter;
+    }
+    if (gasLimit != null) {
+      $result.gasLimit = gasLimit;
+    }
+    if (storageLimit != null) {
+      $result.storageLimit = storageLimit;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (destination != null) {
+      $result.destination = destination;
+    }
+    if (parameters != null) {
+      $result.parameters = parameters;
+    }
+    if (source != null) {
+      $result.source = source;
+    }
+    if (parametersManager != null) {
+      $result.parametersManager = parametersManager;
+    }
+    return $result;
+  }
+  TezosSignTx_TezosTransactionOp._() : super();
+  factory TezosSignTx_TezosTransactionOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TezosSignTx_TezosTransactionOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TezosSignTx.TezosTransactionOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.tezos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'counter', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'gasLimit', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(5, _omitFieldNames ? '' : 'storageLimit', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(6, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aQM<TezosSignTx_TezosContractID>(7, _omitFieldNames ? '' : 'destination', subBuilder: TezosSignTx_TezosContractID.create)
+    ..a<$core.List<$core.int>>(8, _omitFieldNames ? '' : 'parameters', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(9, _omitFieldNames ? '' : 'source', $pb.PbFieldType.QY)
+    ..aOM<TezosSignTx_TezosTransactionOp_TezosParametersManager>(10, _omitFieldNames ? '' : 'parametersManager', subBuilder: TezosSignTx_TezosTransactionOp_TezosParametersManager.create)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosTransactionOp clone() => TezosSignTx_TezosTransactionOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosTransactionOp copyWith(void Function(TezosSignTx_TezosTransactionOp) updates) => super.copyWith((message) => updates(message as TezosSignTx_TezosTransactionOp)) as TezosSignTx_TezosTransactionOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosTransactionOp create() => TezosSignTx_TezosTransactionOp._();
+  TezosSignTx_TezosTransactionOp createEmptyInstance() => create();
+  static $pb.PbList<TezosSignTx_TezosTransactionOp> createRepeated() => $pb.PbList<TezosSignTx_TezosTransactionOp>();
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosTransactionOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TezosSignTx_TezosTransactionOp>(create);
+  static TezosSignTx_TezosTransactionOp? _defaultInstance;
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get fee => $_getI64(0);
+  @$pb.TagNumber(2)
+  set fee($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasFee() => $_has(0);
+  @$pb.TagNumber(2)
+  void clearFee() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get counter => $_getI64(1);
+  @$pb.TagNumber(3)
+  set counter($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasCounter() => $_has(1);
+  @$pb.TagNumber(3)
+  void clearCounter() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get gasLimit => $_getI64(2);
+  @$pb.TagNumber(4)
+  set gasLimit($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasGasLimit() => $_has(2);
+  @$pb.TagNumber(4)
+  void clearGasLimit() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $fixnum.Int64 get storageLimit => $_getI64(3);
+  @$pb.TagNumber(5)
+  set storageLimit($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasStorageLimit() => $_has(3);
+  @$pb.TagNumber(5)
+  void clearStorageLimit() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $fixnum.Int64 get amount => $_getI64(4);
+  @$pb.TagNumber(6)
+  set amount($fixnum.Int64 v) { $_setInt64(4, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasAmount() => $_has(4);
+  @$pb.TagNumber(6)
+  void clearAmount() => clearField(6);
+
+  @$pb.TagNumber(7)
+  TezosSignTx_TezosContractID get destination => $_getN(5);
+  @$pb.TagNumber(7)
+  set destination(TezosSignTx_TezosContractID v) { setField(7, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasDestination() => $_has(5);
+  @$pb.TagNumber(7)
+  void clearDestination() => clearField(7);
+  @$pb.TagNumber(7)
+  TezosSignTx_TezosContractID ensureDestination() => $_ensure(5);
+
+  @$pb.TagNumber(8)
+  $core.List<$core.int> get parameters => $_getN(6);
+  @$pb.TagNumber(8)
+  set parameters($core.List<$core.int> v) { $_setBytes(6, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasParameters() => $_has(6);
+  @$pb.TagNumber(8)
+  void clearParameters() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.List<$core.int> get source => $_getN(7);
+  @$pb.TagNumber(9)
+  set source($core.List<$core.int> v) { $_setBytes(7, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasSource() => $_has(7);
+  @$pb.TagNumber(9)
+  void clearSource() => clearField(9);
+
+  @$pb.TagNumber(10)
+  TezosSignTx_TezosTransactionOp_TezosParametersManager get parametersManager => $_getN(8);
+  @$pb.TagNumber(10)
+  set parametersManager(TezosSignTx_TezosTransactionOp_TezosParametersManager v) { setField(10, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasParametersManager() => $_has(8);
+  @$pb.TagNumber(10)
+  void clearParametersManager() => clearField(10);
+  @$pb.TagNumber(10)
+  TezosSignTx_TezosTransactionOp_TezosParametersManager ensureParametersManager() => $_ensure(8);
+}
+
+/// *
+///  Structure representing information for origination
+class TezosSignTx_TezosOriginationOp extends $pb.GeneratedMessage {
+  factory TezosSignTx_TezosOriginationOp({
+    $fixnum.Int64? fee,
+    $fixnum.Int64? counter,
+    $fixnum.Int64? gasLimit,
+    $fixnum.Int64? storageLimit,
+    $core.List<$core.int>? managerPubkey,
+    $fixnum.Int64? balance,
+    $core.bool? spendable,
+    $core.bool? delegatable,
+    $core.List<$core.int>? delegate,
+    $core.List<$core.int>? script,
+    $core.List<$core.int>? source,
+  }) {
+    final $result = create();
+    if (fee != null) {
+      $result.fee = fee;
+    }
+    if (counter != null) {
+      $result.counter = counter;
+    }
+    if (gasLimit != null) {
+      $result.gasLimit = gasLimit;
+    }
+    if (storageLimit != null) {
+      $result.storageLimit = storageLimit;
+    }
+    if (managerPubkey != null) {
+      $result.managerPubkey = managerPubkey;
+    }
+    if (balance != null) {
+      $result.balance = balance;
+    }
+    if (spendable != null) {
+      $result.spendable = spendable;
+    }
+    if (delegatable != null) {
+      $result.delegatable = delegatable;
+    }
+    if (delegate != null) {
+      $result.delegate = delegate;
+    }
+    if (script != null) {
+      $result.script = script;
+    }
+    if (source != null) {
+      $result.source = source;
+    }
+    return $result;
+  }
+  TezosSignTx_TezosOriginationOp._() : super();
+  factory TezosSignTx_TezosOriginationOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TezosSignTx_TezosOriginationOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TezosSignTx.TezosOriginationOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.tezos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'counter', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'gasLimit', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(5, _omitFieldNames ? '' : 'storageLimit', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'managerPubkey', $pb.PbFieldType.OY)
+    ..a<$fixnum.Int64>(7, _omitFieldNames ? '' : 'balance', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aOB(8, _omitFieldNames ? '' : 'spendable')
+    ..aOB(9, _omitFieldNames ? '' : 'delegatable')
+    ..a<$core.List<$core.int>>(10, _omitFieldNames ? '' : 'delegate', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(11, _omitFieldNames ? '' : 'script', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(12, _omitFieldNames ? '' : 'source', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosOriginationOp clone() => TezosSignTx_TezosOriginationOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosOriginationOp copyWith(void Function(TezosSignTx_TezosOriginationOp) updates) => super.copyWith((message) => updates(message as TezosSignTx_TezosOriginationOp)) as TezosSignTx_TezosOriginationOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosOriginationOp create() => TezosSignTx_TezosOriginationOp._();
+  TezosSignTx_TezosOriginationOp createEmptyInstance() => create();
+  static $pb.PbList<TezosSignTx_TezosOriginationOp> createRepeated() => $pb.PbList<TezosSignTx_TezosOriginationOp>();
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosOriginationOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TezosSignTx_TezosOriginationOp>(create);
+  static TezosSignTx_TezosOriginationOp? _defaultInstance;
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get fee => $_getI64(0);
+  @$pb.TagNumber(2)
+  set fee($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasFee() => $_has(0);
+  @$pb.TagNumber(2)
+  void clearFee() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get counter => $_getI64(1);
+  @$pb.TagNumber(3)
+  set counter($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasCounter() => $_has(1);
+  @$pb.TagNumber(3)
+  void clearCounter() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get gasLimit => $_getI64(2);
+  @$pb.TagNumber(4)
+  set gasLimit($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasGasLimit() => $_has(2);
+  @$pb.TagNumber(4)
+  void clearGasLimit() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $fixnum.Int64 get storageLimit => $_getI64(3);
+  @$pb.TagNumber(5)
+  set storageLimit($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasStorageLimit() => $_has(3);
+  @$pb.TagNumber(5)
+  void clearStorageLimit() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get managerPubkey => $_getN(4);
+  @$pb.TagNumber(6)
+  set managerPubkey($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasManagerPubkey() => $_has(4);
+  @$pb.TagNumber(6)
+  void clearManagerPubkey() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $fixnum.Int64 get balance => $_getI64(5);
+  @$pb.TagNumber(7)
+  set balance($fixnum.Int64 v) { $_setInt64(5, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasBalance() => $_has(5);
+  @$pb.TagNumber(7)
+  void clearBalance() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.bool get spendable => $_getBF(6);
+  @$pb.TagNumber(8)
+  set spendable($core.bool v) { $_setBool(6, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasSpendable() => $_has(6);
+  @$pb.TagNumber(8)
+  void clearSpendable() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.bool get delegatable => $_getBF(7);
+  @$pb.TagNumber(9)
+  set delegatable($core.bool v) { $_setBool(7, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasDelegatable() => $_has(7);
+  @$pb.TagNumber(9)
+  void clearDelegatable() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.List<$core.int> get delegate => $_getN(8);
+  @$pb.TagNumber(10)
+  set delegate($core.List<$core.int> v) { $_setBytes(8, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasDelegate() => $_has(8);
+  @$pb.TagNumber(10)
+  void clearDelegate() => clearField(10);
+
+  @$pb.TagNumber(11)
+  $core.List<$core.int> get script => $_getN(9);
+  @$pb.TagNumber(11)
+  set script($core.List<$core.int> v) { $_setBytes(9, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasScript() => $_has(9);
+  @$pb.TagNumber(11)
+  void clearScript() => clearField(11);
+
+  @$pb.TagNumber(12)
+  $core.List<$core.int> get source => $_getN(10);
+  @$pb.TagNumber(12)
+  set source($core.List<$core.int> v) { $_setBytes(10, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasSource() => $_has(10);
+  @$pb.TagNumber(12)
+  void clearSource() => clearField(12);
+}
+
+/// *
+///  Structure representing information for delegation
+class TezosSignTx_TezosDelegationOp extends $pb.GeneratedMessage {
+  factory TezosSignTx_TezosDelegationOp({
+    $fixnum.Int64? fee,
+    $fixnum.Int64? counter,
+    $fixnum.Int64? gasLimit,
+    $fixnum.Int64? storageLimit,
+    $core.List<$core.int>? delegate,
+    $core.List<$core.int>? source,
+  }) {
+    final $result = create();
+    if (fee != null) {
+      $result.fee = fee;
+    }
+    if (counter != null) {
+      $result.counter = counter;
+    }
+    if (gasLimit != null) {
+      $result.gasLimit = gasLimit;
+    }
+    if (storageLimit != null) {
+      $result.storageLimit = storageLimit;
+    }
+    if (delegate != null) {
+      $result.delegate = delegate;
+    }
+    if (source != null) {
+      $result.source = source;
+    }
+    return $result;
+  }
+  TezosSignTx_TezosDelegationOp._() : super();
+  factory TezosSignTx_TezosDelegationOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TezosSignTx_TezosDelegationOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TezosSignTx.TezosDelegationOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.tezos'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'counter', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'gasLimit', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(5, _omitFieldNames ? '' : 'storageLimit', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.List<$core.int>>(6, _omitFieldNames ? '' : 'delegate', $pb.PbFieldType.QY)
+    ..a<$core.List<$core.int>>(7, _omitFieldNames ? '' : 'source', $pb.PbFieldType.QY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosDelegationOp clone() => TezosSignTx_TezosDelegationOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosDelegationOp copyWith(void Function(TezosSignTx_TezosDelegationOp) updates) => super.copyWith((message) => updates(message as TezosSignTx_TezosDelegationOp)) as TezosSignTx_TezosDelegationOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosDelegationOp create() => TezosSignTx_TezosDelegationOp._();
+  TezosSignTx_TezosDelegationOp createEmptyInstance() => create();
+  static $pb.PbList<TezosSignTx_TezosDelegationOp> createRepeated() => $pb.PbList<TezosSignTx_TezosDelegationOp>();
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosDelegationOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TezosSignTx_TezosDelegationOp>(create);
+  static TezosSignTx_TezosDelegationOp? _defaultInstance;
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get fee => $_getI64(0);
+  @$pb.TagNumber(2)
+  set fee($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasFee() => $_has(0);
+  @$pb.TagNumber(2)
+  void clearFee() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get counter => $_getI64(1);
+  @$pb.TagNumber(3)
+  set counter($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasCounter() => $_has(1);
+  @$pb.TagNumber(3)
+  void clearCounter() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get gasLimit => $_getI64(2);
+  @$pb.TagNumber(4)
+  set gasLimit($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasGasLimit() => $_has(2);
+  @$pb.TagNumber(4)
+  void clearGasLimit() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $fixnum.Int64 get storageLimit => $_getI64(3);
+  @$pb.TagNumber(5)
+  set storageLimit($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasStorageLimit() => $_has(3);
+  @$pb.TagNumber(5)
+  void clearStorageLimit() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<$core.int> get delegate => $_getN(4);
+  @$pb.TagNumber(6)
+  set delegate($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasDelegate() => $_has(4);
+  @$pb.TagNumber(6)
+  void clearDelegate() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.List<$core.int> get source => $_getN(5);
+  @$pb.TagNumber(7)
+  set source($core.List<$core.int> v) { $_setBytes(5, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasSource() => $_has(5);
+  @$pb.TagNumber(7)
+  void clearSource() => clearField(7);
+}
+
+/// *
+///  Structure representing information for proposal
+class TezosSignTx_TezosProposalOp extends $pb.GeneratedMessage {
+  factory TezosSignTx_TezosProposalOp({
+    $core.List<$core.int>? source,
+    $fixnum.Int64? period,
+    $core.Iterable<$core.List<$core.int>>? proposals,
+  }) {
+    final $result = create();
+    if (source != null) {
+      $result.source = source;
+    }
+    if (period != null) {
+      $result.period = period;
+    }
+    if (proposals != null) {
+      $result.proposals.addAll(proposals);
+    }
+    return $result;
+  }
+  TezosSignTx_TezosProposalOp._() : super();
+  factory TezosSignTx_TezosProposalOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TezosSignTx_TezosProposalOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TezosSignTx.TezosProposalOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.tezos'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'source', $pb.PbFieldType.QY)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'period', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..p<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'proposals', $pb.PbFieldType.PY)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosProposalOp clone() => TezosSignTx_TezosProposalOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosProposalOp copyWith(void Function(TezosSignTx_TezosProposalOp) updates) => super.copyWith((message) => updates(message as TezosSignTx_TezosProposalOp)) as TezosSignTx_TezosProposalOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosProposalOp create() => TezosSignTx_TezosProposalOp._();
+  TezosSignTx_TezosProposalOp createEmptyInstance() => create();
+  static $pb.PbList<TezosSignTx_TezosProposalOp> createRepeated() => $pb.PbList<TezosSignTx_TezosProposalOp>();
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosProposalOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TezosSignTx_TezosProposalOp>(create);
+  static TezosSignTx_TezosProposalOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get source => $_getN(0);
+  @$pb.TagNumber(1)
+  set source($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSource() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSource() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get period => $_getI64(1);
+  @$pb.TagNumber(2)
+  set period($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPeriod() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPeriod() => clearField(2);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.List<$core.int>> get proposals => $_getList(2);
+}
+
+/// *
+///  Structure representing information for ballot
+class TezosSignTx_TezosBallotOp extends $pb.GeneratedMessage {
+  factory TezosSignTx_TezosBallotOp({
+    $core.List<$core.int>? source,
+    $fixnum.Int64? period,
+    $core.List<$core.int>? proposal,
+    TezosSignTx_TezosBallotOp_TezosBallotType? ballot,
+  }) {
+    final $result = create();
+    if (source != null) {
+      $result.source = source;
+    }
+    if (period != null) {
+      $result.period = period;
+    }
+    if (proposal != null) {
+      $result.proposal = proposal;
+    }
+    if (ballot != null) {
+      $result.ballot = ballot;
+    }
+    return $result;
+  }
+  TezosSignTx_TezosBallotOp._() : super();
+  factory TezosSignTx_TezosBallotOp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TezosSignTx_TezosBallotOp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TezosSignTx.TezosBallotOp', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.tezos'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'source', $pb.PbFieldType.QY)
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'period', $pb.PbFieldType.QU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'proposal', $pb.PbFieldType.QY)
+    ..e<TezosSignTx_TezosBallotOp_TezosBallotType>(4, _omitFieldNames ? '' : 'ballot', $pb.PbFieldType.QE, defaultOrMaker: TezosSignTx_TezosBallotOp_TezosBallotType.Yay, valueOf: TezosSignTx_TezosBallotOp_TezosBallotType.valueOf, enumValues: TezosSignTx_TezosBallotOp_TezosBallotType.values)
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosBallotOp clone() => TezosSignTx_TezosBallotOp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TezosSignTx_TezosBallotOp copyWith(void Function(TezosSignTx_TezosBallotOp) updates) => super.copyWith((message) => updates(message as TezosSignTx_TezosBallotOp)) as TezosSignTx_TezosBallotOp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosBallotOp create() => TezosSignTx_TezosBallotOp._();
+  TezosSignTx_TezosBallotOp createEmptyInstance() => create();
+  static $pb.PbList<TezosSignTx_TezosBallotOp> createRepeated() => $pb.PbList<TezosSignTx_TezosBallotOp>();
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx_TezosBallotOp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TezosSignTx_TezosBallotOp>(create);
+  static TezosSignTx_TezosBallotOp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get source => $_getN(0);
+  @$pb.TagNumber(1)
+  set source($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSource() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSource() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get period => $_getI64(1);
+  @$pb.TagNumber(2)
+  set period($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPeriod() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPeriod() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get proposal => $_getN(2);
+  @$pb.TagNumber(3)
+  set proposal($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasProposal() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearProposal() => clearField(3);
+
+  @$pb.TagNumber(4)
+  TezosSignTx_TezosBallotOp_TezosBallotType get ballot => $_getN(3);
+  @$pb.TagNumber(4)
+  set ballot(TezosSignTx_TezosBallotOp_TezosBallotType v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasBallot() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearBallot() => clearField(4);
+}
+
+/// *
+///  Request: Ask device to sign Tezos transaction
+///  @start
+///  @next TezosSignedTx
+class TezosSignTx extends $pb.GeneratedMessage {
+  factory TezosSignTx({
+    $core.Iterable<$core.int>? addressN,
+    $core.List<$core.int>? branch,
+    TezosSignTx_TezosRevealOp? reveal,
+    TezosSignTx_TezosTransactionOp? transaction,
+    TezosSignTx_TezosOriginationOp? origination,
+    TezosSignTx_TezosDelegationOp? delegation,
+    TezosSignTx_TezosProposalOp? proposal,
+    TezosSignTx_TezosBallotOp? ballot,
+    $core.bool? chunkify,
+  }) {
+    final $result = create();
+    if (addressN != null) {
+      $result.addressN.addAll(addressN);
+    }
+    if (branch != null) {
+      $result.branch = branch;
+    }
+    if (reveal != null) {
+      $result.reveal = reveal;
+    }
+    if (transaction != null) {
+      $result.transaction = transaction;
+    }
+    if (origination != null) {
+      $result.origination = origination;
+    }
+    if (delegation != null) {
+      $result.delegation = delegation;
+    }
+    if (proposal != null) {
+      $result.proposal = proposal;
+    }
+    if (ballot != null) {
+      $result.ballot = ballot;
+    }
+    if (chunkify != null) {
+      $result.chunkify = chunkify;
+    }
+    return $result;
+  }
+  TezosSignTx._() : super();
+  factory TezosSignTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TezosSignTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TezosSignTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.tezos'), createEmptyInstance: create)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'addressN', $pb.PbFieldType.PU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'branch', $pb.PbFieldType.QY)
+    ..aOM<TezosSignTx_TezosRevealOp>(3, _omitFieldNames ? '' : 'reveal', subBuilder: TezosSignTx_TezosRevealOp.create)
+    ..aOM<TezosSignTx_TezosTransactionOp>(4, _omitFieldNames ? '' : 'transaction', subBuilder: TezosSignTx_TezosTransactionOp.create)
+    ..aOM<TezosSignTx_TezosOriginationOp>(5, _omitFieldNames ? '' : 'origination', subBuilder: TezosSignTx_TezosOriginationOp.create)
+    ..aOM<TezosSignTx_TezosDelegationOp>(6, _omitFieldNames ? '' : 'delegation', subBuilder: TezosSignTx_TezosDelegationOp.create)
+    ..aOM<TezosSignTx_TezosProposalOp>(7, _omitFieldNames ? '' : 'proposal', subBuilder: TezosSignTx_TezosProposalOp.create)
+    ..aOM<TezosSignTx_TezosBallotOp>(8, _omitFieldNames ? '' : 'ballot', subBuilder: TezosSignTx_TezosBallotOp.create)
+    ..aOB(9, _omitFieldNames ? '' : 'chunkify')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TezosSignTx clone() => TezosSignTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TezosSignTx copyWith(void Function(TezosSignTx) updates) => super.copyWith((message) => updates(message as TezosSignTx)) as TezosSignTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx create() => TezosSignTx._();
+  TezosSignTx createEmptyInstance() => create();
+  static $pb.PbList<TezosSignTx> createRepeated() => $pb.PbList<TezosSignTx>();
+  @$core.pragma('dart2js:noInline')
+  static TezosSignTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TezosSignTx>(create);
+  static TezosSignTx? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get addressN => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get branch => $_getN(1);
+  @$pb.TagNumber(2)
+  set branch($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasBranch() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearBranch() => clearField(2);
+
+  @$pb.TagNumber(3)
+  TezosSignTx_TezosRevealOp get reveal => $_getN(2);
+  @$pb.TagNumber(3)
+  set reveal(TezosSignTx_TezosRevealOp v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasReveal() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearReveal() => clearField(3);
+  @$pb.TagNumber(3)
+  TezosSignTx_TezosRevealOp ensureReveal() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  TezosSignTx_TezosTransactionOp get transaction => $_getN(3);
+  @$pb.TagNumber(4)
+  set transaction(TezosSignTx_TezosTransactionOp v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasTransaction() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearTransaction() => clearField(4);
+  @$pb.TagNumber(4)
+  TezosSignTx_TezosTransactionOp ensureTransaction() => $_ensure(3);
+
+  @$pb.TagNumber(5)
+  TezosSignTx_TezosOriginationOp get origination => $_getN(4);
+  @$pb.TagNumber(5)
+  set origination(TezosSignTx_TezosOriginationOp v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasOrigination() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearOrigination() => clearField(5);
+  @$pb.TagNumber(5)
+  TezosSignTx_TezosOriginationOp ensureOrigination() => $_ensure(4);
+
+  @$pb.TagNumber(6)
+  TezosSignTx_TezosDelegationOp get delegation => $_getN(5);
+  @$pb.TagNumber(6)
+  set delegation(TezosSignTx_TezosDelegationOp v) { setField(6, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasDelegation() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearDelegation() => clearField(6);
+  @$pb.TagNumber(6)
+  TezosSignTx_TezosDelegationOp ensureDelegation() => $_ensure(5);
+
+  @$pb.TagNumber(7)
+  TezosSignTx_TezosProposalOp get proposal => $_getN(6);
+  @$pb.TagNumber(7)
+  set proposal(TezosSignTx_TezosProposalOp v) { setField(7, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasProposal() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearProposal() => clearField(7);
+  @$pb.TagNumber(7)
+  TezosSignTx_TezosProposalOp ensureProposal() => $_ensure(6);
+
+  @$pb.TagNumber(8)
+  TezosSignTx_TezosBallotOp get ballot => $_getN(7);
+  @$pb.TagNumber(8)
+  set ballot(TezosSignTx_TezosBallotOp v) { setField(8, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasBallot() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearBallot() => clearField(8);
+  @$pb.TagNumber(8)
+  TezosSignTx_TezosBallotOp ensureBallot() => $_ensure(7);
+
+  @$pb.TagNumber(9)
+  $core.bool get chunkify => $_getBF(8);
+  @$pb.TagNumber(9)
+  set chunkify($core.bool v) { $_setBool(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasChunkify() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearChunkify() => clearField(9);
+}
+
+/// *
+///  Response: Contains Tezos transaction signature
+///  @end
+class TezosSignedTx extends $pb.GeneratedMessage {
+  factory TezosSignedTx({
+    $core.String? signature,
+    $core.List<$core.int>? sigOpContents,
+    $core.String? operationHash,
+  }) {
+    final $result = create();
+    if (signature != null) {
+      $result.signature = signature;
+    }
+    if (sigOpContents != null) {
+      $result.sigOpContents = sigOpContents;
+    }
+    if (operationHash != null) {
+      $result.operationHash = operationHash;
+    }
+    return $result;
+  }
+  TezosSignedTx._() : super();
+  factory TezosSignedTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TezosSignedTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TezosSignedTx', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.tezos'), createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'signature')
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'sigOpContents', $pb.PbFieldType.QY)
+    ..aQS(3, _omitFieldNames ? '' : 'operationHash')
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TezosSignedTx clone() => TezosSignedTx()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TezosSignedTx copyWith(void Function(TezosSignedTx) updates) => super.copyWith((message) => updates(message as TezosSignedTx)) as TezosSignedTx;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TezosSignedTx create() => TezosSignedTx._();
+  TezosSignedTx createEmptyInstance() => create();
+  static $pb.PbList<TezosSignedTx> createRepeated() => $pb.PbList<TezosSignedTx>();
+  @$core.pragma('dart2js:noInline')
+  static TezosSignedTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TezosSignedTx>(create);
+  static TezosSignedTx? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get signature => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set signature($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSignature() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSignature() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get sigOpContents => $_getN(1);
+  @$pb.TagNumber(2)
+  set sigOpContents($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSigOpContents() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSigOpContents() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get operationHash => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set operationHash($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasOperationHash() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearOperationHash() => clearField(3);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-tezos.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-tezos.pbenum.dart
@@ -1,0 +1,51 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-tezos.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+///
+///  Type of Tezos Contract type
+class TezosSignTx_TezosContractID_TezosContractType extends $pb.ProtobufEnum {
+  static const TezosSignTx_TezosContractID_TezosContractType Implicit = TezosSignTx_TezosContractID_TezosContractType._(0, _omitEnumNames ? '' : 'Implicit');
+  static const TezosSignTx_TezosContractID_TezosContractType Originated = TezosSignTx_TezosContractID_TezosContractType._(1, _omitEnumNames ? '' : 'Originated');
+
+  static const $core.List<TezosSignTx_TezosContractID_TezosContractType> values = <TezosSignTx_TezosContractID_TezosContractType> [
+    Implicit,
+    Originated,
+  ];
+
+  static final $core.Map<$core.int, TezosSignTx_TezosContractID_TezosContractType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static TezosSignTx_TezosContractID_TezosContractType? valueOf($core.int value) => _byValue[value];
+
+  const TezosSignTx_TezosContractID_TezosContractType._($core.int v, $core.String n) : super(v, n);
+}
+
+class TezosSignTx_TezosBallotOp_TezosBallotType extends $pb.ProtobufEnum {
+  static const TezosSignTx_TezosBallotOp_TezosBallotType Yay = TezosSignTx_TezosBallotOp_TezosBallotType._(0, _omitEnumNames ? '' : 'Yay');
+  static const TezosSignTx_TezosBallotOp_TezosBallotType Nay = TezosSignTx_TezosBallotOp_TezosBallotType._(1, _omitEnumNames ? '' : 'Nay');
+  static const TezosSignTx_TezosBallotOp_TezosBallotType Pass = TezosSignTx_TezosBallotOp_TezosBallotType._(2, _omitEnumNames ? '' : 'Pass');
+
+  static const $core.List<TezosSignTx_TezosBallotOp_TezosBallotType> values = <TezosSignTx_TezosBallotOp_TezosBallotType> [
+    Yay,
+    Nay,
+    Pass,
+  ];
+
+  static final $core.Map<$core.int, TezosSignTx_TezosBallotOp_TezosBallotType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static TezosSignTx_TezosBallotOp_TezosBallotType? valueOf($core.int value) => _byValue[value];
+
+  const TezosSignTx_TezosBallotOp_TezosBallotType._($core.int v, $core.String n) : super(v, n);
+}
+
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-tezos.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-tezos.pbjson.dart
@@ -1,0 +1,285 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-tezos.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use tezosGetAddressDescriptor instead')
+const TezosGetAddress$json = {
+  '1': 'TezosGetAddress',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'show_display', '3': 2, '4': 1, '5': 8, '10': 'showDisplay'},
+    {'1': 'chunkify', '3': 3, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `TezosGetAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List tezosGetAddressDescriptor = $convert.base64Decode(
+    'Cg9UZXpvc0dldEFkZHJlc3MSGwoJYWRkcmVzc19uGAEgAygNUghhZGRyZXNzThIhCgxzaG93X2'
+    'Rpc3BsYXkYAiABKAhSC3Nob3dEaXNwbGF5EhoKCGNodW5raWZ5GAMgASgIUghjaHVua2lmeQ==');
+
+@$core.Deprecated('Use tezosAddressDescriptor instead')
+const TezosAddress$json = {
+  '1': 'TezosAddress',
+  '2': [
+    {'1': 'address', '3': 1, '4': 2, '5': 9, '10': 'address'},
+  ],
+};
+
+/// Descriptor for `TezosAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List tezosAddressDescriptor = $convert.base64Decode(
+    'CgxUZXpvc0FkZHJlc3MSGAoHYWRkcmVzcxgBIAIoCVIHYWRkcmVzcw==');
+
+@$core.Deprecated('Use tezosGetPublicKeyDescriptor instead')
+const TezosGetPublicKey$json = {
+  '1': 'TezosGetPublicKey',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'show_display', '3': 2, '4': 1, '5': 8, '10': 'showDisplay'},
+    {'1': 'chunkify', '3': 3, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+};
+
+/// Descriptor for `TezosGetPublicKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List tezosGetPublicKeyDescriptor = $convert.base64Decode(
+    'ChFUZXpvc0dldFB1YmxpY0tleRIbCglhZGRyZXNzX24YASADKA1SCGFkZHJlc3NOEiEKDHNob3'
+    'dfZGlzcGxheRgCIAEoCFILc2hvd0Rpc3BsYXkSGgoIY2h1bmtpZnkYAyABKAhSCGNodW5raWZ5');
+
+@$core.Deprecated('Use tezosPublicKeyDescriptor instead')
+const TezosPublicKey$json = {
+  '1': 'TezosPublicKey',
+  '2': [
+    {'1': 'public_key', '3': 1, '4': 2, '5': 9, '10': 'publicKey'},
+  ],
+};
+
+/// Descriptor for `TezosPublicKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List tezosPublicKeyDescriptor = $convert.base64Decode(
+    'Cg5UZXpvc1B1YmxpY0tleRIdCgpwdWJsaWNfa2V5GAEgAigJUglwdWJsaWNLZXk=');
+
+@$core.Deprecated('Use tezosSignTxDescriptor instead')
+const TezosSignTx$json = {
+  '1': 'TezosSignTx',
+  '2': [
+    {'1': 'address_n', '3': 1, '4': 3, '5': 13, '10': 'addressN'},
+    {'1': 'branch', '3': 2, '4': 2, '5': 12, '10': 'branch'},
+    {'1': 'reveal', '3': 3, '4': 1, '5': 11, '6': '.hw.trezor.messages.tezos.TezosSignTx.TezosRevealOp', '10': 'reveal'},
+    {'1': 'transaction', '3': 4, '4': 1, '5': 11, '6': '.hw.trezor.messages.tezos.TezosSignTx.TezosTransactionOp', '10': 'transaction'},
+    {'1': 'origination', '3': 5, '4': 1, '5': 11, '6': '.hw.trezor.messages.tezos.TezosSignTx.TezosOriginationOp', '10': 'origination'},
+    {'1': 'delegation', '3': 6, '4': 1, '5': 11, '6': '.hw.trezor.messages.tezos.TezosSignTx.TezosDelegationOp', '10': 'delegation'},
+    {'1': 'proposal', '3': 7, '4': 1, '5': 11, '6': '.hw.trezor.messages.tezos.TezosSignTx.TezosProposalOp', '10': 'proposal'},
+    {'1': 'ballot', '3': 8, '4': 1, '5': 11, '6': '.hw.trezor.messages.tezos.TezosSignTx.TezosBallotOp', '10': 'ballot'},
+    {'1': 'chunkify', '3': 9, '4': 1, '5': 8, '10': 'chunkify'},
+  ],
+  '3': [TezosSignTx_TezosContractID$json, TezosSignTx_TezosRevealOp$json, TezosSignTx_TezosTransactionOp$json, TezosSignTx_TezosOriginationOp$json, TezosSignTx_TezosDelegationOp$json, TezosSignTx_TezosProposalOp$json, TezosSignTx_TezosBallotOp$json],
+};
+
+@$core.Deprecated('Use tezosSignTxDescriptor instead')
+const TezosSignTx_TezosContractID$json = {
+  '1': 'TezosContractID',
+  '2': [
+    {'1': 'tag', '3': 1, '4': 2, '5': 14, '6': '.hw.trezor.messages.tezos.TezosSignTx.TezosContractID.TezosContractType', '10': 'tag'},
+    {'1': 'hash', '3': 2, '4': 2, '5': 12, '10': 'hash'},
+  ],
+  '4': [TezosSignTx_TezosContractID_TezosContractType$json],
+};
+
+@$core.Deprecated('Use tezosSignTxDescriptor instead')
+const TezosSignTx_TezosContractID_TezosContractType$json = {
+  '1': 'TezosContractType',
+  '2': [
+    {'1': 'Implicit', '2': 0},
+    {'1': 'Originated', '2': 1},
+  ],
+};
+
+@$core.Deprecated('Use tezosSignTxDescriptor instead')
+const TezosSignTx_TezosRevealOp$json = {
+  '1': 'TezosRevealOp',
+  '2': [
+    {'1': 'source', '3': 7, '4': 2, '5': 12, '10': 'source'},
+    {'1': 'fee', '3': 2, '4': 2, '5': 4, '10': 'fee'},
+    {'1': 'counter', '3': 3, '4': 2, '5': 4, '10': 'counter'},
+    {'1': 'gas_limit', '3': 4, '4': 2, '5': 4, '10': 'gasLimit'},
+    {'1': 'storage_limit', '3': 5, '4': 2, '5': 4, '10': 'storageLimit'},
+    {'1': 'public_key', '3': 6, '4': 2, '5': 12, '10': 'publicKey'},
+  ],
+};
+
+@$core.Deprecated('Use tezosSignTxDescriptor instead')
+const TezosSignTx_TezosTransactionOp$json = {
+  '1': 'TezosTransactionOp',
+  '2': [
+    {'1': 'source', '3': 9, '4': 2, '5': 12, '10': 'source'},
+    {'1': 'fee', '3': 2, '4': 2, '5': 4, '10': 'fee'},
+    {'1': 'counter', '3': 3, '4': 2, '5': 4, '10': 'counter'},
+    {'1': 'gas_limit', '3': 4, '4': 2, '5': 4, '10': 'gasLimit'},
+    {'1': 'storage_limit', '3': 5, '4': 2, '5': 4, '10': 'storageLimit'},
+    {'1': 'amount', '3': 6, '4': 2, '5': 4, '10': 'amount'},
+    {'1': 'destination', '3': 7, '4': 2, '5': 11, '6': '.hw.trezor.messages.tezos.TezosSignTx.TezosContractID', '10': 'destination'},
+    {'1': 'parameters', '3': 8, '4': 1, '5': 12, '10': 'parameters'},
+    {'1': 'parameters_manager', '3': 10, '4': 1, '5': 11, '6': '.hw.trezor.messages.tezos.TezosSignTx.TezosTransactionOp.TezosParametersManager', '10': 'parametersManager'},
+  ],
+  '3': [TezosSignTx_TezosTransactionOp_TezosParametersManager$json],
+};
+
+@$core.Deprecated('Use tezosSignTxDescriptor instead')
+const TezosSignTx_TezosTransactionOp_TezosParametersManager$json = {
+  '1': 'TezosParametersManager',
+  '2': [
+    {'1': 'set_delegate', '3': 1, '4': 1, '5': 12, '10': 'setDelegate'},
+    {'1': 'cancel_delegate', '3': 2, '4': 1, '5': 8, '10': 'cancelDelegate'},
+    {'1': 'transfer', '3': 3, '4': 1, '5': 11, '6': '.hw.trezor.messages.tezos.TezosSignTx.TezosTransactionOp.TezosParametersManager.TezosManagerTransfer', '10': 'transfer'},
+  ],
+  '3': [TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer$json],
+};
+
+@$core.Deprecated('Use tezosSignTxDescriptor instead')
+const TezosSignTx_TezosTransactionOp_TezosParametersManager_TezosManagerTransfer$json = {
+  '1': 'TezosManagerTransfer',
+  '2': [
+    {'1': 'destination', '3': 1, '4': 2, '5': 11, '6': '.hw.trezor.messages.tezos.TezosSignTx.TezosContractID', '10': 'destination'},
+    {'1': 'amount', '3': 2, '4': 2, '5': 4, '10': 'amount'},
+  ],
+};
+
+@$core.Deprecated('Use tezosSignTxDescriptor instead')
+const TezosSignTx_TezosOriginationOp$json = {
+  '1': 'TezosOriginationOp',
+  '2': [
+    {'1': 'source', '3': 12, '4': 2, '5': 12, '10': 'source'},
+    {'1': 'fee', '3': 2, '4': 2, '5': 4, '10': 'fee'},
+    {'1': 'counter', '3': 3, '4': 2, '5': 4, '10': 'counter'},
+    {'1': 'gas_limit', '3': 4, '4': 2, '5': 4, '10': 'gasLimit'},
+    {'1': 'storage_limit', '3': 5, '4': 2, '5': 4, '10': 'storageLimit'},
+    {'1': 'manager_pubkey', '3': 6, '4': 1, '5': 12, '10': 'managerPubkey'},
+    {'1': 'balance', '3': 7, '4': 2, '5': 4, '10': 'balance'},
+    {'1': 'spendable', '3': 8, '4': 1, '5': 8, '10': 'spendable'},
+    {'1': 'delegatable', '3': 9, '4': 1, '5': 8, '10': 'delegatable'},
+    {'1': 'delegate', '3': 10, '4': 1, '5': 12, '10': 'delegate'},
+    {'1': 'script', '3': 11, '4': 2, '5': 12, '10': 'script'},
+  ],
+};
+
+@$core.Deprecated('Use tezosSignTxDescriptor instead')
+const TezosSignTx_TezosDelegationOp$json = {
+  '1': 'TezosDelegationOp',
+  '2': [
+    {'1': 'source', '3': 7, '4': 2, '5': 12, '10': 'source'},
+    {'1': 'fee', '3': 2, '4': 2, '5': 4, '10': 'fee'},
+    {'1': 'counter', '3': 3, '4': 2, '5': 4, '10': 'counter'},
+    {'1': 'gas_limit', '3': 4, '4': 2, '5': 4, '10': 'gasLimit'},
+    {'1': 'storage_limit', '3': 5, '4': 2, '5': 4, '10': 'storageLimit'},
+    {'1': 'delegate', '3': 6, '4': 2, '5': 12, '10': 'delegate'},
+  ],
+};
+
+@$core.Deprecated('Use tezosSignTxDescriptor instead')
+const TezosSignTx_TezosProposalOp$json = {
+  '1': 'TezosProposalOp',
+  '2': [
+    {'1': 'source', '3': 1, '4': 2, '5': 12, '10': 'source'},
+    {'1': 'period', '3': 2, '4': 2, '5': 4, '10': 'period'},
+    {'1': 'proposals', '3': 4, '4': 3, '5': 12, '10': 'proposals'},
+  ],
+};
+
+@$core.Deprecated('Use tezosSignTxDescriptor instead')
+const TezosSignTx_TezosBallotOp$json = {
+  '1': 'TezosBallotOp',
+  '2': [
+    {'1': 'source', '3': 1, '4': 2, '5': 12, '10': 'source'},
+    {'1': 'period', '3': 2, '4': 2, '5': 4, '10': 'period'},
+    {'1': 'proposal', '3': 3, '4': 2, '5': 12, '10': 'proposal'},
+    {'1': 'ballot', '3': 4, '4': 2, '5': 14, '6': '.hw.trezor.messages.tezos.TezosSignTx.TezosBallotOp.TezosBallotType', '10': 'ballot'},
+  ],
+  '4': [TezosSignTx_TezosBallotOp_TezosBallotType$json],
+};
+
+@$core.Deprecated('Use tezosSignTxDescriptor instead')
+const TezosSignTx_TezosBallotOp_TezosBallotType$json = {
+  '1': 'TezosBallotType',
+  '2': [
+    {'1': 'Yay', '2': 0},
+    {'1': 'Nay', '2': 1},
+    {'1': 'Pass', '2': 2},
+  ],
+};
+
+/// Descriptor for `TezosSignTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List tezosSignTxDescriptor = $convert.base64Decode(
+    'CgtUZXpvc1NpZ25UeBIbCglhZGRyZXNzX24YASADKA1SCGFkZHJlc3NOEhYKBmJyYW5jaBgCIA'
+    'IoDFIGYnJhbmNoEksKBnJldmVhbBgDIAEoCzIzLmh3LnRyZXpvci5tZXNzYWdlcy50ZXpvcy5U'
+    'ZXpvc1NpZ25UeC5UZXpvc1JldmVhbE9wUgZyZXZlYWwSWgoLdHJhbnNhY3Rpb24YBCABKAsyOC'
+    '5ody50cmV6b3IubWVzc2FnZXMudGV6b3MuVGV6b3NTaWduVHguVGV6b3NUcmFuc2FjdGlvbk9w'
+    'Ugt0cmFuc2FjdGlvbhJaCgtvcmlnaW5hdGlvbhgFIAEoCzI4Lmh3LnRyZXpvci5tZXNzYWdlcy'
+    '50ZXpvcy5UZXpvc1NpZ25UeC5UZXpvc09yaWdpbmF0aW9uT3BSC29yaWdpbmF0aW9uElcKCmRl'
+    'bGVnYXRpb24YBiABKAsyNy5ody50cmV6b3IubWVzc2FnZXMudGV6b3MuVGV6b3NTaWduVHguVG'
+    'V6b3NEZWxlZ2F0aW9uT3BSCmRlbGVnYXRpb24SUQoIcHJvcG9zYWwYByABKAsyNS5ody50cmV6'
+    'b3IubWVzc2FnZXMudGV6b3MuVGV6b3NTaWduVHguVGV6b3NQcm9wb3NhbE9wUghwcm9wb3NhbB'
+    'JLCgZiYWxsb3QYCCABKAsyMy5ody50cmV6b3IubWVzc2FnZXMudGV6b3MuVGV6b3NTaWduVHgu'
+    'VGV6b3NCYWxsb3RPcFIGYmFsbG90EhoKCGNodW5raWZ5GAkgASgIUghjaHVua2lmeRqzAQoPVG'
+    'V6b3NDb250cmFjdElEElkKA3RhZxgBIAIoDjJHLmh3LnRyZXpvci5tZXNzYWdlcy50ZXpvcy5U'
+    'ZXpvc1NpZ25UeC5UZXpvc0NvbnRyYWN0SUQuVGV6b3NDb250cmFjdFR5cGVSA3RhZxISCgRoYX'
+    'NoGAIgAigMUgRoYXNoIjEKEVRlem9zQ29udHJhY3RUeXBlEgwKCEltcGxpY2l0EAASDgoKT3Jp'
+    'Z2luYXRlZBABGrQBCg1UZXpvc1JldmVhbE9wEhYKBnNvdXJjZRgHIAIoDFIGc291cmNlEhAKA2'
+    'ZlZRgCIAIoBFIDZmVlEhgKB2NvdW50ZXIYAyACKARSB2NvdW50ZXISGwoJZ2FzX2xpbWl0GAQg'
+    'AigEUghnYXNMaW1pdBIjCg1zdG9yYWdlX2xpbWl0GAUgAigEUgxzdG9yYWdlTGltaXQSHQoKcH'
+    'VibGljX2tleRgGIAIoDFIJcHVibGljS2V5Gp8GChJUZXpvc1RyYW5zYWN0aW9uT3ASFgoGc291'
+    'cmNlGAkgAigMUgZzb3VyY2USEAoDZmVlGAIgAigEUgNmZWUSGAoHY291bnRlchgDIAIoBFIHY2'
+    '91bnRlchIbCglnYXNfbGltaXQYBCACKARSCGdhc0xpbWl0EiMKDXN0b3JhZ2VfbGltaXQYBSAC'
+    'KARSDHN0b3JhZ2VMaW1pdBIWCgZhbW91bnQYBiACKARSBmFtb3VudBJXCgtkZXN0aW5hdGlvbh'
+    'gHIAIoCzI1Lmh3LnRyZXpvci5tZXNzYWdlcy50ZXpvcy5UZXpvc1NpZ25UeC5UZXpvc0NvbnRy'
+    'YWN0SURSC2Rlc3RpbmF0aW9uEh4KCnBhcmFtZXRlcnMYCCABKAxSCnBhcmFtZXRlcnMSfgoScG'
+    'FyYW1ldGVyc19tYW5hZ2VyGAogASgLMk8uaHcudHJlem9yLm1lc3NhZ2VzLnRlem9zLlRlem9z'
+    'U2lnblR4LlRlem9zVHJhbnNhY3Rpb25PcC5UZXpvc1BhcmFtZXRlcnNNYW5hZ2VyUhFwYXJhbW'
+    'V0ZXJzTWFuYWdlchrxAgoWVGV6b3NQYXJhbWV0ZXJzTWFuYWdlchIhCgxzZXRfZGVsZWdhdGUY'
+    'ASABKAxSC3NldERlbGVnYXRlEicKD2NhbmNlbF9kZWxlZ2F0ZRgCIAEoCFIOY2FuY2VsRGVsZW'
+    'dhdGUSgAEKCHRyYW5zZmVyGAMgASgLMmQuaHcudHJlem9yLm1lc3NhZ2VzLnRlem9zLlRlem9z'
+    'U2lnblR4LlRlem9zVHJhbnNhY3Rpb25PcC5UZXpvc1BhcmFtZXRlcnNNYW5hZ2VyLlRlem9zTW'
+    'FuYWdlclRyYW5zZmVyUgh0cmFuc2ZlchqHAQoUVGV6b3NNYW5hZ2VyVHJhbnNmZXISVwoLZGVz'
+    'dGluYXRpb24YASACKAsyNS5ody50cmV6b3IubWVzc2FnZXMudGV6b3MuVGV6b3NTaWduVHguVG'
+    'V6b3NDb250cmFjdElEUgtkZXN0aW5hdGlvbhIWCgZhbW91bnQYAiACKARSBmFtb3VudBrPAgoS'
+    'VGV6b3NPcmlnaW5hdGlvbk9wEhYKBnNvdXJjZRgMIAIoDFIGc291cmNlEhAKA2ZlZRgCIAIoBF'
+    'IDZmVlEhgKB2NvdW50ZXIYAyACKARSB2NvdW50ZXISGwoJZ2FzX2xpbWl0GAQgAigEUghnYXNM'
+    'aW1pdBIjCg1zdG9yYWdlX2xpbWl0GAUgAigEUgxzdG9yYWdlTGltaXQSJQoObWFuYWdlcl9wdW'
+    'JrZXkYBiABKAxSDW1hbmFnZXJQdWJrZXkSGAoHYmFsYW5jZRgHIAIoBFIHYmFsYW5jZRIcCglz'
+    'cGVuZGFibGUYCCABKAhSCXNwZW5kYWJsZRIgCgtkZWxlZ2F0YWJsZRgJIAEoCFILZGVsZWdhdG'
+    'FibGUSGgoIZGVsZWdhdGUYCiABKAxSCGRlbGVnYXRlEhYKBnNjcmlwdBgLIAIoDFIGc2NyaXB0'
+    'GrUBChFUZXpvc0RlbGVnYXRpb25PcBIWCgZzb3VyY2UYByACKAxSBnNvdXJjZRIQCgNmZWUYAi'
+    'ACKARSA2ZlZRIYCgdjb3VudGVyGAMgAigEUgdjb3VudGVyEhsKCWdhc19saW1pdBgEIAIoBFII'
+    'Z2FzTGltaXQSIwoNc3RvcmFnZV9saW1pdBgFIAIoBFIMc3RvcmFnZUxpbWl0EhoKCGRlbGVnYX'
+    'RlGAYgAigMUghkZWxlZ2F0ZRpfCg9UZXpvc1Byb3Bvc2FsT3ASFgoGc291cmNlGAEgAigMUgZz'
+    'b3VyY2USFgoGcGVyaW9kGAIgAigEUgZwZXJpb2QSHAoJcHJvcG9zYWxzGAQgAygMUglwcm9wb3'
+    'NhbHMa5wEKDVRlem9zQmFsbG90T3ASFgoGc291cmNlGAEgAigMUgZzb3VyY2USFgoGcGVyaW9k'
+    'GAIgAigEUgZwZXJpb2QSGgoIcHJvcG9zYWwYAyACKAxSCHByb3Bvc2FsElsKBmJhbGxvdBgEIA'
+    'IoDjJDLmh3LnRyZXpvci5tZXNzYWdlcy50ZXpvcy5UZXpvc1NpZ25UeC5UZXpvc0JhbGxvdE9w'
+    'LlRlem9zQmFsbG90VHlwZVIGYmFsbG90Ii0KD1Rlem9zQmFsbG90VHlwZRIHCgNZYXkQABIHCg'
+    'NOYXkQARIICgRQYXNzEAI=');
+
+@$core.Deprecated('Use tezosSignedTxDescriptor instead')
+const TezosSignedTx$json = {
+  '1': 'TezosSignedTx',
+  '2': [
+    {'1': 'signature', '3': 1, '4': 2, '5': 9, '10': 'signature'},
+    {'1': 'sig_op_contents', '3': 2, '4': 2, '5': 12, '10': 'sigOpContents'},
+    {'1': 'operation_hash', '3': 3, '4': 2, '5': 9, '10': 'operationHash'},
+  ],
+};
+
+/// Descriptor for `TezosSignedTx`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List tezosSignedTxDescriptor = $convert.base64Decode(
+    'Cg1UZXpvc1NpZ25lZFR4EhwKCXNpZ25hdHVyZRgBIAIoCVIJc2lnbmF0dXJlEiYKD3NpZ19vcF'
+    '9jb250ZW50cxgCIAIoDFINc2lnT3BDb250ZW50cxIlCg5vcGVyYXRpb25faGFzaBgDIAIoCVIN'
+    'b3BlcmF0aW9uSGFzaA==');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-tezos.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-tezos.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-tezos.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-tezos.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-webauthn.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-webauthn.pb.dart
@@ -1,0 +1,417 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-webauthn.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+/// *
+///  Request: List resident credentials
+///  @start
+///  @next WebAuthnCredentials
+///  @next Failure
+class WebAuthnListResidentCredentials extends $pb.GeneratedMessage {
+  factory WebAuthnListResidentCredentials() => create();
+  WebAuthnListResidentCredentials._() : super();
+  factory WebAuthnListResidentCredentials.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WebAuthnListResidentCredentials.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WebAuthnListResidentCredentials', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.webauthn'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  WebAuthnListResidentCredentials clone() => WebAuthnListResidentCredentials()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WebAuthnListResidentCredentials copyWith(void Function(WebAuthnListResidentCredentials) updates) => super.copyWith((message) => updates(message as WebAuthnListResidentCredentials)) as WebAuthnListResidentCredentials;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static WebAuthnListResidentCredentials create() => WebAuthnListResidentCredentials._();
+  WebAuthnListResidentCredentials createEmptyInstance() => create();
+  static $pb.PbList<WebAuthnListResidentCredentials> createRepeated() => $pb.PbList<WebAuthnListResidentCredentials>();
+  @$core.pragma('dart2js:noInline')
+  static WebAuthnListResidentCredentials getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WebAuthnListResidentCredentials>(create);
+  static WebAuthnListResidentCredentials? _defaultInstance;
+}
+
+/// *
+///  Request: Add resident credential
+///  @start
+///  @next Success
+///  @next Failure
+class WebAuthnAddResidentCredential extends $pb.GeneratedMessage {
+  factory WebAuthnAddResidentCredential({
+    $core.List<$core.int>? credentialId,
+  }) {
+    final $result = create();
+    if (credentialId != null) {
+      $result.credentialId = credentialId;
+    }
+    return $result;
+  }
+  WebAuthnAddResidentCredential._() : super();
+  factory WebAuthnAddResidentCredential.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WebAuthnAddResidentCredential.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WebAuthnAddResidentCredential', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.webauthn'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'credentialId', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  WebAuthnAddResidentCredential clone() => WebAuthnAddResidentCredential()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WebAuthnAddResidentCredential copyWith(void Function(WebAuthnAddResidentCredential) updates) => super.copyWith((message) => updates(message as WebAuthnAddResidentCredential)) as WebAuthnAddResidentCredential;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static WebAuthnAddResidentCredential create() => WebAuthnAddResidentCredential._();
+  WebAuthnAddResidentCredential createEmptyInstance() => create();
+  static $pb.PbList<WebAuthnAddResidentCredential> createRepeated() => $pb.PbList<WebAuthnAddResidentCredential>();
+  @$core.pragma('dart2js:noInline')
+  static WebAuthnAddResidentCredential getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WebAuthnAddResidentCredential>(create);
+  static WebAuthnAddResidentCredential? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get credentialId => $_getN(0);
+  @$pb.TagNumber(1)
+  set credentialId($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasCredentialId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCredentialId() => clearField(1);
+}
+
+/// *
+///  Request: Remove resident credential
+///  @start
+///  @next Success
+///  @next Failure
+class WebAuthnRemoveResidentCredential extends $pb.GeneratedMessage {
+  factory WebAuthnRemoveResidentCredential({
+    $core.int? index,
+  }) {
+    final $result = create();
+    if (index != null) {
+      $result.index = index;
+    }
+    return $result;
+  }
+  WebAuthnRemoveResidentCredential._() : super();
+  factory WebAuthnRemoveResidentCredential.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WebAuthnRemoveResidentCredential.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WebAuthnRemoveResidentCredential', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.webauthn'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'index', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  WebAuthnRemoveResidentCredential clone() => WebAuthnRemoveResidentCredential()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WebAuthnRemoveResidentCredential copyWith(void Function(WebAuthnRemoveResidentCredential) updates) => super.copyWith((message) => updates(message as WebAuthnRemoveResidentCredential)) as WebAuthnRemoveResidentCredential;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static WebAuthnRemoveResidentCredential create() => WebAuthnRemoveResidentCredential._();
+  WebAuthnRemoveResidentCredential createEmptyInstance() => create();
+  static $pb.PbList<WebAuthnRemoveResidentCredential> createRepeated() => $pb.PbList<WebAuthnRemoveResidentCredential>();
+  @$core.pragma('dart2js:noInline')
+  static WebAuthnRemoveResidentCredential getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WebAuthnRemoveResidentCredential>(create);
+  static WebAuthnRemoveResidentCredential? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get index => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set index($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasIndex() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearIndex() => clearField(1);
+}
+
+class WebAuthnCredentials_WebAuthnCredential extends $pb.GeneratedMessage {
+  factory WebAuthnCredentials_WebAuthnCredential({
+    $core.int? index,
+    $core.List<$core.int>? id,
+    $core.String? rpId,
+    $core.String? rpName,
+    $core.List<$core.int>? userId,
+    $core.String? userName,
+    $core.String? userDisplayName,
+    $core.int? creationTime,
+    $core.bool? hmacSecret,
+    $core.bool? useSignCount,
+    $core.int? algorithm,
+    $core.int? curve,
+  }) {
+    final $result = create();
+    if (index != null) {
+      $result.index = index;
+    }
+    if (id != null) {
+      $result.id = id;
+    }
+    if (rpId != null) {
+      $result.rpId = rpId;
+    }
+    if (rpName != null) {
+      $result.rpName = rpName;
+    }
+    if (userId != null) {
+      $result.userId = userId;
+    }
+    if (userName != null) {
+      $result.userName = userName;
+    }
+    if (userDisplayName != null) {
+      $result.userDisplayName = userDisplayName;
+    }
+    if (creationTime != null) {
+      $result.creationTime = creationTime;
+    }
+    if (hmacSecret != null) {
+      $result.hmacSecret = hmacSecret;
+    }
+    if (useSignCount != null) {
+      $result.useSignCount = useSignCount;
+    }
+    if (algorithm != null) {
+      $result.algorithm = algorithm;
+    }
+    if (curve != null) {
+      $result.curve = curve;
+    }
+    return $result;
+  }
+  WebAuthnCredentials_WebAuthnCredential._() : super();
+  factory WebAuthnCredentials_WebAuthnCredential.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WebAuthnCredentials_WebAuthnCredential.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WebAuthnCredentials.WebAuthnCredential', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.webauthn'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'index', $pb.PbFieldType.OU3)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'id', $pb.PbFieldType.OY)
+    ..aOS(3, _omitFieldNames ? '' : 'rpId')
+    ..aOS(4, _omitFieldNames ? '' : 'rpName')
+    ..a<$core.List<$core.int>>(5, _omitFieldNames ? '' : 'userId', $pb.PbFieldType.OY)
+    ..aOS(6, _omitFieldNames ? '' : 'userName')
+    ..aOS(7, _omitFieldNames ? '' : 'userDisplayName')
+    ..a<$core.int>(8, _omitFieldNames ? '' : 'creationTime', $pb.PbFieldType.OU3)
+    ..aOB(9, _omitFieldNames ? '' : 'hmacSecret')
+    ..aOB(10, _omitFieldNames ? '' : 'useSignCount')
+    ..a<$core.int>(11, _omitFieldNames ? '' : 'algorithm', $pb.PbFieldType.OS3)
+    ..a<$core.int>(12, _omitFieldNames ? '' : 'curve', $pb.PbFieldType.OS3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  WebAuthnCredentials_WebAuthnCredential clone() => WebAuthnCredentials_WebAuthnCredential()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WebAuthnCredentials_WebAuthnCredential copyWith(void Function(WebAuthnCredentials_WebAuthnCredential) updates) => super.copyWith((message) => updates(message as WebAuthnCredentials_WebAuthnCredential)) as WebAuthnCredentials_WebAuthnCredential;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static WebAuthnCredentials_WebAuthnCredential create() => WebAuthnCredentials_WebAuthnCredential._();
+  WebAuthnCredentials_WebAuthnCredential createEmptyInstance() => create();
+  static $pb.PbList<WebAuthnCredentials_WebAuthnCredential> createRepeated() => $pb.PbList<WebAuthnCredentials_WebAuthnCredential>();
+  @$core.pragma('dart2js:noInline')
+  static WebAuthnCredentials_WebAuthnCredential getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WebAuthnCredentials_WebAuthnCredential>(create);
+  static WebAuthnCredentials_WebAuthnCredential? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get index => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set index($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasIndex() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearIndex() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get id => $_getN(1);
+  @$pb.TagNumber(2)
+  set id($core.List<$core.int> v) { $_setBytes(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasId() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearId() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get rpId => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set rpId($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasRpId() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearRpId() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get rpName => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set rpName($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasRpName() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearRpName() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.List<$core.int> get userId => $_getN(4);
+  @$pb.TagNumber(5)
+  set userId($core.List<$core.int> v) { $_setBytes(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasUserId() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearUserId() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.String get userName => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set userName($core.String v) { $_setString(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasUserName() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearUserName() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.String get userDisplayName => $_getSZ(6);
+  @$pb.TagNumber(7)
+  set userDisplayName($core.String v) { $_setString(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasUserDisplayName() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearUserDisplayName() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.int get creationTime => $_getIZ(7);
+  @$pb.TagNumber(8)
+  set creationTime($core.int v) { $_setUnsignedInt32(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasCreationTime() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearCreationTime() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.bool get hmacSecret => $_getBF(8);
+  @$pb.TagNumber(9)
+  set hmacSecret($core.bool v) { $_setBool(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasHmacSecret() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearHmacSecret() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.bool get useSignCount => $_getBF(9);
+  @$pb.TagNumber(10)
+  set useSignCount($core.bool v) { $_setBool(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasUseSignCount() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearUseSignCount() => clearField(10);
+
+  @$pb.TagNumber(11)
+  $core.int get algorithm => $_getIZ(10);
+  @$pb.TagNumber(11)
+  set algorithm($core.int v) { $_setSignedInt32(10, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasAlgorithm() => $_has(10);
+  @$pb.TagNumber(11)
+  void clearAlgorithm() => clearField(11);
+
+  @$pb.TagNumber(12)
+  $core.int get curve => $_getIZ(11);
+  @$pb.TagNumber(12)
+  set curve($core.int v) { $_setSignedInt32(11, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasCurve() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearCurve() => clearField(12);
+}
+
+/// *
+///  Response: Resident credential list
+///  @start
+///  @next end
+class WebAuthnCredentials extends $pb.GeneratedMessage {
+  factory WebAuthnCredentials({
+    $core.Iterable<WebAuthnCredentials_WebAuthnCredential>? credentials,
+  }) {
+    final $result = create();
+    if (credentials != null) {
+      $result.credentials.addAll(credentials);
+    }
+    return $result;
+  }
+  WebAuthnCredentials._() : super();
+  factory WebAuthnCredentials.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WebAuthnCredentials.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WebAuthnCredentials', package: const $pb.PackageName(_omitMessageNames ? '' : 'hw.trezor.messages.webauthn'), createEmptyInstance: create)
+    ..pc<WebAuthnCredentials_WebAuthnCredential>(1, _omitFieldNames ? '' : 'credentials', $pb.PbFieldType.PM, subBuilder: WebAuthnCredentials_WebAuthnCredential.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  WebAuthnCredentials clone() => WebAuthnCredentials()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WebAuthnCredentials copyWith(void Function(WebAuthnCredentials) updates) => super.copyWith((message) => updates(message as WebAuthnCredentials)) as WebAuthnCredentials;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static WebAuthnCredentials create() => WebAuthnCredentials._();
+  WebAuthnCredentials createEmptyInstance() => create();
+  static $pb.PbList<WebAuthnCredentials> createRepeated() => $pb.PbList<WebAuthnCredentials>();
+  @$core.pragma('dart2js:noInline')
+  static WebAuthnCredentials getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WebAuthnCredentials>(create);
+  static WebAuthnCredentials? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<WebAuthnCredentials_WebAuthnCredential> get credentials => $_getList(0);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-webauthn.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-webauthn.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-webauthn.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-webauthn.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-webauthn.pbjson.dart
@@ -1,0 +1,90 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-webauthn.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use webAuthnListResidentCredentialsDescriptor instead')
+const WebAuthnListResidentCredentials$json = {
+  '1': 'WebAuthnListResidentCredentials',
+};
+
+/// Descriptor for `WebAuthnListResidentCredentials`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List webAuthnListResidentCredentialsDescriptor = $convert.base64Decode(
+    'Ch9XZWJBdXRobkxpc3RSZXNpZGVudENyZWRlbnRpYWxz');
+
+@$core.Deprecated('Use webAuthnAddResidentCredentialDescriptor instead')
+const WebAuthnAddResidentCredential$json = {
+  '1': 'WebAuthnAddResidentCredential',
+  '2': [
+    {'1': 'credential_id', '3': 1, '4': 1, '5': 12, '10': 'credentialId'},
+  ],
+};
+
+/// Descriptor for `WebAuthnAddResidentCredential`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List webAuthnAddResidentCredentialDescriptor = $convert.base64Decode(
+    'Ch1XZWJBdXRobkFkZFJlc2lkZW50Q3JlZGVudGlhbBIjCg1jcmVkZW50aWFsX2lkGAEgASgMUg'
+    'xjcmVkZW50aWFsSWQ=');
+
+@$core.Deprecated('Use webAuthnRemoveResidentCredentialDescriptor instead')
+const WebAuthnRemoveResidentCredential$json = {
+  '1': 'WebAuthnRemoveResidentCredential',
+  '2': [
+    {'1': 'index', '3': 1, '4': 1, '5': 13, '10': 'index'},
+  ],
+};
+
+/// Descriptor for `WebAuthnRemoveResidentCredential`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List webAuthnRemoveResidentCredentialDescriptor = $convert.base64Decode(
+    'CiBXZWJBdXRoblJlbW92ZVJlc2lkZW50Q3JlZGVudGlhbBIUCgVpbmRleBgBIAEoDVIFaW5kZX'
+    'g=');
+
+@$core.Deprecated('Use webAuthnCredentialsDescriptor instead')
+const WebAuthnCredentials$json = {
+  '1': 'WebAuthnCredentials',
+  '2': [
+    {'1': 'credentials', '3': 1, '4': 3, '5': 11, '6': '.hw.trezor.messages.webauthn.WebAuthnCredentials.WebAuthnCredential', '10': 'credentials'},
+  ],
+  '3': [WebAuthnCredentials_WebAuthnCredential$json],
+};
+
+@$core.Deprecated('Use webAuthnCredentialsDescriptor instead')
+const WebAuthnCredentials_WebAuthnCredential$json = {
+  '1': 'WebAuthnCredential',
+  '2': [
+    {'1': 'index', '3': 1, '4': 1, '5': 13, '10': 'index'},
+    {'1': 'id', '3': 2, '4': 1, '5': 12, '10': 'id'},
+    {'1': 'rp_id', '3': 3, '4': 1, '5': 9, '10': 'rpId'},
+    {'1': 'rp_name', '3': 4, '4': 1, '5': 9, '10': 'rpName'},
+    {'1': 'user_id', '3': 5, '4': 1, '5': 12, '10': 'userId'},
+    {'1': 'user_name', '3': 6, '4': 1, '5': 9, '10': 'userName'},
+    {'1': 'user_display_name', '3': 7, '4': 1, '5': 9, '10': 'userDisplayName'},
+    {'1': 'creation_time', '3': 8, '4': 1, '5': 13, '10': 'creationTime'},
+    {'1': 'hmac_secret', '3': 9, '4': 1, '5': 8, '10': 'hmacSecret'},
+    {'1': 'use_sign_count', '3': 10, '4': 1, '5': 8, '10': 'useSignCount'},
+    {'1': 'algorithm', '3': 11, '4': 1, '5': 17, '10': 'algorithm'},
+    {'1': 'curve', '3': 12, '4': 1, '5': 17, '10': 'curve'},
+  ],
+};
+
+/// Descriptor for `WebAuthnCredentials`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List webAuthnCredentialsDescriptor = $convert.base64Decode(
+    'ChNXZWJBdXRobkNyZWRlbnRpYWxzEmUKC2NyZWRlbnRpYWxzGAEgAygLMkMuaHcudHJlem9yLm'
+    '1lc3NhZ2VzLndlYmF1dGhuLldlYkF1dGhuQ3JlZGVudGlhbHMuV2ViQXV0aG5DcmVkZW50aWFs'
+    'UgtjcmVkZW50aWFscxrqAgoSV2ViQXV0aG5DcmVkZW50aWFsEhQKBWluZGV4GAEgASgNUgVpbm'
+    'RleBIOCgJpZBgCIAEoDFICaWQSEwoFcnBfaWQYAyABKAlSBHJwSWQSFwoHcnBfbmFtZRgEIAEo'
+    'CVIGcnBOYW1lEhcKB3VzZXJfaWQYBSABKAxSBnVzZXJJZBIbCgl1c2VyX25hbWUYBiABKAlSCH'
+    'VzZXJOYW1lEioKEXVzZXJfZGlzcGxheV9uYW1lGAcgASgJUg91c2VyRGlzcGxheU5hbWUSIwoN'
+    'Y3JlYXRpb25fdGltZRgIIAEoDVIMY3JlYXRpb25UaW1lEh8KC2htYWNfc2VjcmV0GAkgASgIUg'
+    'pobWFjU2VjcmV0EiQKDnVzZV9zaWduX2NvdW50GAogASgIUgx1c2VTaWduQ291bnQSHAoJYWxn'
+    'b3JpdGhtGAsgASgRUglhbGdvcml0aG0SFAoFY3VydmUYDCABKBFSBWN1cnZl');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-webauthn.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages-webauthn.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages-webauthn.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages-webauthn.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages.pb.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages.pb.dart
@@ -1,0 +1,51 @@
+//
+//  Generated code. Do not modify.
+//  source: messages.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+export 'messages.pbenum.dart';
+
+class Messages {
+  static final wireIn = $pb.Extension<$core.bool>(_omitMessageNames ? '' : 'google.protobuf.EnumValueOptions', _omitFieldNames ? '' : 'wireIn', 50002, $pb.PbFieldType.OB);
+  static final wireOut = $pb.Extension<$core.bool>(_omitMessageNames ? '' : 'google.protobuf.EnumValueOptions', _omitFieldNames ? '' : 'wireOut', 50003, $pb.PbFieldType.OB);
+  static final wireDebugIn = $pb.Extension<$core.bool>(_omitMessageNames ? '' : 'google.protobuf.EnumValueOptions', _omitFieldNames ? '' : 'wireDebugIn', 50004, $pb.PbFieldType.OB);
+  static final wireDebugOut = $pb.Extension<$core.bool>(_omitMessageNames ? '' : 'google.protobuf.EnumValueOptions', _omitFieldNames ? '' : 'wireDebugOut', 50005, $pb.PbFieldType.OB);
+  static final wireTiny = $pb.Extension<$core.bool>(_omitMessageNames ? '' : 'google.protobuf.EnumValueOptions', _omitFieldNames ? '' : 'wireTiny', 50006, $pb.PbFieldType.OB);
+  static final wireBootloader = $pb.Extension<$core.bool>(_omitMessageNames ? '' : 'google.protobuf.EnumValueOptions', _omitFieldNames ? '' : 'wireBootloader', 50007, $pb.PbFieldType.OB);
+  static final wireNoFsm = $pb.Extension<$core.bool>(_omitMessageNames ? '' : 'google.protobuf.EnumValueOptions', _omitFieldNames ? '' : 'wireNoFsm', 50008, $pb.PbFieldType.OB);
+  static final bitcoinOnly = $pb.Extension<$core.bool>(_omitMessageNames ? '' : 'google.protobuf.EnumValueOptions', _omitFieldNames ? '' : 'bitcoinOnly', 60000, $pb.PbFieldType.OB);
+  static final hasBitcoinOnlyValues = $pb.Extension<$core.bool>(_omitMessageNames ? '' : 'google.protobuf.EnumOptions', _omitFieldNames ? '' : 'hasBitcoinOnlyValues', 51001, $pb.PbFieldType.OB);
+  static final experimentalMessage = $pb.Extension<$core.bool>(_omitMessageNames ? '' : 'google.protobuf.MessageOptions', _omitFieldNames ? '' : 'experimentalMessage', 52001, $pb.PbFieldType.OB);
+  static final wireType = $pb.Extension<$core.int>(_omitMessageNames ? '' : 'google.protobuf.MessageOptions', _omitFieldNames ? '' : 'wireType', 52002, $pb.PbFieldType.OU3);
+  static final experimentalField = $pb.Extension<$core.bool>(_omitMessageNames ? '' : 'google.protobuf.FieldOptions', _omitFieldNames ? '' : 'experimentalField', 53001, $pb.PbFieldType.OB);
+  static final includeInBitcoinOnly = $pb.Extension<$core.bool>(_omitMessageNames ? '' : 'google.protobuf.FileOptions', _omitFieldNames ? '' : 'includeInBitcoinOnly', 60000, $pb.PbFieldType.OB);
+  static void registerAllExtensions($pb.ExtensionRegistry registry) {
+    registry.add(wireIn);
+    registry.add(wireOut);
+    registry.add(wireDebugIn);
+    registry.add(wireDebugOut);
+    registry.add(wireTiny);
+    registry.add(wireBootloader);
+    registry.add(wireNoFsm);
+    registry.add(bitcoinOnly);
+    registry.add(hasBitcoinOnlyValues);
+    registry.add(experimentalMessage);
+    registry.add(wireType);
+    registry.add(experimentalField);
+    registry.add(includeInBitcoinOnly);
+  }
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages.pbenum.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages.pbenum.dart
@@ -1,0 +1,516 @@
+//
+//  Generated code. Do not modify.
+//  source: messages.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+/// *
+///  Mapping between Trezor wire identifier (uint) and a protobuf message
+class MessageType extends $pb.ProtobufEnum {
+  static const MessageType MessageType_Initialize = MessageType._(0, _omitEnumNames ? '' : 'MessageType_Initialize');
+  static const MessageType MessageType_Ping = MessageType._(1, _omitEnumNames ? '' : 'MessageType_Ping');
+  static const MessageType MessageType_Success = MessageType._(2, _omitEnumNames ? '' : 'MessageType_Success');
+  static const MessageType MessageType_Failure = MessageType._(3, _omitEnumNames ? '' : 'MessageType_Failure');
+  static const MessageType MessageType_ChangePin = MessageType._(4, _omitEnumNames ? '' : 'MessageType_ChangePin');
+  static const MessageType MessageType_WipeDevice = MessageType._(5, _omitEnumNames ? '' : 'MessageType_WipeDevice');
+  static const MessageType MessageType_GetEntropy = MessageType._(9, _omitEnumNames ? '' : 'MessageType_GetEntropy');
+  static const MessageType MessageType_Entropy = MessageType._(10, _omitEnumNames ? '' : 'MessageType_Entropy');
+  static const MessageType MessageType_LoadDevice = MessageType._(13, _omitEnumNames ? '' : 'MessageType_LoadDevice');
+  static const MessageType MessageType_ResetDevice = MessageType._(14, _omitEnumNames ? '' : 'MessageType_ResetDevice');
+  static const MessageType MessageType_SetBusy = MessageType._(16, _omitEnumNames ? '' : 'MessageType_SetBusy');
+  static const MessageType MessageType_Features = MessageType._(17, _omitEnumNames ? '' : 'MessageType_Features');
+  static const MessageType MessageType_PinMatrixRequest = MessageType._(18, _omitEnumNames ? '' : 'MessageType_PinMatrixRequest');
+  static const MessageType MessageType_PinMatrixAck = MessageType._(19, _omitEnumNames ? '' : 'MessageType_PinMatrixAck');
+  static const MessageType MessageType_Cancel = MessageType._(20, _omitEnumNames ? '' : 'MessageType_Cancel');
+  static const MessageType MessageType_LockDevice = MessageType._(24, _omitEnumNames ? '' : 'MessageType_LockDevice');
+  static const MessageType MessageType_ApplySettings = MessageType._(25, _omitEnumNames ? '' : 'MessageType_ApplySettings');
+  static const MessageType MessageType_ButtonRequest = MessageType._(26, _omitEnumNames ? '' : 'MessageType_ButtonRequest');
+  static const MessageType MessageType_ButtonAck = MessageType._(27, _omitEnumNames ? '' : 'MessageType_ButtonAck');
+  static const MessageType MessageType_ApplyFlags = MessageType._(28, _omitEnumNames ? '' : 'MessageType_ApplyFlags');
+  static const MessageType MessageType_GetNonce = MessageType._(31, _omitEnumNames ? '' : 'MessageType_GetNonce');
+  static const MessageType MessageType_Nonce = MessageType._(33, _omitEnumNames ? '' : 'MessageType_Nonce');
+  static const MessageType MessageType_BackupDevice = MessageType._(34, _omitEnumNames ? '' : 'MessageType_BackupDevice');
+  static const MessageType MessageType_EntropyRequest = MessageType._(35, _omitEnumNames ? '' : 'MessageType_EntropyRequest');
+  static const MessageType MessageType_EntropyAck = MessageType._(36, _omitEnumNames ? '' : 'MessageType_EntropyAck');
+  static const MessageType MessageType_PassphraseRequest = MessageType._(41, _omitEnumNames ? '' : 'MessageType_PassphraseRequest');
+  static const MessageType MessageType_PassphraseAck = MessageType._(42, _omitEnumNames ? '' : 'MessageType_PassphraseAck');
+  static const MessageType MessageType_RecoveryDevice = MessageType._(45, _omitEnumNames ? '' : 'MessageType_RecoveryDevice');
+  static const MessageType MessageType_WordRequest = MessageType._(46, _omitEnumNames ? '' : 'MessageType_WordRequest');
+  static const MessageType MessageType_WordAck = MessageType._(47, _omitEnumNames ? '' : 'MessageType_WordAck');
+  static const MessageType MessageType_GetFeatures = MessageType._(55, _omitEnumNames ? '' : 'MessageType_GetFeatures');
+  static const MessageType MessageType_SdProtect = MessageType._(79, _omitEnumNames ? '' : 'MessageType_SdProtect');
+  static const MessageType MessageType_ChangeWipeCode = MessageType._(82, _omitEnumNames ? '' : 'MessageType_ChangeWipeCode');
+  static const MessageType MessageType_EndSession = MessageType._(83, _omitEnumNames ? '' : 'MessageType_EndSession');
+  static const MessageType MessageType_DoPreauthorized = MessageType._(84, _omitEnumNames ? '' : 'MessageType_DoPreauthorized');
+  static const MessageType MessageType_PreauthorizedRequest = MessageType._(85, _omitEnumNames ? '' : 'MessageType_PreauthorizedRequest');
+  static const MessageType MessageType_CancelAuthorization = MessageType._(86, _omitEnumNames ? '' : 'MessageType_CancelAuthorization');
+  static const MessageType MessageType_RebootToBootloader = MessageType._(87, _omitEnumNames ? '' : 'MessageType_RebootToBootloader');
+  static const MessageType MessageType_GetFirmwareHash = MessageType._(88, _omitEnumNames ? '' : 'MessageType_GetFirmwareHash');
+  static const MessageType MessageType_FirmwareHash = MessageType._(89, _omitEnumNames ? '' : 'MessageType_FirmwareHash');
+  static const MessageType MessageType_UnlockPath = MessageType._(93, _omitEnumNames ? '' : 'MessageType_UnlockPath');
+  static const MessageType MessageType_UnlockedPathRequest = MessageType._(94, _omitEnumNames ? '' : 'MessageType_UnlockedPathRequest');
+  static const MessageType MessageType_ShowDeviceTutorial = MessageType._(95, _omitEnumNames ? '' : 'MessageType_ShowDeviceTutorial');
+  static const MessageType MessageType_UnlockBootloader = MessageType._(96, _omitEnumNames ? '' : 'MessageType_UnlockBootloader');
+  static const MessageType MessageType_AuthenticateDevice = MessageType._(97, _omitEnumNames ? '' : 'MessageType_AuthenticateDevice');
+  static const MessageType MessageType_AuthenticityProof = MessageType._(98, _omitEnumNames ? '' : 'MessageType_AuthenticityProof');
+  static const MessageType MessageType_ChangeLanguage = MessageType._(990, _omitEnumNames ? '' : 'MessageType_ChangeLanguage');
+  static const MessageType MessageType_TranslationDataRequest = MessageType._(991, _omitEnumNames ? '' : 'MessageType_TranslationDataRequest');
+  static const MessageType MessageType_TranslationDataAck = MessageType._(992, _omitEnumNames ? '' : 'MessageType_TranslationDataAck');
+  static const MessageType MessageType_SetU2FCounter = MessageType._(63, _omitEnumNames ? '' : 'MessageType_SetU2FCounter');
+  static const MessageType MessageType_GetNextU2FCounter = MessageType._(80, _omitEnumNames ? '' : 'MessageType_GetNextU2FCounter');
+  static const MessageType MessageType_NextU2FCounter = MessageType._(81, _omitEnumNames ? '' : 'MessageType_NextU2FCounter');
+  static const MessageType MessageType_Deprecated_PassphraseStateRequest = MessageType._(77, _omitEnumNames ? '' : 'MessageType_Deprecated_PassphraseStateRequest');
+  static const MessageType MessageType_Deprecated_PassphraseStateAck = MessageType._(78, _omitEnumNames ? '' : 'MessageType_Deprecated_PassphraseStateAck');
+  static const MessageType MessageType_FirmwareErase = MessageType._(6, _omitEnumNames ? '' : 'MessageType_FirmwareErase');
+  static const MessageType MessageType_FirmwareUpload = MessageType._(7, _omitEnumNames ? '' : 'MessageType_FirmwareUpload');
+  static const MessageType MessageType_FirmwareRequest = MessageType._(8, _omitEnumNames ? '' : 'MessageType_FirmwareRequest');
+  static const MessageType MessageType_ProdTestT1 = MessageType._(32, _omitEnumNames ? '' : 'MessageType_ProdTestT1');
+  static const MessageType MessageType_GetPublicKey = MessageType._(11, _omitEnumNames ? '' : 'MessageType_GetPublicKey');
+  static const MessageType MessageType_PublicKey = MessageType._(12, _omitEnumNames ? '' : 'MessageType_PublicKey');
+  static const MessageType MessageType_SignTx = MessageType._(15, _omitEnumNames ? '' : 'MessageType_SignTx');
+  static const MessageType MessageType_TxRequest = MessageType._(21, _omitEnumNames ? '' : 'MessageType_TxRequest');
+  static const MessageType MessageType_TxAck = MessageType._(22, _omitEnumNames ? '' : 'MessageType_TxAck');
+  static const MessageType MessageType_GetAddress = MessageType._(29, _omitEnumNames ? '' : 'MessageType_GetAddress');
+  static const MessageType MessageType_Address = MessageType._(30, _omitEnumNames ? '' : 'MessageType_Address');
+  static const MessageType MessageType_TxAckPaymentRequest = MessageType._(37, _omitEnumNames ? '' : 'MessageType_TxAckPaymentRequest');
+  static const MessageType MessageType_SignMessage = MessageType._(38, _omitEnumNames ? '' : 'MessageType_SignMessage');
+  static const MessageType MessageType_VerifyMessage = MessageType._(39, _omitEnumNames ? '' : 'MessageType_VerifyMessage');
+  static const MessageType MessageType_MessageSignature = MessageType._(40, _omitEnumNames ? '' : 'MessageType_MessageSignature');
+  static const MessageType MessageType_GetOwnershipId = MessageType._(43, _omitEnumNames ? '' : 'MessageType_GetOwnershipId');
+  static const MessageType MessageType_OwnershipId = MessageType._(44, _omitEnumNames ? '' : 'MessageType_OwnershipId');
+  static const MessageType MessageType_GetOwnershipProof = MessageType._(49, _omitEnumNames ? '' : 'MessageType_GetOwnershipProof');
+  static const MessageType MessageType_OwnershipProof = MessageType._(50, _omitEnumNames ? '' : 'MessageType_OwnershipProof');
+  static const MessageType MessageType_AuthorizeCoinJoin = MessageType._(51, _omitEnumNames ? '' : 'MessageType_AuthorizeCoinJoin');
+  static const MessageType MessageType_CipherKeyValue = MessageType._(23, _omitEnumNames ? '' : 'MessageType_CipherKeyValue');
+  static const MessageType MessageType_CipheredKeyValue = MessageType._(48, _omitEnumNames ? '' : 'MessageType_CipheredKeyValue');
+  static const MessageType MessageType_SignIdentity = MessageType._(53, _omitEnumNames ? '' : 'MessageType_SignIdentity');
+  static const MessageType MessageType_SignedIdentity = MessageType._(54, _omitEnumNames ? '' : 'MessageType_SignedIdentity');
+  static const MessageType MessageType_GetECDHSessionKey = MessageType._(61, _omitEnumNames ? '' : 'MessageType_GetECDHSessionKey');
+  static const MessageType MessageType_ECDHSessionKey = MessageType._(62, _omitEnumNames ? '' : 'MessageType_ECDHSessionKey');
+  static const MessageType MessageType_CosiCommit = MessageType._(71, _omitEnumNames ? '' : 'MessageType_CosiCommit');
+  static const MessageType MessageType_CosiCommitment = MessageType._(72, _omitEnumNames ? '' : 'MessageType_CosiCommitment');
+  static const MessageType MessageType_CosiSign = MessageType._(73, _omitEnumNames ? '' : 'MessageType_CosiSign');
+  static const MessageType MessageType_CosiSignature = MessageType._(74, _omitEnumNames ? '' : 'MessageType_CosiSignature');
+  static const MessageType MessageType_DebugLinkDecision = MessageType._(100, _omitEnumNames ? '' : 'MessageType_DebugLinkDecision');
+  static const MessageType MessageType_DebugLinkGetState = MessageType._(101, _omitEnumNames ? '' : 'MessageType_DebugLinkGetState');
+  static const MessageType MessageType_DebugLinkState = MessageType._(102, _omitEnumNames ? '' : 'MessageType_DebugLinkState');
+  static const MessageType MessageType_DebugLinkStop = MessageType._(103, _omitEnumNames ? '' : 'MessageType_DebugLinkStop');
+  static const MessageType MessageType_DebugLinkLog = MessageType._(104, _omitEnumNames ? '' : 'MessageType_DebugLinkLog');
+  static const MessageType MessageType_DebugLinkMemoryRead = MessageType._(110, _omitEnumNames ? '' : 'MessageType_DebugLinkMemoryRead');
+  static const MessageType MessageType_DebugLinkMemory = MessageType._(111, _omitEnumNames ? '' : 'MessageType_DebugLinkMemory');
+  static const MessageType MessageType_DebugLinkMemoryWrite = MessageType._(112, _omitEnumNames ? '' : 'MessageType_DebugLinkMemoryWrite');
+  static const MessageType MessageType_DebugLinkFlashErase = MessageType._(113, _omitEnumNames ? '' : 'MessageType_DebugLinkFlashErase');
+  static const MessageType MessageType_DebugLinkLayout = MessageType._(9001, _omitEnumNames ? '' : 'MessageType_DebugLinkLayout');
+  static const MessageType MessageType_DebugLinkReseedRandom = MessageType._(9002, _omitEnumNames ? '' : 'MessageType_DebugLinkReseedRandom');
+  static const MessageType MessageType_DebugLinkRecordScreen = MessageType._(9003, _omitEnumNames ? '' : 'MessageType_DebugLinkRecordScreen');
+  static const MessageType MessageType_DebugLinkEraseSdCard = MessageType._(9005, _omitEnumNames ? '' : 'MessageType_DebugLinkEraseSdCard');
+  static const MessageType MessageType_DebugLinkWatchLayout = MessageType._(9006, _omitEnumNames ? '' : 'MessageType_DebugLinkWatchLayout');
+  static const MessageType MessageType_DebugLinkResetDebugEvents = MessageType._(9007, _omitEnumNames ? '' : 'MessageType_DebugLinkResetDebugEvents');
+  static const MessageType MessageType_EthereumGetPublicKey = MessageType._(450, _omitEnumNames ? '' : 'MessageType_EthereumGetPublicKey');
+  static const MessageType MessageType_EthereumPublicKey = MessageType._(451, _omitEnumNames ? '' : 'MessageType_EthereumPublicKey');
+  static const MessageType MessageType_EthereumGetAddress = MessageType._(56, _omitEnumNames ? '' : 'MessageType_EthereumGetAddress');
+  static const MessageType MessageType_EthereumAddress = MessageType._(57, _omitEnumNames ? '' : 'MessageType_EthereumAddress');
+  static const MessageType MessageType_EthereumSignTx = MessageType._(58, _omitEnumNames ? '' : 'MessageType_EthereumSignTx');
+  static const MessageType MessageType_EthereumSignTxEIP1559 = MessageType._(452, _omitEnumNames ? '' : 'MessageType_EthereumSignTxEIP1559');
+  static const MessageType MessageType_EthereumTxRequest = MessageType._(59, _omitEnumNames ? '' : 'MessageType_EthereumTxRequest');
+  static const MessageType MessageType_EthereumTxAck = MessageType._(60, _omitEnumNames ? '' : 'MessageType_EthereumTxAck');
+  static const MessageType MessageType_EthereumSignMessage = MessageType._(64, _omitEnumNames ? '' : 'MessageType_EthereumSignMessage');
+  static const MessageType MessageType_EthereumVerifyMessage = MessageType._(65, _omitEnumNames ? '' : 'MessageType_EthereumVerifyMessage');
+  static const MessageType MessageType_EthereumMessageSignature = MessageType._(66, _omitEnumNames ? '' : 'MessageType_EthereumMessageSignature');
+  static const MessageType MessageType_EthereumSignTypedData = MessageType._(464, _omitEnumNames ? '' : 'MessageType_EthereumSignTypedData');
+  static const MessageType MessageType_EthereumTypedDataStructRequest = MessageType._(465, _omitEnumNames ? '' : 'MessageType_EthereumTypedDataStructRequest');
+  static const MessageType MessageType_EthereumTypedDataStructAck = MessageType._(466, _omitEnumNames ? '' : 'MessageType_EthereumTypedDataStructAck');
+  static const MessageType MessageType_EthereumTypedDataValueRequest = MessageType._(467, _omitEnumNames ? '' : 'MessageType_EthereumTypedDataValueRequest');
+  static const MessageType MessageType_EthereumTypedDataValueAck = MessageType._(468, _omitEnumNames ? '' : 'MessageType_EthereumTypedDataValueAck');
+  static const MessageType MessageType_EthereumTypedDataSignature = MessageType._(469, _omitEnumNames ? '' : 'MessageType_EthereumTypedDataSignature');
+  static const MessageType MessageType_EthereumSignTypedHash = MessageType._(470, _omitEnumNames ? '' : 'MessageType_EthereumSignTypedHash');
+  static const MessageType MessageType_NEMGetAddress = MessageType._(67, _omitEnumNames ? '' : 'MessageType_NEMGetAddress');
+  static const MessageType MessageType_NEMAddress = MessageType._(68, _omitEnumNames ? '' : 'MessageType_NEMAddress');
+  static const MessageType MessageType_NEMSignTx = MessageType._(69, _omitEnumNames ? '' : 'MessageType_NEMSignTx');
+  static const MessageType MessageType_NEMSignedTx = MessageType._(70, _omitEnumNames ? '' : 'MessageType_NEMSignedTx');
+  static const MessageType MessageType_NEMDecryptMessage = MessageType._(75, _omitEnumNames ? '' : 'MessageType_NEMDecryptMessage');
+  static const MessageType MessageType_NEMDecryptedMessage = MessageType._(76, _omitEnumNames ? '' : 'MessageType_NEMDecryptedMessage');
+  static const MessageType MessageType_TezosGetAddress = MessageType._(150, _omitEnumNames ? '' : 'MessageType_TezosGetAddress');
+  static const MessageType MessageType_TezosAddress = MessageType._(151, _omitEnumNames ? '' : 'MessageType_TezosAddress');
+  static const MessageType MessageType_TezosSignTx = MessageType._(152, _omitEnumNames ? '' : 'MessageType_TezosSignTx');
+  static const MessageType MessageType_TezosSignedTx = MessageType._(153, _omitEnumNames ? '' : 'MessageType_TezosSignedTx');
+  static const MessageType MessageType_TezosGetPublicKey = MessageType._(154, _omitEnumNames ? '' : 'MessageType_TezosGetPublicKey');
+  static const MessageType MessageType_TezosPublicKey = MessageType._(155, _omitEnumNames ? '' : 'MessageType_TezosPublicKey');
+  static const MessageType MessageType_StellarSignTx = MessageType._(202, _omitEnumNames ? '' : 'MessageType_StellarSignTx');
+  static const MessageType MessageType_StellarTxOpRequest = MessageType._(203, _omitEnumNames ? '' : 'MessageType_StellarTxOpRequest');
+  static const MessageType MessageType_StellarGetAddress = MessageType._(207, _omitEnumNames ? '' : 'MessageType_StellarGetAddress');
+  static const MessageType MessageType_StellarAddress = MessageType._(208, _omitEnumNames ? '' : 'MessageType_StellarAddress');
+  static const MessageType MessageType_StellarCreateAccountOp = MessageType._(210, _omitEnumNames ? '' : 'MessageType_StellarCreateAccountOp');
+  static const MessageType MessageType_StellarPaymentOp = MessageType._(211, _omitEnumNames ? '' : 'MessageType_StellarPaymentOp');
+  static const MessageType MessageType_StellarPathPaymentStrictReceiveOp = MessageType._(212, _omitEnumNames ? '' : 'MessageType_StellarPathPaymentStrictReceiveOp');
+  static const MessageType MessageType_StellarManageSellOfferOp = MessageType._(213, _omitEnumNames ? '' : 'MessageType_StellarManageSellOfferOp');
+  static const MessageType MessageType_StellarCreatePassiveSellOfferOp = MessageType._(214, _omitEnumNames ? '' : 'MessageType_StellarCreatePassiveSellOfferOp');
+  static const MessageType MessageType_StellarSetOptionsOp = MessageType._(215, _omitEnumNames ? '' : 'MessageType_StellarSetOptionsOp');
+  static const MessageType MessageType_StellarChangeTrustOp = MessageType._(216, _omitEnumNames ? '' : 'MessageType_StellarChangeTrustOp');
+  static const MessageType MessageType_StellarAllowTrustOp = MessageType._(217, _omitEnumNames ? '' : 'MessageType_StellarAllowTrustOp');
+  static const MessageType MessageType_StellarAccountMergeOp = MessageType._(218, _omitEnumNames ? '' : 'MessageType_StellarAccountMergeOp');
+  static const MessageType MessageType_StellarManageDataOp = MessageType._(220, _omitEnumNames ? '' : 'MessageType_StellarManageDataOp');
+  static const MessageType MessageType_StellarBumpSequenceOp = MessageType._(221, _omitEnumNames ? '' : 'MessageType_StellarBumpSequenceOp');
+  static const MessageType MessageType_StellarManageBuyOfferOp = MessageType._(222, _omitEnumNames ? '' : 'MessageType_StellarManageBuyOfferOp');
+  static const MessageType MessageType_StellarPathPaymentStrictSendOp = MessageType._(223, _omitEnumNames ? '' : 'MessageType_StellarPathPaymentStrictSendOp');
+  static const MessageType MessageType_StellarClaimClaimableBalanceOp = MessageType._(225, _omitEnumNames ? '' : 'MessageType_StellarClaimClaimableBalanceOp');
+  static const MessageType MessageType_StellarSignedTx = MessageType._(230, _omitEnumNames ? '' : 'MessageType_StellarSignedTx');
+  static const MessageType MessageType_CardanoGetPublicKey = MessageType._(305, _omitEnumNames ? '' : 'MessageType_CardanoGetPublicKey');
+  static const MessageType MessageType_CardanoPublicKey = MessageType._(306, _omitEnumNames ? '' : 'MessageType_CardanoPublicKey');
+  static const MessageType MessageType_CardanoGetAddress = MessageType._(307, _omitEnumNames ? '' : 'MessageType_CardanoGetAddress');
+  static const MessageType MessageType_CardanoAddress = MessageType._(308, _omitEnumNames ? '' : 'MessageType_CardanoAddress');
+  static const MessageType MessageType_CardanoTxItemAck = MessageType._(313, _omitEnumNames ? '' : 'MessageType_CardanoTxItemAck');
+  static const MessageType MessageType_CardanoTxAuxiliaryDataSupplement = MessageType._(314, _omitEnumNames ? '' : 'MessageType_CardanoTxAuxiliaryDataSupplement');
+  static const MessageType MessageType_CardanoTxWitnessRequest = MessageType._(315, _omitEnumNames ? '' : 'MessageType_CardanoTxWitnessRequest');
+  static const MessageType MessageType_CardanoTxWitnessResponse = MessageType._(316, _omitEnumNames ? '' : 'MessageType_CardanoTxWitnessResponse');
+  static const MessageType MessageType_CardanoTxHostAck = MessageType._(317, _omitEnumNames ? '' : 'MessageType_CardanoTxHostAck');
+  static const MessageType MessageType_CardanoTxBodyHash = MessageType._(318, _omitEnumNames ? '' : 'MessageType_CardanoTxBodyHash');
+  static const MessageType MessageType_CardanoSignTxFinished = MessageType._(319, _omitEnumNames ? '' : 'MessageType_CardanoSignTxFinished');
+  static const MessageType MessageType_CardanoSignTxInit = MessageType._(320, _omitEnumNames ? '' : 'MessageType_CardanoSignTxInit');
+  static const MessageType MessageType_CardanoTxInput = MessageType._(321, _omitEnumNames ? '' : 'MessageType_CardanoTxInput');
+  static const MessageType MessageType_CardanoTxOutput = MessageType._(322, _omitEnumNames ? '' : 'MessageType_CardanoTxOutput');
+  static const MessageType MessageType_CardanoAssetGroup = MessageType._(323, _omitEnumNames ? '' : 'MessageType_CardanoAssetGroup');
+  static const MessageType MessageType_CardanoToken = MessageType._(324, _omitEnumNames ? '' : 'MessageType_CardanoToken');
+  static const MessageType MessageType_CardanoTxCertificate = MessageType._(325, _omitEnumNames ? '' : 'MessageType_CardanoTxCertificate');
+  static const MessageType MessageType_CardanoTxWithdrawal = MessageType._(326, _omitEnumNames ? '' : 'MessageType_CardanoTxWithdrawal');
+  static const MessageType MessageType_CardanoTxAuxiliaryData = MessageType._(327, _omitEnumNames ? '' : 'MessageType_CardanoTxAuxiliaryData');
+  static const MessageType MessageType_CardanoPoolOwner = MessageType._(328, _omitEnumNames ? '' : 'MessageType_CardanoPoolOwner');
+  static const MessageType MessageType_CardanoPoolRelayParameters = MessageType._(329, _omitEnumNames ? '' : 'MessageType_CardanoPoolRelayParameters');
+  static const MessageType MessageType_CardanoGetNativeScriptHash = MessageType._(330, _omitEnumNames ? '' : 'MessageType_CardanoGetNativeScriptHash');
+  static const MessageType MessageType_CardanoNativeScriptHash = MessageType._(331, _omitEnumNames ? '' : 'MessageType_CardanoNativeScriptHash');
+  static const MessageType MessageType_CardanoTxMint = MessageType._(332, _omitEnumNames ? '' : 'MessageType_CardanoTxMint');
+  static const MessageType MessageType_CardanoTxCollateralInput = MessageType._(333, _omitEnumNames ? '' : 'MessageType_CardanoTxCollateralInput');
+  static const MessageType MessageType_CardanoTxRequiredSigner = MessageType._(334, _omitEnumNames ? '' : 'MessageType_CardanoTxRequiredSigner');
+  static const MessageType MessageType_CardanoTxInlineDatumChunk = MessageType._(335, _omitEnumNames ? '' : 'MessageType_CardanoTxInlineDatumChunk');
+  static const MessageType MessageType_CardanoTxReferenceScriptChunk = MessageType._(336, _omitEnumNames ? '' : 'MessageType_CardanoTxReferenceScriptChunk');
+  static const MessageType MessageType_CardanoTxReferenceInput = MessageType._(337, _omitEnumNames ? '' : 'MessageType_CardanoTxReferenceInput');
+  static const MessageType MessageType_RippleGetAddress = MessageType._(400, _omitEnumNames ? '' : 'MessageType_RippleGetAddress');
+  static const MessageType MessageType_RippleAddress = MessageType._(401, _omitEnumNames ? '' : 'MessageType_RippleAddress');
+  static const MessageType MessageType_RippleSignTx = MessageType._(402, _omitEnumNames ? '' : 'MessageType_RippleSignTx');
+  static const MessageType MessageType_RippleSignedTx = MessageType._(403, _omitEnumNames ? '' : 'MessageType_RippleSignedTx');
+  static const MessageType MessageType_MoneroTransactionInitRequest = MessageType._(501, _omitEnumNames ? '' : 'MessageType_MoneroTransactionInitRequest');
+  static const MessageType MessageType_MoneroTransactionInitAck = MessageType._(502, _omitEnumNames ? '' : 'MessageType_MoneroTransactionInitAck');
+  static const MessageType MessageType_MoneroTransactionSetInputRequest = MessageType._(503, _omitEnumNames ? '' : 'MessageType_MoneroTransactionSetInputRequest');
+  static const MessageType MessageType_MoneroTransactionSetInputAck = MessageType._(504, _omitEnumNames ? '' : 'MessageType_MoneroTransactionSetInputAck');
+  static const MessageType MessageType_MoneroTransactionInputViniRequest = MessageType._(507, _omitEnumNames ? '' : 'MessageType_MoneroTransactionInputViniRequest');
+  static const MessageType MessageType_MoneroTransactionInputViniAck = MessageType._(508, _omitEnumNames ? '' : 'MessageType_MoneroTransactionInputViniAck');
+  static const MessageType MessageType_MoneroTransactionAllInputsSetRequest = MessageType._(509, _omitEnumNames ? '' : 'MessageType_MoneroTransactionAllInputsSetRequest');
+  static const MessageType MessageType_MoneroTransactionAllInputsSetAck = MessageType._(510, _omitEnumNames ? '' : 'MessageType_MoneroTransactionAllInputsSetAck');
+  static const MessageType MessageType_MoneroTransactionSetOutputRequest = MessageType._(511, _omitEnumNames ? '' : 'MessageType_MoneroTransactionSetOutputRequest');
+  static const MessageType MessageType_MoneroTransactionSetOutputAck = MessageType._(512, _omitEnumNames ? '' : 'MessageType_MoneroTransactionSetOutputAck');
+  static const MessageType MessageType_MoneroTransactionAllOutSetRequest = MessageType._(513, _omitEnumNames ? '' : 'MessageType_MoneroTransactionAllOutSetRequest');
+  static const MessageType MessageType_MoneroTransactionAllOutSetAck = MessageType._(514, _omitEnumNames ? '' : 'MessageType_MoneroTransactionAllOutSetAck');
+  static const MessageType MessageType_MoneroTransactionSignInputRequest = MessageType._(515, _omitEnumNames ? '' : 'MessageType_MoneroTransactionSignInputRequest');
+  static const MessageType MessageType_MoneroTransactionSignInputAck = MessageType._(516, _omitEnumNames ? '' : 'MessageType_MoneroTransactionSignInputAck');
+  static const MessageType MessageType_MoneroTransactionFinalRequest = MessageType._(517, _omitEnumNames ? '' : 'MessageType_MoneroTransactionFinalRequest');
+  static const MessageType MessageType_MoneroTransactionFinalAck = MessageType._(518, _omitEnumNames ? '' : 'MessageType_MoneroTransactionFinalAck');
+  static const MessageType MessageType_MoneroKeyImageExportInitRequest = MessageType._(530, _omitEnumNames ? '' : 'MessageType_MoneroKeyImageExportInitRequest');
+  static const MessageType MessageType_MoneroKeyImageExportInitAck = MessageType._(531, _omitEnumNames ? '' : 'MessageType_MoneroKeyImageExportInitAck');
+  static const MessageType MessageType_MoneroKeyImageSyncStepRequest = MessageType._(532, _omitEnumNames ? '' : 'MessageType_MoneroKeyImageSyncStepRequest');
+  static const MessageType MessageType_MoneroKeyImageSyncStepAck = MessageType._(533, _omitEnumNames ? '' : 'MessageType_MoneroKeyImageSyncStepAck');
+  static const MessageType MessageType_MoneroKeyImageSyncFinalRequest = MessageType._(534, _omitEnumNames ? '' : 'MessageType_MoneroKeyImageSyncFinalRequest');
+  static const MessageType MessageType_MoneroKeyImageSyncFinalAck = MessageType._(535, _omitEnumNames ? '' : 'MessageType_MoneroKeyImageSyncFinalAck');
+  static const MessageType MessageType_MoneroGetAddress = MessageType._(540, _omitEnumNames ? '' : 'MessageType_MoneroGetAddress');
+  static const MessageType MessageType_MoneroAddress = MessageType._(541, _omitEnumNames ? '' : 'MessageType_MoneroAddress');
+  static const MessageType MessageType_MoneroGetWatchKey = MessageType._(542, _omitEnumNames ? '' : 'MessageType_MoneroGetWatchKey');
+  static const MessageType MessageType_MoneroWatchKey = MessageType._(543, _omitEnumNames ? '' : 'MessageType_MoneroWatchKey');
+  static const MessageType MessageType_DebugMoneroDiagRequest = MessageType._(546, _omitEnumNames ? '' : 'MessageType_DebugMoneroDiagRequest');
+  static const MessageType MessageType_DebugMoneroDiagAck = MessageType._(547, _omitEnumNames ? '' : 'MessageType_DebugMoneroDiagAck');
+  static const MessageType MessageType_MoneroGetTxKeyRequest = MessageType._(550, _omitEnumNames ? '' : 'MessageType_MoneroGetTxKeyRequest');
+  static const MessageType MessageType_MoneroGetTxKeyAck = MessageType._(551, _omitEnumNames ? '' : 'MessageType_MoneroGetTxKeyAck');
+  static const MessageType MessageType_MoneroLiveRefreshStartRequest = MessageType._(552, _omitEnumNames ? '' : 'MessageType_MoneroLiveRefreshStartRequest');
+  static const MessageType MessageType_MoneroLiveRefreshStartAck = MessageType._(553, _omitEnumNames ? '' : 'MessageType_MoneroLiveRefreshStartAck');
+  static const MessageType MessageType_MoneroLiveRefreshStepRequest = MessageType._(554, _omitEnumNames ? '' : 'MessageType_MoneroLiveRefreshStepRequest');
+  static const MessageType MessageType_MoneroLiveRefreshStepAck = MessageType._(555, _omitEnumNames ? '' : 'MessageType_MoneroLiveRefreshStepAck');
+  static const MessageType MessageType_MoneroLiveRefreshFinalRequest = MessageType._(556, _omitEnumNames ? '' : 'MessageType_MoneroLiveRefreshFinalRequest');
+  static const MessageType MessageType_MoneroLiveRefreshFinalAck = MessageType._(557, _omitEnumNames ? '' : 'MessageType_MoneroLiveRefreshFinalAck');
+  static const MessageType MessageType_EosGetPublicKey = MessageType._(600, _omitEnumNames ? '' : 'MessageType_EosGetPublicKey');
+  static const MessageType MessageType_EosPublicKey = MessageType._(601, _omitEnumNames ? '' : 'MessageType_EosPublicKey');
+  static const MessageType MessageType_EosSignTx = MessageType._(602, _omitEnumNames ? '' : 'MessageType_EosSignTx');
+  static const MessageType MessageType_EosTxActionRequest = MessageType._(603, _omitEnumNames ? '' : 'MessageType_EosTxActionRequest');
+  static const MessageType MessageType_EosTxActionAck = MessageType._(604, _omitEnumNames ? '' : 'MessageType_EosTxActionAck');
+  static const MessageType MessageType_EosSignedTx = MessageType._(605, _omitEnumNames ? '' : 'MessageType_EosSignedTx');
+  static const MessageType MessageType_BinanceGetAddress = MessageType._(700, _omitEnumNames ? '' : 'MessageType_BinanceGetAddress');
+  static const MessageType MessageType_BinanceAddress = MessageType._(701, _omitEnumNames ? '' : 'MessageType_BinanceAddress');
+  static const MessageType MessageType_BinanceGetPublicKey = MessageType._(702, _omitEnumNames ? '' : 'MessageType_BinanceGetPublicKey');
+  static const MessageType MessageType_BinancePublicKey = MessageType._(703, _omitEnumNames ? '' : 'MessageType_BinancePublicKey');
+  static const MessageType MessageType_BinanceSignTx = MessageType._(704, _omitEnumNames ? '' : 'MessageType_BinanceSignTx');
+  static const MessageType MessageType_BinanceTxRequest = MessageType._(705, _omitEnumNames ? '' : 'MessageType_BinanceTxRequest');
+  static const MessageType MessageType_BinanceTransferMsg = MessageType._(706, _omitEnumNames ? '' : 'MessageType_BinanceTransferMsg');
+  static const MessageType MessageType_BinanceOrderMsg = MessageType._(707, _omitEnumNames ? '' : 'MessageType_BinanceOrderMsg');
+  static const MessageType MessageType_BinanceCancelMsg = MessageType._(708, _omitEnumNames ? '' : 'MessageType_BinanceCancelMsg');
+  static const MessageType MessageType_BinanceSignedTx = MessageType._(709, _omitEnumNames ? '' : 'MessageType_BinanceSignedTx');
+  static const MessageType MessageType_WebAuthnListResidentCredentials = MessageType._(800, _omitEnumNames ? '' : 'MessageType_WebAuthnListResidentCredentials');
+  static const MessageType MessageType_WebAuthnCredentials = MessageType._(801, _omitEnumNames ? '' : 'MessageType_WebAuthnCredentials');
+  static const MessageType MessageType_WebAuthnAddResidentCredential = MessageType._(802, _omitEnumNames ? '' : 'MessageType_WebAuthnAddResidentCredential');
+  static const MessageType MessageType_WebAuthnRemoveResidentCredential = MessageType._(803, _omitEnumNames ? '' : 'MessageType_WebAuthnRemoveResidentCredential');
+  static const MessageType MessageType_SolanaGetPublicKey = MessageType._(900, _omitEnumNames ? '' : 'MessageType_SolanaGetPublicKey');
+  static const MessageType MessageType_SolanaPublicKey = MessageType._(901, _omitEnumNames ? '' : 'MessageType_SolanaPublicKey');
+  static const MessageType MessageType_SolanaGetAddress = MessageType._(902, _omitEnumNames ? '' : 'MessageType_SolanaGetAddress');
+  static const MessageType MessageType_SolanaAddress = MessageType._(903, _omitEnumNames ? '' : 'MessageType_SolanaAddress');
+  static const MessageType MessageType_SolanaSignTx = MessageType._(904, _omitEnumNames ? '' : 'MessageType_SolanaSignTx');
+  static const MessageType MessageType_SolanaTxSignature = MessageType._(905, _omitEnumNames ? '' : 'MessageType_SolanaTxSignature');
+
+  static const $core.List<MessageType> values = <MessageType> [
+    MessageType_Initialize,
+    MessageType_Ping,
+    MessageType_Success,
+    MessageType_Failure,
+    MessageType_ChangePin,
+    MessageType_WipeDevice,
+    MessageType_GetEntropy,
+    MessageType_Entropy,
+    MessageType_LoadDevice,
+    MessageType_ResetDevice,
+    MessageType_SetBusy,
+    MessageType_Features,
+    MessageType_PinMatrixRequest,
+    MessageType_PinMatrixAck,
+    MessageType_Cancel,
+    MessageType_LockDevice,
+    MessageType_ApplySettings,
+    MessageType_ButtonRequest,
+    MessageType_ButtonAck,
+    MessageType_ApplyFlags,
+    MessageType_GetNonce,
+    MessageType_Nonce,
+    MessageType_BackupDevice,
+    MessageType_EntropyRequest,
+    MessageType_EntropyAck,
+    MessageType_PassphraseRequest,
+    MessageType_PassphraseAck,
+    MessageType_RecoveryDevice,
+    MessageType_WordRequest,
+    MessageType_WordAck,
+    MessageType_GetFeatures,
+    MessageType_SdProtect,
+    MessageType_ChangeWipeCode,
+    MessageType_EndSession,
+    MessageType_DoPreauthorized,
+    MessageType_PreauthorizedRequest,
+    MessageType_CancelAuthorization,
+    MessageType_RebootToBootloader,
+    MessageType_GetFirmwareHash,
+    MessageType_FirmwareHash,
+    MessageType_UnlockPath,
+    MessageType_UnlockedPathRequest,
+    MessageType_ShowDeviceTutorial,
+    MessageType_UnlockBootloader,
+    MessageType_AuthenticateDevice,
+    MessageType_AuthenticityProof,
+    MessageType_ChangeLanguage,
+    MessageType_TranslationDataRequest,
+    MessageType_TranslationDataAck,
+    MessageType_SetU2FCounter,
+    MessageType_GetNextU2FCounter,
+    MessageType_NextU2FCounter,
+    MessageType_Deprecated_PassphraseStateRequest,
+    MessageType_Deprecated_PassphraseStateAck,
+    MessageType_FirmwareErase,
+    MessageType_FirmwareUpload,
+    MessageType_FirmwareRequest,
+    MessageType_ProdTestT1,
+    MessageType_GetPublicKey,
+    MessageType_PublicKey,
+    MessageType_SignTx,
+    MessageType_TxRequest,
+    MessageType_TxAck,
+    MessageType_GetAddress,
+    MessageType_Address,
+    MessageType_TxAckPaymentRequest,
+    MessageType_SignMessage,
+    MessageType_VerifyMessage,
+    MessageType_MessageSignature,
+    MessageType_GetOwnershipId,
+    MessageType_OwnershipId,
+    MessageType_GetOwnershipProof,
+    MessageType_OwnershipProof,
+    MessageType_AuthorizeCoinJoin,
+    MessageType_CipherKeyValue,
+    MessageType_CipheredKeyValue,
+    MessageType_SignIdentity,
+    MessageType_SignedIdentity,
+    MessageType_GetECDHSessionKey,
+    MessageType_ECDHSessionKey,
+    MessageType_CosiCommit,
+    MessageType_CosiCommitment,
+    MessageType_CosiSign,
+    MessageType_CosiSignature,
+    MessageType_DebugLinkDecision,
+    MessageType_DebugLinkGetState,
+    MessageType_DebugLinkState,
+    MessageType_DebugLinkStop,
+    MessageType_DebugLinkLog,
+    MessageType_DebugLinkMemoryRead,
+    MessageType_DebugLinkMemory,
+    MessageType_DebugLinkMemoryWrite,
+    MessageType_DebugLinkFlashErase,
+    MessageType_DebugLinkLayout,
+    MessageType_DebugLinkReseedRandom,
+    MessageType_DebugLinkRecordScreen,
+    MessageType_DebugLinkEraseSdCard,
+    MessageType_DebugLinkWatchLayout,
+    MessageType_DebugLinkResetDebugEvents,
+    MessageType_EthereumGetPublicKey,
+    MessageType_EthereumPublicKey,
+    MessageType_EthereumGetAddress,
+    MessageType_EthereumAddress,
+    MessageType_EthereumSignTx,
+    MessageType_EthereumSignTxEIP1559,
+    MessageType_EthereumTxRequest,
+    MessageType_EthereumTxAck,
+    MessageType_EthereumSignMessage,
+    MessageType_EthereumVerifyMessage,
+    MessageType_EthereumMessageSignature,
+    MessageType_EthereumSignTypedData,
+    MessageType_EthereumTypedDataStructRequest,
+    MessageType_EthereumTypedDataStructAck,
+    MessageType_EthereumTypedDataValueRequest,
+    MessageType_EthereumTypedDataValueAck,
+    MessageType_EthereumTypedDataSignature,
+    MessageType_EthereumSignTypedHash,
+    MessageType_NEMGetAddress,
+    MessageType_NEMAddress,
+    MessageType_NEMSignTx,
+    MessageType_NEMSignedTx,
+    MessageType_NEMDecryptMessage,
+    MessageType_NEMDecryptedMessage,
+    MessageType_TezosGetAddress,
+    MessageType_TezosAddress,
+    MessageType_TezosSignTx,
+    MessageType_TezosSignedTx,
+    MessageType_TezosGetPublicKey,
+    MessageType_TezosPublicKey,
+    MessageType_StellarSignTx,
+    MessageType_StellarTxOpRequest,
+    MessageType_StellarGetAddress,
+    MessageType_StellarAddress,
+    MessageType_StellarCreateAccountOp,
+    MessageType_StellarPaymentOp,
+    MessageType_StellarPathPaymentStrictReceiveOp,
+    MessageType_StellarManageSellOfferOp,
+    MessageType_StellarCreatePassiveSellOfferOp,
+    MessageType_StellarSetOptionsOp,
+    MessageType_StellarChangeTrustOp,
+    MessageType_StellarAllowTrustOp,
+    MessageType_StellarAccountMergeOp,
+    MessageType_StellarManageDataOp,
+    MessageType_StellarBumpSequenceOp,
+    MessageType_StellarManageBuyOfferOp,
+    MessageType_StellarPathPaymentStrictSendOp,
+    MessageType_StellarClaimClaimableBalanceOp,
+    MessageType_StellarSignedTx,
+    MessageType_CardanoGetPublicKey,
+    MessageType_CardanoPublicKey,
+    MessageType_CardanoGetAddress,
+    MessageType_CardanoAddress,
+    MessageType_CardanoTxItemAck,
+    MessageType_CardanoTxAuxiliaryDataSupplement,
+    MessageType_CardanoTxWitnessRequest,
+    MessageType_CardanoTxWitnessResponse,
+    MessageType_CardanoTxHostAck,
+    MessageType_CardanoTxBodyHash,
+    MessageType_CardanoSignTxFinished,
+    MessageType_CardanoSignTxInit,
+    MessageType_CardanoTxInput,
+    MessageType_CardanoTxOutput,
+    MessageType_CardanoAssetGroup,
+    MessageType_CardanoToken,
+    MessageType_CardanoTxCertificate,
+    MessageType_CardanoTxWithdrawal,
+    MessageType_CardanoTxAuxiliaryData,
+    MessageType_CardanoPoolOwner,
+    MessageType_CardanoPoolRelayParameters,
+    MessageType_CardanoGetNativeScriptHash,
+    MessageType_CardanoNativeScriptHash,
+    MessageType_CardanoTxMint,
+    MessageType_CardanoTxCollateralInput,
+    MessageType_CardanoTxRequiredSigner,
+    MessageType_CardanoTxInlineDatumChunk,
+    MessageType_CardanoTxReferenceScriptChunk,
+    MessageType_CardanoTxReferenceInput,
+    MessageType_RippleGetAddress,
+    MessageType_RippleAddress,
+    MessageType_RippleSignTx,
+    MessageType_RippleSignedTx,
+    MessageType_MoneroTransactionInitRequest,
+    MessageType_MoneroTransactionInitAck,
+    MessageType_MoneroTransactionSetInputRequest,
+    MessageType_MoneroTransactionSetInputAck,
+    MessageType_MoneroTransactionInputViniRequest,
+    MessageType_MoneroTransactionInputViniAck,
+    MessageType_MoneroTransactionAllInputsSetRequest,
+    MessageType_MoneroTransactionAllInputsSetAck,
+    MessageType_MoneroTransactionSetOutputRequest,
+    MessageType_MoneroTransactionSetOutputAck,
+    MessageType_MoneroTransactionAllOutSetRequest,
+    MessageType_MoneroTransactionAllOutSetAck,
+    MessageType_MoneroTransactionSignInputRequest,
+    MessageType_MoneroTransactionSignInputAck,
+    MessageType_MoneroTransactionFinalRequest,
+    MessageType_MoneroTransactionFinalAck,
+    MessageType_MoneroKeyImageExportInitRequest,
+    MessageType_MoneroKeyImageExportInitAck,
+    MessageType_MoneroKeyImageSyncStepRequest,
+    MessageType_MoneroKeyImageSyncStepAck,
+    MessageType_MoneroKeyImageSyncFinalRequest,
+    MessageType_MoneroKeyImageSyncFinalAck,
+    MessageType_MoneroGetAddress,
+    MessageType_MoneroAddress,
+    MessageType_MoneroGetWatchKey,
+    MessageType_MoneroWatchKey,
+    MessageType_DebugMoneroDiagRequest,
+    MessageType_DebugMoneroDiagAck,
+    MessageType_MoneroGetTxKeyRequest,
+    MessageType_MoneroGetTxKeyAck,
+    MessageType_MoneroLiveRefreshStartRequest,
+    MessageType_MoneroLiveRefreshStartAck,
+    MessageType_MoneroLiveRefreshStepRequest,
+    MessageType_MoneroLiveRefreshStepAck,
+    MessageType_MoneroLiveRefreshFinalRequest,
+    MessageType_MoneroLiveRefreshFinalAck,
+    MessageType_EosGetPublicKey,
+    MessageType_EosPublicKey,
+    MessageType_EosSignTx,
+    MessageType_EosTxActionRequest,
+    MessageType_EosTxActionAck,
+    MessageType_EosSignedTx,
+    MessageType_BinanceGetAddress,
+    MessageType_BinanceAddress,
+    MessageType_BinanceGetPublicKey,
+    MessageType_BinancePublicKey,
+    MessageType_BinanceSignTx,
+    MessageType_BinanceTxRequest,
+    MessageType_BinanceTransferMsg,
+    MessageType_BinanceOrderMsg,
+    MessageType_BinanceCancelMsg,
+    MessageType_BinanceSignedTx,
+    MessageType_WebAuthnListResidentCredentials,
+    MessageType_WebAuthnCredentials,
+    MessageType_WebAuthnAddResidentCredential,
+    MessageType_WebAuthnRemoveResidentCredential,
+    MessageType_SolanaGetPublicKey,
+    MessageType_SolanaPublicKey,
+    MessageType_SolanaGetAddress,
+    MessageType_SolanaAddress,
+    MessageType_SolanaSignTx,
+    MessageType_SolanaTxSignature,
+  ];
+
+  static final $core.Map<$core.int, MessageType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static MessageType? valueOf($core.int value) => _byValue[value];
+
+  const MessageType._($core.int v, $core.String n) : super(v, n);
+}
+
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages.pbjson.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages.pbjson.dart
@@ -1,0 +1,480 @@
+//
+//  Generated code. Do not modify.
+//  source: messages.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use messageTypeDescriptor instead')
+const MessageType$json = {
+  '1': 'MessageType',
+  '2': [
+    {'1': 'MessageType_Initialize', '2': 0, '3': {}},
+    {'1': 'MessageType_Ping', '2': 1, '3': {}},
+    {'1': 'MessageType_Success', '2': 2, '3': {}},
+    {'1': 'MessageType_Failure', '2': 3, '3': {}},
+    {'1': 'MessageType_ChangePin', '2': 4, '3': {}},
+    {'1': 'MessageType_WipeDevice', '2': 5, '3': {}},
+    {'1': 'MessageType_GetEntropy', '2': 9, '3': {}},
+    {'1': 'MessageType_Entropy', '2': 10, '3': {}},
+    {'1': 'MessageType_LoadDevice', '2': 13, '3': {}},
+    {'1': 'MessageType_ResetDevice', '2': 14, '3': {}},
+    {'1': 'MessageType_SetBusy', '2': 16, '3': {}},
+    {'1': 'MessageType_Features', '2': 17, '3': {}},
+    {'1': 'MessageType_PinMatrixRequest', '2': 18, '3': {}},
+    {'1': 'MessageType_PinMatrixAck', '2': 19, '3': {}},
+    {'1': 'MessageType_Cancel', '2': 20, '3': {}},
+    {'1': 'MessageType_LockDevice', '2': 24, '3': {}},
+    {'1': 'MessageType_ApplySettings', '2': 25, '3': {}},
+    {'1': 'MessageType_ButtonRequest', '2': 26, '3': {}},
+    {'1': 'MessageType_ButtonAck', '2': 27, '3': {}},
+    {'1': 'MessageType_ApplyFlags', '2': 28, '3': {}},
+    {'1': 'MessageType_GetNonce', '2': 31, '3': {}},
+    {'1': 'MessageType_Nonce', '2': 33, '3': {}},
+    {'1': 'MessageType_BackupDevice', '2': 34, '3': {}},
+    {'1': 'MessageType_EntropyRequest', '2': 35, '3': {}},
+    {'1': 'MessageType_EntropyAck', '2': 36, '3': {}},
+    {'1': 'MessageType_PassphraseRequest', '2': 41, '3': {}},
+    {'1': 'MessageType_PassphraseAck', '2': 42, '3': {}},
+    {'1': 'MessageType_RecoveryDevice', '2': 45, '3': {}},
+    {'1': 'MessageType_WordRequest', '2': 46, '3': {}},
+    {'1': 'MessageType_WordAck', '2': 47, '3': {}},
+    {'1': 'MessageType_GetFeatures', '2': 55, '3': {}},
+    {'1': 'MessageType_SdProtect', '2': 79, '3': {}},
+    {'1': 'MessageType_ChangeWipeCode', '2': 82, '3': {}},
+    {'1': 'MessageType_EndSession', '2': 83, '3': {}},
+    {'1': 'MessageType_DoPreauthorized', '2': 84, '3': {}},
+    {'1': 'MessageType_PreauthorizedRequest', '2': 85, '3': {}},
+    {'1': 'MessageType_CancelAuthorization', '2': 86, '3': {}},
+    {'1': 'MessageType_RebootToBootloader', '2': 87, '3': {}},
+    {'1': 'MessageType_GetFirmwareHash', '2': 88, '3': {}},
+    {'1': 'MessageType_FirmwareHash', '2': 89, '3': {}},
+    {'1': 'MessageType_UnlockPath', '2': 93, '3': {}},
+    {'1': 'MessageType_UnlockedPathRequest', '2': 94, '3': {}},
+    {'1': 'MessageType_ShowDeviceTutorial', '2': 95, '3': {}},
+    {'1': 'MessageType_UnlockBootloader', '2': 96, '3': {}},
+    {'1': 'MessageType_AuthenticateDevice', '2': 97, '3': {}},
+    {'1': 'MessageType_AuthenticityProof', '2': 98, '3': {}},
+    {'1': 'MessageType_ChangeLanguage', '2': 990, '3': {}},
+    {'1': 'MessageType_TranslationDataRequest', '2': 991, '3': {}},
+    {'1': 'MessageType_TranslationDataAck', '2': 992, '3': {}},
+    {'1': 'MessageType_SetU2FCounter', '2': 63, '3': {}},
+    {'1': 'MessageType_GetNextU2FCounter', '2': 80, '3': {}},
+    {'1': 'MessageType_NextU2FCounter', '2': 81, '3': {}},
+    {
+      '1': 'MessageType_Deprecated_PassphraseStateRequest',
+      '2': 77,
+      '3': {'1': true},
+    },
+    {
+      '1': 'MessageType_Deprecated_PassphraseStateAck',
+      '2': 78,
+      '3': {'1': true},
+    },
+    {'1': 'MessageType_FirmwareErase', '2': 6, '3': {}},
+    {'1': 'MessageType_FirmwareUpload', '2': 7, '3': {}},
+    {'1': 'MessageType_FirmwareRequest', '2': 8, '3': {}},
+    {'1': 'MessageType_ProdTestT1', '2': 32, '3': {}},
+    {'1': 'MessageType_GetPublicKey', '2': 11, '3': {}},
+    {'1': 'MessageType_PublicKey', '2': 12, '3': {}},
+    {'1': 'MessageType_SignTx', '2': 15, '3': {}},
+    {'1': 'MessageType_TxRequest', '2': 21, '3': {}},
+    {'1': 'MessageType_TxAck', '2': 22, '3': {}},
+    {'1': 'MessageType_GetAddress', '2': 29, '3': {}},
+    {'1': 'MessageType_Address', '2': 30, '3': {}},
+    {'1': 'MessageType_TxAckPaymentRequest', '2': 37, '3': {}},
+    {'1': 'MessageType_SignMessage', '2': 38, '3': {}},
+    {'1': 'MessageType_VerifyMessage', '2': 39, '3': {}},
+    {'1': 'MessageType_MessageSignature', '2': 40, '3': {}},
+    {'1': 'MessageType_GetOwnershipId', '2': 43, '3': {}},
+    {'1': 'MessageType_OwnershipId', '2': 44, '3': {}},
+    {'1': 'MessageType_GetOwnershipProof', '2': 49, '3': {}},
+    {'1': 'MessageType_OwnershipProof', '2': 50, '3': {}},
+    {'1': 'MessageType_AuthorizeCoinJoin', '2': 51, '3': {}},
+    {'1': 'MessageType_CipherKeyValue', '2': 23, '3': {}},
+    {'1': 'MessageType_CipheredKeyValue', '2': 48, '3': {}},
+    {'1': 'MessageType_SignIdentity', '2': 53, '3': {}},
+    {'1': 'MessageType_SignedIdentity', '2': 54, '3': {}},
+    {'1': 'MessageType_GetECDHSessionKey', '2': 61, '3': {}},
+    {'1': 'MessageType_ECDHSessionKey', '2': 62, '3': {}},
+    {'1': 'MessageType_CosiCommit', '2': 71, '3': {}},
+    {'1': 'MessageType_CosiCommitment', '2': 72, '3': {}},
+    {'1': 'MessageType_CosiSign', '2': 73, '3': {}},
+    {'1': 'MessageType_CosiSignature', '2': 74, '3': {}},
+    {'1': 'MessageType_DebugLinkDecision', '2': 100, '3': {}},
+    {'1': 'MessageType_DebugLinkGetState', '2': 101, '3': {}},
+    {'1': 'MessageType_DebugLinkState', '2': 102, '3': {}},
+    {'1': 'MessageType_DebugLinkStop', '2': 103, '3': {}},
+    {'1': 'MessageType_DebugLinkLog', '2': 104, '3': {}},
+    {'1': 'MessageType_DebugLinkMemoryRead', '2': 110, '3': {}},
+    {'1': 'MessageType_DebugLinkMemory', '2': 111, '3': {}},
+    {'1': 'MessageType_DebugLinkMemoryWrite', '2': 112, '3': {}},
+    {'1': 'MessageType_DebugLinkFlashErase', '2': 113, '3': {}},
+    {'1': 'MessageType_DebugLinkLayout', '2': 9001, '3': {}},
+    {'1': 'MessageType_DebugLinkReseedRandom', '2': 9002, '3': {}},
+    {'1': 'MessageType_DebugLinkRecordScreen', '2': 9003, '3': {}},
+    {'1': 'MessageType_DebugLinkEraseSdCard', '2': 9005, '3': {}},
+    {'1': 'MessageType_DebugLinkWatchLayout', '2': 9006, '3': {}},
+    {'1': 'MessageType_DebugLinkResetDebugEvents', '2': 9007, '3': {}},
+    {'1': 'MessageType_EthereumGetPublicKey', '2': 450, '3': {}},
+    {'1': 'MessageType_EthereumPublicKey', '2': 451, '3': {}},
+    {'1': 'MessageType_EthereumGetAddress', '2': 56, '3': {}},
+    {'1': 'MessageType_EthereumAddress', '2': 57, '3': {}},
+    {'1': 'MessageType_EthereumSignTx', '2': 58, '3': {}},
+    {'1': 'MessageType_EthereumSignTxEIP1559', '2': 452, '3': {}},
+    {'1': 'MessageType_EthereumTxRequest', '2': 59, '3': {}},
+    {'1': 'MessageType_EthereumTxAck', '2': 60, '3': {}},
+    {'1': 'MessageType_EthereumSignMessage', '2': 64, '3': {}},
+    {'1': 'MessageType_EthereumVerifyMessage', '2': 65, '3': {}},
+    {'1': 'MessageType_EthereumMessageSignature', '2': 66, '3': {}},
+    {'1': 'MessageType_EthereumSignTypedData', '2': 464, '3': {}},
+    {'1': 'MessageType_EthereumTypedDataStructRequest', '2': 465, '3': {}},
+    {'1': 'MessageType_EthereumTypedDataStructAck', '2': 466, '3': {}},
+    {'1': 'MessageType_EthereumTypedDataValueRequest', '2': 467, '3': {}},
+    {'1': 'MessageType_EthereumTypedDataValueAck', '2': 468, '3': {}},
+    {'1': 'MessageType_EthereumTypedDataSignature', '2': 469, '3': {}},
+    {'1': 'MessageType_EthereumSignTypedHash', '2': 470, '3': {}},
+    {'1': 'MessageType_NEMGetAddress', '2': 67, '3': {}},
+    {'1': 'MessageType_NEMAddress', '2': 68, '3': {}},
+    {'1': 'MessageType_NEMSignTx', '2': 69, '3': {}},
+    {'1': 'MessageType_NEMSignedTx', '2': 70, '3': {}},
+    {'1': 'MessageType_NEMDecryptMessage', '2': 75, '3': {}},
+    {'1': 'MessageType_NEMDecryptedMessage', '2': 76, '3': {}},
+    {'1': 'MessageType_TezosGetAddress', '2': 150, '3': {}},
+    {'1': 'MessageType_TezosAddress', '2': 151, '3': {}},
+    {'1': 'MessageType_TezosSignTx', '2': 152, '3': {}},
+    {'1': 'MessageType_TezosSignedTx', '2': 153, '3': {}},
+    {'1': 'MessageType_TezosGetPublicKey', '2': 154, '3': {}},
+    {'1': 'MessageType_TezosPublicKey', '2': 155, '3': {}},
+    {'1': 'MessageType_StellarSignTx', '2': 202, '3': {}},
+    {'1': 'MessageType_StellarTxOpRequest', '2': 203, '3': {}},
+    {'1': 'MessageType_StellarGetAddress', '2': 207, '3': {}},
+    {'1': 'MessageType_StellarAddress', '2': 208, '3': {}},
+    {'1': 'MessageType_StellarCreateAccountOp', '2': 210, '3': {}},
+    {'1': 'MessageType_StellarPaymentOp', '2': 211, '3': {}},
+    {'1': 'MessageType_StellarPathPaymentStrictReceiveOp', '2': 212, '3': {}},
+    {'1': 'MessageType_StellarManageSellOfferOp', '2': 213, '3': {}},
+    {'1': 'MessageType_StellarCreatePassiveSellOfferOp', '2': 214, '3': {}},
+    {'1': 'MessageType_StellarSetOptionsOp', '2': 215, '3': {}},
+    {'1': 'MessageType_StellarChangeTrustOp', '2': 216, '3': {}},
+    {'1': 'MessageType_StellarAllowTrustOp', '2': 217, '3': {}},
+    {'1': 'MessageType_StellarAccountMergeOp', '2': 218, '3': {}},
+    {'1': 'MessageType_StellarManageDataOp', '2': 220, '3': {}},
+    {'1': 'MessageType_StellarBumpSequenceOp', '2': 221, '3': {}},
+    {'1': 'MessageType_StellarManageBuyOfferOp', '2': 222, '3': {}},
+    {'1': 'MessageType_StellarPathPaymentStrictSendOp', '2': 223, '3': {}},
+    {'1': 'MessageType_StellarClaimClaimableBalanceOp', '2': 225, '3': {}},
+    {'1': 'MessageType_StellarSignedTx', '2': 230, '3': {}},
+    {'1': 'MessageType_CardanoGetPublicKey', '2': 305, '3': {}},
+    {'1': 'MessageType_CardanoPublicKey', '2': 306, '3': {}},
+    {'1': 'MessageType_CardanoGetAddress', '2': 307, '3': {}},
+    {'1': 'MessageType_CardanoAddress', '2': 308, '3': {}},
+    {'1': 'MessageType_CardanoTxItemAck', '2': 313, '3': {}},
+    {'1': 'MessageType_CardanoTxAuxiliaryDataSupplement', '2': 314, '3': {}},
+    {'1': 'MessageType_CardanoTxWitnessRequest', '2': 315, '3': {}},
+    {'1': 'MessageType_CardanoTxWitnessResponse', '2': 316, '3': {}},
+    {'1': 'MessageType_CardanoTxHostAck', '2': 317, '3': {}},
+    {'1': 'MessageType_CardanoTxBodyHash', '2': 318, '3': {}},
+    {'1': 'MessageType_CardanoSignTxFinished', '2': 319, '3': {}},
+    {'1': 'MessageType_CardanoSignTxInit', '2': 320, '3': {}},
+    {'1': 'MessageType_CardanoTxInput', '2': 321, '3': {}},
+    {'1': 'MessageType_CardanoTxOutput', '2': 322, '3': {}},
+    {'1': 'MessageType_CardanoAssetGroup', '2': 323, '3': {}},
+    {'1': 'MessageType_CardanoToken', '2': 324, '3': {}},
+    {'1': 'MessageType_CardanoTxCertificate', '2': 325, '3': {}},
+    {'1': 'MessageType_CardanoTxWithdrawal', '2': 326, '3': {}},
+    {'1': 'MessageType_CardanoTxAuxiliaryData', '2': 327, '3': {}},
+    {'1': 'MessageType_CardanoPoolOwner', '2': 328, '3': {}},
+    {'1': 'MessageType_CardanoPoolRelayParameters', '2': 329, '3': {}},
+    {'1': 'MessageType_CardanoGetNativeScriptHash', '2': 330, '3': {}},
+    {'1': 'MessageType_CardanoNativeScriptHash', '2': 331, '3': {}},
+    {'1': 'MessageType_CardanoTxMint', '2': 332, '3': {}},
+    {'1': 'MessageType_CardanoTxCollateralInput', '2': 333, '3': {}},
+    {'1': 'MessageType_CardanoTxRequiredSigner', '2': 334, '3': {}},
+    {'1': 'MessageType_CardanoTxInlineDatumChunk', '2': 335, '3': {}},
+    {'1': 'MessageType_CardanoTxReferenceScriptChunk', '2': 336, '3': {}},
+    {'1': 'MessageType_CardanoTxReferenceInput', '2': 337, '3': {}},
+    {'1': 'MessageType_RippleGetAddress', '2': 400, '3': {}},
+    {'1': 'MessageType_RippleAddress', '2': 401, '3': {}},
+    {'1': 'MessageType_RippleSignTx', '2': 402, '3': {}},
+    {'1': 'MessageType_RippleSignedTx', '2': 403, '3': {}},
+    {'1': 'MessageType_MoneroTransactionInitRequest', '2': 501, '3': {}},
+    {'1': 'MessageType_MoneroTransactionInitAck', '2': 502, '3': {}},
+    {'1': 'MessageType_MoneroTransactionSetInputRequest', '2': 503, '3': {}},
+    {'1': 'MessageType_MoneroTransactionSetInputAck', '2': 504, '3': {}},
+    {'1': 'MessageType_MoneroTransactionInputViniRequest', '2': 507, '3': {}},
+    {'1': 'MessageType_MoneroTransactionInputViniAck', '2': 508, '3': {}},
+    {'1': 'MessageType_MoneroTransactionAllInputsSetRequest', '2': 509, '3': {}},
+    {'1': 'MessageType_MoneroTransactionAllInputsSetAck', '2': 510, '3': {}},
+    {'1': 'MessageType_MoneroTransactionSetOutputRequest', '2': 511, '3': {}},
+    {'1': 'MessageType_MoneroTransactionSetOutputAck', '2': 512, '3': {}},
+    {'1': 'MessageType_MoneroTransactionAllOutSetRequest', '2': 513, '3': {}},
+    {'1': 'MessageType_MoneroTransactionAllOutSetAck', '2': 514, '3': {}},
+    {'1': 'MessageType_MoneroTransactionSignInputRequest', '2': 515, '3': {}},
+    {'1': 'MessageType_MoneroTransactionSignInputAck', '2': 516, '3': {}},
+    {'1': 'MessageType_MoneroTransactionFinalRequest', '2': 517, '3': {}},
+    {'1': 'MessageType_MoneroTransactionFinalAck', '2': 518, '3': {}},
+    {'1': 'MessageType_MoneroKeyImageExportInitRequest', '2': 530, '3': {}},
+    {'1': 'MessageType_MoneroKeyImageExportInitAck', '2': 531, '3': {}},
+    {'1': 'MessageType_MoneroKeyImageSyncStepRequest', '2': 532, '3': {}},
+    {'1': 'MessageType_MoneroKeyImageSyncStepAck', '2': 533, '3': {}},
+    {'1': 'MessageType_MoneroKeyImageSyncFinalRequest', '2': 534, '3': {}},
+    {'1': 'MessageType_MoneroKeyImageSyncFinalAck', '2': 535, '3': {}},
+    {'1': 'MessageType_MoneroGetAddress', '2': 540, '3': {}},
+    {'1': 'MessageType_MoneroAddress', '2': 541, '3': {}},
+    {'1': 'MessageType_MoneroGetWatchKey', '2': 542, '3': {}},
+    {'1': 'MessageType_MoneroWatchKey', '2': 543, '3': {}},
+    {'1': 'MessageType_DebugMoneroDiagRequest', '2': 546, '3': {}},
+    {'1': 'MessageType_DebugMoneroDiagAck', '2': 547, '3': {}},
+    {'1': 'MessageType_MoneroGetTxKeyRequest', '2': 550, '3': {}},
+    {'1': 'MessageType_MoneroGetTxKeyAck', '2': 551, '3': {}},
+    {'1': 'MessageType_MoneroLiveRefreshStartRequest', '2': 552, '3': {}},
+    {'1': 'MessageType_MoneroLiveRefreshStartAck', '2': 553, '3': {}},
+    {'1': 'MessageType_MoneroLiveRefreshStepRequest', '2': 554, '3': {}},
+    {'1': 'MessageType_MoneroLiveRefreshStepAck', '2': 555, '3': {}},
+    {'1': 'MessageType_MoneroLiveRefreshFinalRequest', '2': 556, '3': {}},
+    {'1': 'MessageType_MoneroLiveRefreshFinalAck', '2': 557, '3': {}},
+    {'1': 'MessageType_EosGetPublicKey', '2': 600, '3': {}},
+    {'1': 'MessageType_EosPublicKey', '2': 601, '3': {}},
+    {'1': 'MessageType_EosSignTx', '2': 602, '3': {}},
+    {'1': 'MessageType_EosTxActionRequest', '2': 603, '3': {}},
+    {'1': 'MessageType_EosTxActionAck', '2': 604, '3': {}},
+    {'1': 'MessageType_EosSignedTx', '2': 605, '3': {}},
+    {'1': 'MessageType_BinanceGetAddress', '2': 700, '3': {}},
+    {'1': 'MessageType_BinanceAddress', '2': 701, '3': {}},
+    {'1': 'MessageType_BinanceGetPublicKey', '2': 702, '3': {}},
+    {'1': 'MessageType_BinancePublicKey', '2': 703, '3': {}},
+    {'1': 'MessageType_BinanceSignTx', '2': 704, '3': {}},
+    {'1': 'MessageType_BinanceTxRequest', '2': 705, '3': {}},
+    {'1': 'MessageType_BinanceTransferMsg', '2': 706, '3': {}},
+    {'1': 'MessageType_BinanceOrderMsg', '2': 707, '3': {}},
+    {'1': 'MessageType_BinanceCancelMsg', '2': 708, '3': {}},
+    {'1': 'MessageType_BinanceSignedTx', '2': 709, '3': {}},
+    {'1': 'MessageType_WebAuthnListResidentCredentials', '2': 800, '3': {}},
+    {'1': 'MessageType_WebAuthnCredentials', '2': 801, '3': {}},
+    {'1': 'MessageType_WebAuthnAddResidentCredential', '2': 802, '3': {}},
+    {'1': 'MessageType_WebAuthnRemoveResidentCredential', '2': 803, '3': {}},
+    {'1': 'MessageType_SolanaGetPublicKey', '2': 900, '3': {}},
+    {'1': 'MessageType_SolanaPublicKey', '2': 901, '3': {}},
+    {'1': 'MessageType_SolanaGetAddress', '2': 902, '3': {}},
+    {'1': 'MessageType_SolanaAddress', '2': 903, '3': {}},
+    {'1': 'MessageType_SolanaSignTx', '2': 904, '3': {}},
+    {'1': 'MessageType_SolanaTxSignature', '2': 905, '3': {}},
+  ],
+  '3': {},
+  '4': [
+    {'1': 90, '2': 92},
+    {'1': 114, '2': 122},
+    {'1': 219, '2': 219},
+    {'1': 224, '2': 224},
+    {'1': 300, '2': 304},
+    {'1': 309, '2': 312},
+  ],
+};
+
+/// Descriptor for `MessageType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List messageTypeDescriptor = $convert.base64Decode(
+    'CgtNZXNzYWdlVHlwZRIoChZNZXNzYWdlVHlwZV9Jbml0aWFsaXplEAAaDICmHQGQtRgBsLUYAR'
+    'IeChBNZXNzYWdlVHlwZV9QaW5nEAEaCICmHQGQtRgBEiUKE01lc3NhZ2VUeXBlX1N1Y2Nlc3MQ'
+    'AhoMgKYdAZi1GAGotRgBEiUKE01lc3NhZ2VUeXBlX0ZhaWx1cmUQAxoMgKYdAZi1GAGotRgBEi'
+    'MKFU1lc3NhZ2VUeXBlX0NoYW5nZVBpbhAEGgiAph0BkLUYARIkChZNZXNzYWdlVHlwZV9XaXBl'
+    'RGV2aWNlEAUaCICmHQGQtRgBEiQKFk1lc3NhZ2VUeXBlX0dldEVudHJvcHkQCRoIgKYdAZC1GA'
+    'ESIQoTTWVzc2FnZVR5cGVfRW50cm9weRAKGgiAph0BmLUYARIkChZNZXNzYWdlVHlwZV9Mb2Fk'
+    'RGV2aWNlEA0aCICmHQGQtRgBEiUKF01lc3NhZ2VUeXBlX1Jlc2V0RGV2aWNlEA4aCICmHQGQtR'
+    'gBEiEKE01lc3NhZ2VUeXBlX1NldEJ1c3kQEBoIgKYdAZC1GAESIgoUTWVzc2FnZVR5cGVfRmVh'
+    'dHVyZXMQERoIgKYdAZi1GAESKgocTWVzc2FnZVR5cGVfUGluTWF0cml4UmVxdWVzdBASGgiAph'
+    '0BmLUYARIuChhNZXNzYWdlVHlwZV9QaW5NYXRyaXhBY2sQExoQgKYdAZC1GAGwtRgBwLUYARIk'
+    'ChJNZXNzYWdlVHlwZV9DYW5jZWwQFBoMgKYdAZC1GAGwtRgBEiQKFk1lc3NhZ2VUeXBlX0xvY2'
+    'tEZXZpY2UQGBoIgKYdAZC1GAESJwoZTWVzc2FnZVR5cGVfQXBwbHlTZXR0aW5ncxAZGgiAph0B'
+    'kLUYARInChlNZXNzYWdlVHlwZV9CdXR0b25SZXF1ZXN0EBoaCICmHQGYtRgBEisKFU1lc3NhZ2'
+    'VUeXBlX0J1dHRvbkFjaxAbGhCAph0BkLUYAbC1GAHAtRgBEiQKFk1lc3NhZ2VUeXBlX0FwcGx5'
+    'RmxhZ3MQHBoIgKYdAZC1GAESIgoUTWVzc2FnZVR5cGVfR2V0Tm9uY2UQHxoIgKYdAZC1GAESHw'
+    'oRTWVzc2FnZVR5cGVfTm9uY2UQIRoIgKYdAZi1GAESJgoYTWVzc2FnZVR5cGVfQmFja3VwRGV2'
+    'aWNlECIaCICmHQGQtRgBEigKGk1lc3NhZ2VUeXBlX0VudHJvcHlSZXF1ZXN0ECMaCICmHQGYtR'
+    'gBEiQKFk1lc3NhZ2VUeXBlX0VudHJvcHlBY2sQJBoIgKYdAZC1GAESKwodTWVzc2FnZVR5cGVf'
+    'UGFzc3BocmFzZVJlcXVlc3QQKRoIgKYdAZi1GAESLwoZTWVzc2FnZVR5cGVfUGFzc3BocmFzZU'
+    'FjaxAqGhCAph0BkLUYAbC1GAHAtRgBEigKGk1lc3NhZ2VUeXBlX1JlY292ZXJ5RGV2aWNlEC0a'
+    'CICmHQGQtRgBEiUKF01lc3NhZ2VUeXBlX1dvcmRSZXF1ZXN0EC4aCICmHQGYtRgBEiEKE01lc3'
+    'NhZ2VUeXBlX1dvcmRBY2sQLxoIgKYdAZC1GAESJQoXTWVzc2FnZVR5cGVfR2V0RmVhdHVyZXMQ'
+    'NxoIgKYdAZC1GAESIwoVTWVzc2FnZVR5cGVfU2RQcm90ZWN0EE8aCICmHQGQtRgBEigKGk1lc3'
+    'NhZ2VUeXBlX0NoYW5nZVdpcGVDb2RlEFIaCICmHQGQtRgBEiQKFk1lc3NhZ2VUeXBlX0VuZFNl'
+    'c3Npb24QUxoIgKYdAZC1GAESKQobTWVzc2FnZVR5cGVfRG9QcmVhdXRob3JpemVkEFQaCICmHQ'
+    'GQtRgBEi4KIE1lc3NhZ2VUeXBlX1ByZWF1dGhvcml6ZWRSZXF1ZXN0EFUaCICmHQGYtRgBEi0K'
+    'H01lc3NhZ2VUeXBlX0NhbmNlbEF1dGhvcml6YXRpb24QVhoIgKYdAZC1GAESLAoeTWVzc2FnZV'
+    'R5cGVfUmVib290VG9Cb290bG9hZGVyEFcaCICmHQGQtRgBEikKG01lc3NhZ2VUeXBlX0dldEZp'
+    'cm13YXJlSGFzaBBYGgiAph0BkLUYARImChhNZXNzYWdlVHlwZV9GaXJtd2FyZUhhc2gQWRoIgK'
+    'YdAZi1GAESJAoWTWVzc2FnZVR5cGVfVW5sb2NrUGF0aBBdGgiAph0BkLUYARItCh9NZXNzYWdl'
+    'VHlwZV9VbmxvY2tlZFBhdGhSZXF1ZXN0EF4aCICmHQGYtRgBEiwKHk1lc3NhZ2VUeXBlX1Nob3'
+    'dEZXZpY2VUdXRvcmlhbBBfGgiAph0BkLUYARIqChxNZXNzYWdlVHlwZV9VbmxvY2tCb290bG9h'
+    'ZGVyEGAaCICmHQGQtRgBEiwKHk1lc3NhZ2VUeXBlX0F1dGhlbnRpY2F0ZURldmljZRBhGgiAph'
+    '0BmLUYARIrCh1NZXNzYWdlVHlwZV9BdXRoZW50aWNpdHlQcm9vZhBiGgiAph0BkLUYARIpChpN'
+    'ZXNzYWdlVHlwZV9DaGFuZ2VMYW5ndWFnZRDeBxoIgKYdAZC1GAESMQoiTWVzc2FnZVR5cGVfVH'
+    'JhbnNsYXRpb25EYXRhUmVxdWVzdBDfBxoIgKYdAZi1GAESLQoeTWVzc2FnZVR5cGVfVHJhbnNs'
+    'YXRpb25EYXRhQWNrEOAHGgiAph0BkLUYARIjChlNZXNzYWdlVHlwZV9TZXRVMkZDb3VudGVyED'
+    '8aBJC1GAESJwodTWVzc2FnZVR5cGVfR2V0TmV4dFUyRkNvdW50ZXIQUBoEkLUYARIkChpNZXNz'
+    'YWdlVHlwZV9OZXh0VTJGQ291bnRlchBRGgSYtRgBEjUKLU1lc3NhZ2VUeXBlX0RlcHJlY2F0ZW'
+    'RfUGFzc3BocmFzZVN0YXRlUmVxdWVzdBBNGgIIARIxCilNZXNzYWdlVHlwZV9EZXByZWNhdGVk'
+    'X1Bhc3NwaHJhc2VTdGF0ZUFjaxBOGgIIARIrChlNZXNzYWdlVHlwZV9GaXJtd2FyZUVyYXNlEA'
+    'YaDICmHQGQtRgBuLUYARIsChpNZXNzYWdlVHlwZV9GaXJtd2FyZVVwbG9hZBAHGgyAph0BkLUY'
+    'Abi1GAESLQobTWVzc2FnZVR5cGVfRmlybXdhcmVSZXF1ZXN0EAgaDICmHQGYtRgBuLUYARIoCh'
+    'ZNZXNzYWdlVHlwZV9Qcm9kVGVzdFQxECAaDICmHQGQtRgBuLUYARImChhNZXNzYWdlVHlwZV9H'
+    'ZXRQdWJsaWNLZXkQCxoIgKYdAZC1GAESIwoVTWVzc2FnZVR5cGVfUHVibGljS2V5EAwaCICmHQ'
+    'GYtRgBEiAKEk1lc3NhZ2VUeXBlX1NpZ25UeBAPGgiAph0BkLUYARIjChVNZXNzYWdlVHlwZV9U'
+    'eFJlcXVlc3QQFRoIgKYdAZi1GAESHwoRTWVzc2FnZVR5cGVfVHhBY2sQFhoIgKYdAZC1GAESJA'
+    'oWTWVzc2FnZVR5cGVfR2V0QWRkcmVzcxAdGgiAph0BkLUYARIhChNNZXNzYWdlVHlwZV9BZGRy'
+    'ZXNzEB4aCICmHQGYtRgBEikKH01lc3NhZ2VUeXBlX1R4QWNrUGF5bWVudFJlcXVlc3QQJRoEkL'
+    'UYARIlChdNZXNzYWdlVHlwZV9TaWduTWVzc2FnZRAmGgiAph0BkLUYARInChlNZXNzYWdlVHlw'
+    'ZV9WZXJpZnlNZXNzYWdlECcaCICmHQGQtRgBEioKHE1lc3NhZ2VUeXBlX01lc3NhZ2VTaWduYX'
+    'R1cmUQKBoIgKYdAZi1GAESKAoaTWVzc2FnZVR5cGVfR2V0T3duZXJzaGlwSWQQKxoIgKYdAZC1'
+    'GAESJQoXTWVzc2FnZVR5cGVfT3duZXJzaGlwSWQQLBoIgKYdAZi1GAESKwodTWVzc2FnZVR5cG'
+    'VfR2V0T3duZXJzaGlwUHJvb2YQMRoIgKYdAZC1GAESKAoaTWVzc2FnZVR5cGVfT3duZXJzaGlw'
+    'UHJvb2YQMhoIgKYdAZi1GAESKwodTWVzc2FnZVR5cGVfQXV0aG9yaXplQ29pbkpvaW4QMxoIgK'
+    'YdAZC1GAESKAoaTWVzc2FnZVR5cGVfQ2lwaGVyS2V5VmFsdWUQFxoIgKYdAZC1GAESKgocTWVz'
+    'c2FnZVR5cGVfQ2lwaGVyZWRLZXlWYWx1ZRAwGgiAph0BmLUYARImChhNZXNzYWdlVHlwZV9TaW'
+    'duSWRlbnRpdHkQNRoIgKYdAZC1GAESKAoaTWVzc2FnZVR5cGVfU2lnbmVkSWRlbnRpdHkQNhoI'
+    'gKYdAZi1GAESKwodTWVzc2FnZVR5cGVfR2V0RUNESFNlc3Npb25LZXkQPRoIgKYdAZC1GAESKA'
+    'oaTWVzc2FnZVR5cGVfRUNESFNlc3Npb25LZXkQPhoIgKYdAZi1GAESJAoWTWVzc2FnZVR5cGVf'
+    'Q29zaUNvbW1pdBBHGgiAph0BkLUYARIoChpNZXNzYWdlVHlwZV9Db3NpQ29tbWl0bWVudBBIGg'
+    'iAph0BmLUYARIiChRNZXNzYWdlVHlwZV9Db3NpU2lnbhBJGgiAph0BkLUYARInChlNZXNzYWdl'
+    'VHlwZV9Db3NpU2lnbmF0dXJlEEoaCICmHQGYtRgBEjMKHU1lc3NhZ2VUeXBlX0RlYnVnTGlua0'
+    'RlY2lzaW9uEGQaEICmHQGgtRgBsLUYAcC1GAESLwodTWVzc2FnZVR5cGVfRGVidWdMaW5rR2V0'
+    'U3RhdGUQZRoMgKYdAaC1GAGwtRgBEigKGk1lc3NhZ2VUeXBlX0RlYnVnTGlua1N0YXRlEGYaCI'
+    'CmHQGotRgBEicKGU1lc3NhZ2VUeXBlX0RlYnVnTGlua1N0b3AQZxoIgKYdAaC1GAESJgoYTWVz'
+    'c2FnZVR5cGVfRGVidWdMaW5rTG9nEGgaCICmHQGotRgBEi0KH01lc3NhZ2VUeXBlX0RlYnVnTG'
+    'lua01lbW9yeVJlYWQQbhoIgKYdAaC1GAESKQobTWVzc2FnZVR5cGVfRGVidWdMaW5rTWVtb3J5'
+    'EG8aCICmHQGotRgBEi4KIE1lc3NhZ2VUeXBlX0RlYnVnTGlua01lbW9yeVdyaXRlEHAaCICmHQ'
+    'GgtRgBEi0KH01lc3NhZ2VUeXBlX0RlYnVnTGlua0ZsYXNoRXJhc2UQcRoIgKYdAaC1GAESKgob'
+    'TWVzc2FnZVR5cGVfRGVidWdMaW5rTGF5b3V0EKlGGgiAph0BqLUYARIwCiFNZXNzYWdlVHlwZV'
+    '9EZWJ1Z0xpbmtSZXNlZWRSYW5kb20QqkYaCICmHQGgtRgBEjAKIU1lc3NhZ2VUeXBlX0RlYnVn'
+    'TGlua1JlY29yZFNjcmVlbhCrRhoIgKYdAaC1GAESLwogTWVzc2FnZVR5cGVfRGVidWdMaW5rRX'
+    'Jhc2VTZENhcmQQrUYaCICmHQGgtRgBEi8KIE1lc3NhZ2VUeXBlX0RlYnVnTGlua1dhdGNoTGF5'
+    'b3V0EK5GGgiAph0BoLUYARI0CiVNZXNzYWdlVHlwZV9EZWJ1Z0xpbmtSZXNldERlYnVnRXZlbn'
+    'RzEK9GGgiAph0BoLUYARIrCiBNZXNzYWdlVHlwZV9FdGhlcmV1bUdldFB1YmxpY0tleRDCAxoE'
+    'kLUYARIoCh1NZXNzYWdlVHlwZV9FdGhlcmV1bVB1YmxpY0tleRDDAxoEmLUYARIoCh5NZXNzYW'
+    'dlVHlwZV9FdGhlcmV1bUdldEFkZHJlc3MQOBoEkLUYARIlChtNZXNzYWdlVHlwZV9FdGhlcmV1'
+    'bUFkZHJlc3MQORoEmLUYARIkChpNZXNzYWdlVHlwZV9FdGhlcmV1bVNpZ25UeBA6GgSQtRgBEi'
+    'wKIU1lc3NhZ2VUeXBlX0V0aGVyZXVtU2lnblR4RUlQMTU1ORDEAxoEkLUYARInCh1NZXNzYWdl'
+    'VHlwZV9FdGhlcmV1bVR4UmVxdWVzdBA7GgSYtRgBEiMKGU1lc3NhZ2VUeXBlX0V0aGVyZXVtVH'
+    'hBY2sQPBoEkLUYARIpCh9NZXNzYWdlVHlwZV9FdGhlcmV1bVNpZ25NZXNzYWdlEEAaBJC1GAES'
+    'KwohTWVzc2FnZVR5cGVfRXRoZXJldW1WZXJpZnlNZXNzYWdlEEEaBJC1GAESLgokTWVzc2FnZV'
+    'R5cGVfRXRoZXJldW1NZXNzYWdlU2lnbmF0dXJlEEIaBJi1GAESLAohTWVzc2FnZVR5cGVfRXRo'
+    'ZXJldW1TaWduVHlwZWREYXRhENADGgSQtRgBEjUKKk1lc3NhZ2VUeXBlX0V0aGVyZXVtVHlwZW'
+    'REYXRhU3RydWN0UmVxdWVzdBDRAxoEmLUYARIxCiZNZXNzYWdlVHlwZV9FdGhlcmV1bVR5cGVk'
+    'RGF0YVN0cnVjdEFjaxDSAxoEkLUYARI0CilNZXNzYWdlVHlwZV9FdGhlcmV1bVR5cGVkRGF0YV'
+    'ZhbHVlUmVxdWVzdBDTAxoEmLUYARIwCiVNZXNzYWdlVHlwZV9FdGhlcmV1bVR5cGVkRGF0YVZh'
+    'bHVlQWNrENQDGgSQtRgBEjEKJk1lc3NhZ2VUeXBlX0V0aGVyZXVtVHlwZWREYXRhU2lnbmF0dX'
+    'JlENUDGgSYtRgBEiwKIU1lc3NhZ2VUeXBlX0V0aGVyZXVtU2lnblR5cGVkSGFzaBDWAxoEkLUY'
+    'ARIjChlNZXNzYWdlVHlwZV9ORU1HZXRBZGRyZXNzEEMaBJC1GAESIAoWTWVzc2FnZVR5cGVfTk'
+    'VNQWRkcmVzcxBEGgSYtRgBEh8KFU1lc3NhZ2VUeXBlX05FTVNpZ25UeBBFGgSQtRgBEiEKF01l'
+    'c3NhZ2VUeXBlX05FTVNpZ25lZFR4EEYaBJi1GAESJwodTWVzc2FnZVR5cGVfTkVNRGVjcnlwdE'
+    '1lc3NhZ2UQSxoEkLUYARIpCh9NZXNzYWdlVHlwZV9ORU1EZWNyeXB0ZWRNZXNzYWdlEEwaBJi1'
+    'GAESJgobTWVzc2FnZVR5cGVfVGV6b3NHZXRBZGRyZXNzEJYBGgSQtRgBEiMKGE1lc3NhZ2VUeX'
+    'BlX1Rlem9zQWRkcmVzcxCXARoEmLUYARIiChdNZXNzYWdlVHlwZV9UZXpvc1NpZ25UeBCYARoE'
+    'kLUYARIkChlNZXNzYWdlVHlwZV9UZXpvc1NpZ25lZFR4EJkBGgSYtRgBEigKHU1lc3NhZ2VUeX'
+    'BlX1Rlem9zR2V0UHVibGljS2V5EJoBGgSQtRgBEiUKGk1lc3NhZ2VUeXBlX1Rlem9zUHVibGlj'
+    'S2V5EJsBGgSYtRgBEiQKGU1lc3NhZ2VUeXBlX1N0ZWxsYXJTaWduVHgQygEaBJC1GAESKQoeTW'
+    'Vzc2FnZVR5cGVfU3RlbGxhclR4T3BSZXF1ZXN0EMsBGgSYtRgBEigKHU1lc3NhZ2VUeXBlX1N0'
+    'ZWxsYXJHZXRBZGRyZXNzEM8BGgSQtRgBEiUKGk1lc3NhZ2VUeXBlX1N0ZWxsYXJBZGRyZXNzEN'
+    'ABGgSYtRgBEi0KIk1lc3NhZ2VUeXBlX1N0ZWxsYXJDcmVhdGVBY2NvdW50T3AQ0gEaBJC1GAES'
+    'JwocTWVzc2FnZVR5cGVfU3RlbGxhclBheW1lbnRPcBDTARoEkLUYARI4Ci1NZXNzYWdlVHlwZV'
+    '9TdGVsbGFyUGF0aFBheW1lbnRTdHJpY3RSZWNlaXZlT3AQ1AEaBJC1GAESLwokTWVzc2FnZVR5'
+    'cGVfU3RlbGxhck1hbmFnZVNlbGxPZmZlck9wENUBGgSQtRgBEjYKK01lc3NhZ2VUeXBlX1N0ZW'
+    'xsYXJDcmVhdGVQYXNzaXZlU2VsbE9mZmVyT3AQ1gEaBJC1GAESKgofTWVzc2FnZVR5cGVfU3Rl'
+    'bGxhclNldE9wdGlvbnNPcBDXARoEkLUYARIrCiBNZXNzYWdlVHlwZV9TdGVsbGFyQ2hhbmdlVH'
+    'J1c3RPcBDYARoEkLUYARIqCh9NZXNzYWdlVHlwZV9TdGVsbGFyQWxsb3dUcnVzdE9wENkBGgSQ'
+    'tRgBEiwKIU1lc3NhZ2VUeXBlX1N0ZWxsYXJBY2NvdW50TWVyZ2VPcBDaARoEkLUYARIqCh9NZX'
+    'NzYWdlVHlwZV9TdGVsbGFyTWFuYWdlRGF0YU9wENwBGgSQtRgBEiwKIU1lc3NhZ2VUeXBlX1N0'
+    'ZWxsYXJCdW1wU2VxdWVuY2VPcBDdARoEkLUYARIuCiNNZXNzYWdlVHlwZV9TdGVsbGFyTWFuYW'
+    'dlQnV5T2ZmZXJPcBDeARoEkLUYARI1CipNZXNzYWdlVHlwZV9TdGVsbGFyUGF0aFBheW1lbnRT'
+    'dHJpY3RTZW5kT3AQ3wEaBJC1GAESNQoqTWVzc2FnZVR5cGVfU3RlbGxhckNsYWltQ2xhaW1hYm'
+    'xlQmFsYW5jZU9wEOEBGgSQtRgBEiYKG01lc3NhZ2VUeXBlX1N0ZWxsYXJTaWduZWRUeBDmARoE'
+    'mLUYARIqCh9NZXNzYWdlVHlwZV9DYXJkYW5vR2V0UHVibGljS2V5ELECGgSQtRgBEicKHE1lc3'
+    'NhZ2VUeXBlX0NhcmRhbm9QdWJsaWNLZXkQsgIaBJi1GAESKAodTWVzc2FnZVR5cGVfQ2FyZGFu'
+    'b0dldEFkZHJlc3MQswIaBJC1GAESJQoaTWVzc2FnZVR5cGVfQ2FyZGFub0FkZHJlc3MQtAIaBJ'
+    'i1GAESJwocTWVzc2FnZVR5cGVfQ2FyZGFub1R4SXRlbUFjaxC5AhoEmLUYARI3CixNZXNzYWdl'
+    'VHlwZV9DYXJkYW5vVHhBdXhpbGlhcnlEYXRhU3VwcGxlbWVudBC6AhoEmLUYARIuCiNNZXNzYW'
+    'dlVHlwZV9DYXJkYW5vVHhXaXRuZXNzUmVxdWVzdBC7AhoEkLUYARIvCiRNZXNzYWdlVHlwZV9D'
+    'YXJkYW5vVHhXaXRuZXNzUmVzcG9uc2UQvAIaBJi1GAESJwocTWVzc2FnZVR5cGVfQ2FyZGFub1'
+    'R4SG9zdEFjaxC9AhoEkLUYARIoCh1NZXNzYWdlVHlwZV9DYXJkYW5vVHhCb2R5SGFzaBC+AhoE'
+    'mLUYARIsCiFNZXNzYWdlVHlwZV9DYXJkYW5vU2lnblR4RmluaXNoZWQQvwIaBJi1GAESKAodTW'
+    'Vzc2FnZVR5cGVfQ2FyZGFub1NpZ25UeEluaXQQwAIaBJC1GAESJQoaTWVzc2FnZVR5cGVfQ2Fy'
+    'ZGFub1R4SW5wdXQQwQIaBJC1GAESJgobTWVzc2FnZVR5cGVfQ2FyZGFub1R4T3V0cHV0EMICGg'
+    'SQtRgBEigKHU1lc3NhZ2VUeXBlX0NhcmRhbm9Bc3NldEdyb3VwEMMCGgSQtRgBEiMKGE1lc3Nh'
+    'Z2VUeXBlX0NhcmRhbm9Ub2tlbhDEAhoEkLUYARIrCiBNZXNzYWdlVHlwZV9DYXJkYW5vVHhDZX'
+    'J0aWZpY2F0ZRDFAhoEkLUYARIqCh9NZXNzYWdlVHlwZV9DYXJkYW5vVHhXaXRoZHJhd2FsEMYC'
+    'GgSQtRgBEi0KIk1lc3NhZ2VUeXBlX0NhcmRhbm9UeEF1eGlsaWFyeURhdGEQxwIaBJC1GAESJw'
+    'ocTWVzc2FnZVR5cGVfQ2FyZGFub1Bvb2xPd25lchDIAhoEkLUYARIxCiZNZXNzYWdlVHlwZV9D'
+    'YXJkYW5vUG9vbFJlbGF5UGFyYW1ldGVycxDJAhoEkLUYARIxCiZNZXNzYWdlVHlwZV9DYXJkYW'
+    '5vR2V0TmF0aXZlU2NyaXB0SGFzaBDKAhoEkLUYARIuCiNNZXNzYWdlVHlwZV9DYXJkYW5vTmF0'
+    'aXZlU2NyaXB0SGFzaBDLAhoEmLUYARIkChlNZXNzYWdlVHlwZV9DYXJkYW5vVHhNaW50EMwCGg'
+    'SQtRgBEi8KJE1lc3NhZ2VUeXBlX0NhcmRhbm9UeENvbGxhdGVyYWxJbnB1dBDNAhoEkLUYARIu'
+    'CiNNZXNzYWdlVHlwZV9DYXJkYW5vVHhSZXF1aXJlZFNpZ25lchDOAhoEkLUYARIwCiVNZXNzYW'
+    'dlVHlwZV9DYXJkYW5vVHhJbmxpbmVEYXR1bUNodW5rEM8CGgSQtRgBEjQKKU1lc3NhZ2VUeXBl'
+    'X0NhcmRhbm9UeFJlZmVyZW5jZVNjcmlwdENodW5rENACGgSQtRgBEi4KI01lc3NhZ2VUeXBlX0'
+    'NhcmRhbm9UeFJlZmVyZW5jZUlucHV0ENECGgSQtRgBEicKHE1lc3NhZ2VUeXBlX1JpcHBsZUdl'
+    'dEFkZHJlc3MQkAMaBJC1GAESJAoZTWVzc2FnZVR5cGVfUmlwcGxlQWRkcmVzcxCRAxoEmLUYAR'
+    'IjChhNZXNzYWdlVHlwZV9SaXBwbGVTaWduVHgQkgMaBJC1GAESJQoaTWVzc2FnZVR5cGVfUmlw'
+    'cGxlU2lnbmVkVHgQkwMaBJC1GAESMwooTWVzc2FnZVR5cGVfTW9uZXJvVHJhbnNhY3Rpb25Jbm'
+    'l0UmVxdWVzdBD1AxoEmLUYARIvCiRNZXNzYWdlVHlwZV9Nb25lcm9UcmFuc2FjdGlvbkluaXRB'
+    'Y2sQ9gMaBJi1GAESNwosTWVzc2FnZVR5cGVfTW9uZXJvVHJhbnNhY3Rpb25TZXRJbnB1dFJlcX'
+    'Vlc3QQ9wMaBJi1GAESMwooTWVzc2FnZVR5cGVfTW9uZXJvVHJhbnNhY3Rpb25TZXRJbnB1dEFj'
+    'axD4AxoEmLUYARI4Ci1NZXNzYWdlVHlwZV9Nb25lcm9UcmFuc2FjdGlvbklucHV0VmluaVJlcX'
+    'Vlc3QQ+wMaBJi1GAESNAopTWVzc2FnZVR5cGVfTW9uZXJvVHJhbnNhY3Rpb25JbnB1dFZpbmlB'
+    'Y2sQ/AMaBJi1GAESOwowTWVzc2FnZVR5cGVfTW9uZXJvVHJhbnNhY3Rpb25BbGxJbnB1dHNTZX'
+    'RSZXF1ZXN0EP0DGgSYtRgBEjcKLE1lc3NhZ2VUeXBlX01vbmVyb1RyYW5zYWN0aW9uQWxsSW5w'
+    'dXRzU2V0QWNrEP4DGgSYtRgBEjgKLU1lc3NhZ2VUeXBlX01vbmVyb1RyYW5zYWN0aW9uU2V0T3'
+    'V0cHV0UmVxdWVzdBD/AxoEmLUYARI0CilNZXNzYWdlVHlwZV9Nb25lcm9UcmFuc2FjdGlvblNl'
+    'dE91dHB1dEFjaxCABBoEmLUYARI4Ci1NZXNzYWdlVHlwZV9Nb25lcm9UcmFuc2FjdGlvbkFsbE'
+    '91dFNldFJlcXVlc3QQgQQaBJi1GAESNAopTWVzc2FnZVR5cGVfTW9uZXJvVHJhbnNhY3Rpb25B'
+    'bGxPdXRTZXRBY2sQggQaBJi1GAESOAotTWVzc2FnZVR5cGVfTW9uZXJvVHJhbnNhY3Rpb25TaW'
+    'duSW5wdXRSZXF1ZXN0EIMEGgSYtRgBEjQKKU1lc3NhZ2VUeXBlX01vbmVyb1RyYW5zYWN0aW9u'
+    'U2lnbklucHV0QWNrEIQEGgSYtRgBEjQKKU1lc3NhZ2VUeXBlX01vbmVyb1RyYW5zYWN0aW9uRm'
+    'luYWxSZXF1ZXN0EIUEGgSYtRgBEjAKJU1lc3NhZ2VUeXBlX01vbmVyb1RyYW5zYWN0aW9uRmlu'
+    'YWxBY2sQhgQaBJi1GAESNgorTWVzc2FnZVR5cGVfTW9uZXJvS2V5SW1hZ2VFeHBvcnRJbml0Um'
+    'VxdWVzdBCSBBoEmLUYARIyCidNZXNzYWdlVHlwZV9Nb25lcm9LZXlJbWFnZUV4cG9ydEluaXRB'
+    'Y2sQkwQaBJi1GAESNAopTWVzc2FnZVR5cGVfTW9uZXJvS2V5SW1hZ2VTeW5jU3RlcFJlcXVlc3'
+    'QQlAQaBJi1GAESMAolTWVzc2FnZVR5cGVfTW9uZXJvS2V5SW1hZ2VTeW5jU3RlcEFjaxCVBBoE'
+    'mLUYARI1CipNZXNzYWdlVHlwZV9Nb25lcm9LZXlJbWFnZVN5bmNGaW5hbFJlcXVlc3QQlgQaBJ'
+    'i1GAESMQomTWVzc2FnZVR5cGVfTW9uZXJvS2V5SW1hZ2VTeW5jRmluYWxBY2sQlwQaBJi1GAES'
+    'JwocTWVzc2FnZVR5cGVfTW9uZXJvR2V0QWRkcmVzcxCcBBoEkLUYARIkChlNZXNzYWdlVHlwZV'
+    '9Nb25lcm9BZGRyZXNzEJ0EGgSYtRgBEigKHU1lc3NhZ2VUeXBlX01vbmVyb0dldFdhdGNoS2V5'
+    'EJ4EGgSQtRgBEiUKGk1lc3NhZ2VUeXBlX01vbmVyb1dhdGNoS2V5EJ8EGgSYtRgBEi0KIk1lc3'
+    'NhZ2VUeXBlX0RlYnVnTW9uZXJvRGlhZ1JlcXVlc3QQogQaBJC1GAESKQoeTWVzc2FnZVR5cGVf'
+    'RGVidWdNb25lcm9EaWFnQWNrEKMEGgSYtRgBEiwKIU1lc3NhZ2VUeXBlX01vbmVyb0dldFR4S2'
+    'V5UmVxdWVzdBCmBBoEkLUYARIoCh1NZXNzYWdlVHlwZV9Nb25lcm9HZXRUeEtleUFjaxCnBBoE'
+    'mLUYARI0CilNZXNzYWdlVHlwZV9Nb25lcm9MaXZlUmVmcmVzaFN0YXJ0UmVxdWVzdBCoBBoEkL'
+    'UYARIwCiVNZXNzYWdlVHlwZV9Nb25lcm9MaXZlUmVmcmVzaFN0YXJ0QWNrEKkEGgSYtRgBEjMK'
+    'KE1lc3NhZ2VUeXBlX01vbmVyb0xpdmVSZWZyZXNoU3RlcFJlcXVlc3QQqgQaBJC1GAESLwokTW'
+    'Vzc2FnZVR5cGVfTW9uZXJvTGl2ZVJlZnJlc2hTdGVwQWNrEKsEGgSYtRgBEjQKKU1lc3NhZ2VU'
+    'eXBlX01vbmVyb0xpdmVSZWZyZXNoRmluYWxSZXF1ZXN0EKwEGgSQtRgBEjAKJU1lc3NhZ2VUeX'
+    'BlX01vbmVyb0xpdmVSZWZyZXNoRmluYWxBY2sQrQQaBJi1GAESJgobTWVzc2FnZVR5cGVfRW9z'
+    'R2V0UHVibGljS2V5ENgEGgSQtRgBEiMKGE1lc3NhZ2VUeXBlX0Vvc1B1YmxpY0tleRDZBBoEmL'
+    'UYARIgChVNZXNzYWdlVHlwZV9Fb3NTaWduVHgQ2gQaBJC1GAESKQoeTWVzc2FnZVR5cGVfRW9z'
+    'VHhBY3Rpb25SZXF1ZXN0ENsEGgSYtRgBEiUKGk1lc3NhZ2VUeXBlX0Vvc1R4QWN0aW9uQWNrEN'
+    'wEGgSQtRgBEiIKF01lc3NhZ2VUeXBlX0Vvc1NpZ25lZFR4EN0EGgSYtRgBEigKHU1lc3NhZ2VU'
+    'eXBlX0JpbmFuY2VHZXRBZGRyZXNzELwFGgSQtRgBEiUKGk1lc3NhZ2VUeXBlX0JpbmFuY2VBZG'
+    'RyZXNzEL0FGgSYtRgBEioKH01lc3NhZ2VUeXBlX0JpbmFuY2VHZXRQdWJsaWNLZXkQvgUaBJC1'
+    'GAESJwocTWVzc2FnZVR5cGVfQmluYW5jZVB1YmxpY0tleRC/BRoEmLUYARIkChlNZXNzYWdlVH'
+    'lwZV9CaW5hbmNlU2lnblR4EMAFGgSQtRgBEicKHE1lc3NhZ2VUeXBlX0JpbmFuY2VUeFJlcXVl'
+    'c3QQwQUaBJi1GAESKQoeTWVzc2FnZVR5cGVfQmluYW5jZVRyYW5zZmVyTXNnEMIFGgSQtRgBEi'
+    'YKG01lc3NhZ2VUeXBlX0JpbmFuY2VPcmRlck1zZxDDBRoEkLUYARInChxNZXNzYWdlVHlwZV9C'
+    'aW5hbmNlQ2FuY2VsTXNnEMQFGgSQtRgBEiYKG01lc3NhZ2VUeXBlX0JpbmFuY2VTaWduZWRUeB'
+    'DFBRoEmLUYARI2CitNZXNzYWdlVHlwZV9XZWJBdXRobkxpc3RSZXNpZGVudENyZWRlbnRpYWxz'
+    'EKAGGgSQtRgBEioKH01lc3NhZ2VUeXBlX1dlYkF1dGhuQ3JlZGVudGlhbHMQoQYaBJi1GAESNA'
+    'opTWVzc2FnZVR5cGVfV2ViQXV0aG5BZGRSZXNpZGVudENyZWRlbnRpYWwQogYaBJC1GAESNwos'
+    'TWVzc2FnZVR5cGVfV2ViQXV0aG5SZW1vdmVSZXNpZGVudENyZWRlbnRpYWwQowYaBJC1GAESKQ'
+    'oeTWVzc2FnZVR5cGVfU29sYW5hR2V0UHVibGljS2V5EIQHGgSQtRgBEiYKG01lc3NhZ2VUeXBl'
+    'X1NvbGFuYVB1YmxpY0tleRCFBxoEmLUYARInChxNZXNzYWdlVHlwZV9Tb2xhbmFHZXRBZGRyZX'
+    'NzEIYHGgSQtRgBEiQKGU1lc3NhZ2VUeXBlX1NvbGFuYUFkZHJlc3MQhwcaBJi1GAESIwoYTWVz'
+    'c2FnZVR5cGVfU29sYW5hU2lnblR4EIgHGgSQtRgBEigKHU1lc3NhZ2VUeXBlX1NvbGFuYVR4U2'
+    'lnbmF0dXJlEIkHGgSYtRgBGgTI8xgBIgQIWhBcIgQIchB6IgYI2wEQ2wEiBgjgARDgASIGCKwC'
+    'ELACIgYItQIQuAI=');
+

--- a/lib/trezor_protocol/shared/protobuf/messages_compiled/messages.pbserver.dart
+++ b/lib/trezor_protocol/shared/protobuf/messages_compiled/messages.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: messages.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'messages.pb.dart';
+

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-binance.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-binance.proto
@@ -1,0 +1,158 @@
+syntax = "proto2";
+package hw.trezor.messages.binance;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageBinance";
+
+/** XXX
+
+Most likely, ALL fields in this file should be `required`. We are leaving some optionals
+in place, in cases where the field value continues to the JSON as a string -- on the off
+chance that somebody is relying on the behavior.
+
+*/
+
+/**
+ * Request: Ask the device for a Binance address.
+ * @start
+ * @next BinanceAddress
+ * @next Failure
+ */
+message BinanceGetAddress {
+    repeated uint32 address_n = 1;  // BIP-32-style path to derive the key from master node
+    optional bool show_display = 2; // optionally prompt for confirmation on trezor display
+    optional bool chunkify = 3;     // display the address in chunks of 4 characters
+}
+
+/**
+ * Response: A Binance address.
+ * @end
+ */
+message BinanceAddress {
+    required string address = 1;    // prefixed bech32 Binance address
+}
+
+/**
+ * Request: Ask device for a public key corresponding to address_n path.
+ * @start
+ * @next BinancePublicKey
+ */
+message BinanceGetPublicKey {
+    repeated uint32 address_n = 1;  // BIP-32 path to derive the key from master node
+    optional bool show_display = 2; // optionally show on display before sending the result
+}
+
+/**
+ * Response: A public key corresponding to address_n path.
+ * @end
+ */
+message BinancePublicKey {
+    required bytes public_key = 1;
+}
+
+/**
+ * Request: Starts the Binance transaction protocol flow.
+ * A transaction consists of these common fields and a series of Binance<Any>Msg messages.
+ * These parts form a JSON structure (a string) in Trezor's memory, which is signed to produce a BinanceSignedTx.
+ * @start
+ * @next BinanceTxRequest
+ * @next Failure
+*/
+message BinanceSignTx {
+    repeated uint32 address_n = 1; // BIP-32-style path to derive the key from master node
+    required uint32 msg_count = 2; // count of Binance<Any>Msg to be included in this tx
+    required sint64 account_number = 3;
+    optional string chain_id = 4;
+    optional string memo = 5;
+    required sint64 sequence = 6;
+    required sint64 source = 7;
+    optional bool chunkify = 8;    // display the address in chunks of 4 characters
+}
+
+/**
+ * Response: Trezor requests the next message or signals that it is ready to send a BinanceSignedTx.
+ * @next BinanceTransferMsg
+ * @next BinanceOrderMsg
+ * @next BinanceCancelMsg
+ */
+message BinanceTxRequest {
+}
+
+/**
+ * Request: Ask the device to include a Binance transfer msg in the tx.
+ * @next BinanceSignedTx
+ * @next Failure
+ */
+message BinanceTransferMsg {
+    repeated BinanceInputOutput inputs = 1;
+    repeated BinanceInputOutput outputs = 2;
+    optional bool chunkify = 3;               // display the address in chunks of 4 characters
+
+    message BinanceInputOutput {
+        required string address = 1;
+        repeated BinanceCoin coins = 2;
+    }
+
+    message BinanceCoin {
+        required sint64 amount = 1;
+        required string denom = 2;
+    }
+}
+
+/**
+ * Request: Ask the device to include a Binance order msg in the tx.
+ * @next BinanceSignedTx
+ * @next Failure
+ */
+message BinanceOrderMsg {
+    optional string id = 1;
+    required BinanceOrderType ordertype = 2;
+    required sint64 price = 3;
+    required sint64 quantity = 4;
+    optional string sender = 5;
+    required BinanceOrderSide side = 6;
+    optional string symbol = 7;
+    required BinanceTimeInForce timeinforce = 8;
+
+    enum BinanceOrderType {
+        OT_UNKNOWN = 0;
+        MARKET = 1;
+        LIMIT = 2;
+        OT_RESERVED = 3;
+    }
+
+    enum BinanceOrderSide {
+        SIDE_UNKNOWN = 0;
+        BUY = 1;
+        SELL = 2;
+    }
+
+    enum BinanceTimeInForce {
+        TIF_UNKNOWN = 0;
+        GTE = 1;
+        TIF_RESERVED = 2;
+        IOC = 3;
+    }
+}
+
+/**
+ * Request: Ask the device to include a Binance cancel msg in the tx.
+ * @next BinanceSignedTx
+ * @next Failure
+ */
+message BinanceCancelMsg {
+    optional string refid = 1;
+    optional string sender = 2;
+    optional string symbol = 3;
+}
+
+/**
+ * Response: A transaction signature and public key corresponding to the address_n path in BinanceSignTx.
+ * @end
+ */
+message BinanceSignedTx {
+	required bytes signature = 1;
+    required bytes public_key = 2;
+}
+

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-bitcoin.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-bitcoin.proto
@@ -1,0 +1,628 @@
+syntax = "proto2";
+package hw.trezor.messages.bitcoin;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageBitcoin";
+
+option (include_in_bitcoin_only) = true;
+
+import "messages.proto";
+import "messages-common.proto";
+
+/**
+ * Type of script which will be used for transaction input
+ */
+enum InputScriptType {
+    SPENDADDRESS = 0;       // standard P2PKH address
+    SPENDMULTISIG = 1;      // P2SH multisig address
+    EXTERNAL = 2;           // reserved for external inputs (coinjoin)
+    SPENDWITNESS = 3;       // native SegWit
+    SPENDP2SHWITNESS = 4;   // SegWit over P2SH (backward compatible)
+    SPENDTAPROOT = 5;       // Taproot
+}
+
+/**
+ * Type of script which will be used for transaction output
+ */
+enum OutputScriptType {
+    PAYTOADDRESS = 0;       // used for all addresses (bitcoin, p2sh, witness)
+    PAYTOSCRIPTHASH = 1;    // p2sh address (deprecated; use PAYTOADDRESS)
+    PAYTOMULTISIG = 2;      // only for change output
+    PAYTOOPRETURN = 3;      // op_return
+    PAYTOWITNESS = 4;       // only for change output
+    PAYTOP2SHWITNESS = 5;   // only for change output
+    PAYTOTAPROOT = 6;       // only for change output
+}
+
+/**
+ * Type of script which will be used for decred stake transaction input
+ */
+enum DecredStakingSpendType {
+    SSGen = 0;
+    SSRTX = 1;
+}
+
+/**
+ * Unit to be used when showing amounts on the display
+ */
+enum AmountUnit {
+    BITCOIN = 0;        // BTC
+    MILLIBITCOIN = 1;   // mBTC
+    MICROBITCOIN = 2;   // uBTC
+    SATOSHI = 3;        // sat
+}
+
+/**
+ * Type of redeem script used in input
+ * @embed
+ */
+message MultisigRedeemScriptType {
+    repeated HDNodePathType pubkeys = 1;    // pubkeys from multisig address (sorted lexicographically)
+    repeated bytes signatures = 2;          // existing signatures for partially signed input
+    required uint32 m = 3;                  // "m" from n, how many valid signatures is necessary for spending
+    repeated common.HDNodeType nodes = 4;    // simplified way how to specify pubkeys if they share the same address_n path
+    repeated uint32 address_n = 5;                              // use only field 1 or fields 4+5, if fields 4+5 are used, field 1 is ignored
+    /**
+    * Structure representing HDNode + Path
+    */
+    message HDNodePathType {
+        required common.HDNodeType node = 1; // BIP-32 node in deserialized form
+        repeated uint32 address_n = 2;                          // BIP-32 path to derive the key from node
+    }
+}
+
+/**
+ * Request: Ask device for public key corresponding to address_n path
+ * @start
+ * @next PublicKey
+ * @next Failure
+ */
+message GetPublicKey {
+    repeated uint32 address_n = 1;                                      // BIP-32 path to derive the key from master node
+    optional string ecdsa_curve_name = 2;                               // ECDSA curve name to use
+    optional bool show_display = 3;                                     // optionally show on display before sending the result
+    optional string coin_name = 4 [default='Bitcoin'];                  // coin to use for verifying
+    optional InputScriptType script_type = 5 [default=SPENDADDRESS];    // used to distinguish between various address formats (non-segwit, segwit, etc.)
+    optional bool ignore_xpub_magic = 6;                                // ignore SLIP-0132 XPUB magic, use xpub/tpub prefix for all account types
+}
+
+/**
+ * Response: Contains public key derived from device private seed
+ * @end
+ */
+message PublicKey {
+    required common.HDNodeType node = 1;        // BIP-32 public node
+    required string xpub = 2;                   // serialized form of public node
+    optional uint32 root_fingerprint = 3;       // master root node fingerprint
+    optional string descriptor = 4;             // BIP-380 descriptor
+}
+
+/**
+ * Request: Ask device for address corresponding to address_n path
+ * @start
+ * @next Address
+ * @next Failure
+ */
+message GetAddress {
+    repeated uint32 address_n = 1;                                      // BIP-32 path to derive the key from master node
+    optional string coin_name = 2 [default='Bitcoin'];                  // coin to use
+    optional bool show_display = 3;                                     // optionally show on display before sending the result
+    optional MultisigRedeemScriptType multisig = 4;                     // filled if we are showing a multisig address
+    optional InputScriptType script_type = 5 [default=SPENDADDRESS];    // used to distinguish between various address formats (non-segwit, segwit, etc.)
+    optional bool ignore_xpub_magic = 6;                                // ignore SLIP-0132 XPUB magic, use xpub/tpub prefix for all account types
+    optional bool chunkify = 7;                                         // display the address in chunks of 4 characters
+}
+
+/**
+ * Response: Contains address derived from device private seed
+ * @end
+ */
+message Address {
+    required string address = 1;    // Coin address in Base58 encoding
+    optional bytes mac = 2;         // Address authentication code
+}
+
+/**
+ * Request: Ask device for ownership identifier corresponding to scriptPubKey for address_n path
+ * @start
+ * @next OwnershipId
+ * @next Failure
+ */
+message GetOwnershipId {
+    repeated uint32 address_n = 1;                                      // BIP-32 path to derive the key from master node
+    optional string coin_name = 2 [default='Bitcoin'];                  // coin to use
+    optional MultisigRedeemScriptType multisig = 3;                     // filled if we are dealing with a multisig scriptPubKey
+    optional InputScriptType script_type = 4 [default=SPENDADDRESS];    // used to distinguish between various address formats (non-segwit, segwit, etc.)
+}
+
+/**
+ * Response: Contains the ownership identifier for the scriptPubKey and device private seed
+ * @end
+ */
+message OwnershipId {
+    required bytes ownership_id = 1;    // ownership identifier
+}
+
+/**
+ * Request: Ask device to sign message
+ * @start
+ * @next MessageSignature
+ * @next Failure
+ */
+message SignMessage {
+    repeated uint32 address_n = 1;                                      // BIP-32 path to derive the key from master node
+    required bytes message = 2;                                         // message to be signed
+    optional string coin_name = 3 [default='Bitcoin'];                  // coin to use for signing
+    optional InputScriptType script_type = 4 [default=SPENDADDRESS];    // used to distinguish between various address formats (non-segwit, segwit, etc.)
+    optional bool no_script_type = 5;                                   // don't include script type information in the recovery byte of the signature, same as in Bitcoin Core
+    optional bool chunkify = 6;                                         // display the address in chunks of 4 characters
+}
+
+/**
+ * Response: Signed message
+ * @end
+ */
+message MessageSignature {
+    required string address = 1;    // address used to sign the message
+    required bytes signature = 2;   // signature of the message
+}
+
+/**
+ * Request: Ask device to verify message
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message VerifyMessage {
+    required string address = 1;                        // address to verify
+    required bytes signature = 2;                       // signature to verify
+    required bytes message = 3;                         // message to verify
+    optional string coin_name = 4 [default='Bitcoin'];  // coin to use for verifying
+    optional bool chunkify = 5;                         // display the address in chunks of 4 characters
+}
+
+/**
+ * Request: Ask device to sign transaction
+ * @start
+ * @next TxRequest
+ * @next Failure
+ */
+message SignTx {
+    required uint32 outputs_count = 1;                         // number of transaction outputs
+    required uint32 inputs_count = 2;                          // number of transaction inputs
+    optional string coin_name = 3 [default='Bitcoin'];         // coin to use
+    optional uint32 version = 4 [default=1];                   // transaction version
+    optional uint32 lock_time = 5 [default=0];                 // transaction lock_time
+    optional uint32 expiry = 6;                                // only for Decred and Zcash
+    optional bool overwintered = 7 [deprecated=true];          // deprecated in 2.3.2, the field is not needed as it can be derived from `version`
+    optional uint32 version_group_id = 8;                      // only for Zcash, nVersionGroupId
+    optional uint32 timestamp = 9;                             // only for Peercoin
+    optional uint32 branch_id = 10;                            // only for Zcash, BRANCH_ID
+    optional AmountUnit amount_unit = 11 [default=BITCOIN];    // show amounts in
+    optional bool decred_staking_ticket = 12 [default=false];  // only for Decred, this is signing a ticket purchase
+    optional bool serialize = 13 [default=true];               // serialize the full transaction, as opposed to only outputting the signatures
+    optional CoinJoinRequest coinjoin_request = 14;            // only for preauthorized CoinJoins
+    optional bool chunkify = 15;                               // display the address in chunks of 4 characters
+
+    /**
+     * Signing request for a CoinJoin transaction.
+     */
+    message CoinJoinRequest {
+        required uint32 fee_rate = 1;                // coordination fee rate in units of 10^-6 percent
+        required uint64 no_fee_threshold = 2;        // PlebsDontPayThreshold in Wasabi, the input amount above which the fee rate applies
+        required uint64 min_registrable_amount = 3;  // minimum registrable output amount
+        required bytes mask_public_key = 4;          // ephemeral secp256k1 public key used for masking coinjoin_flags, 33 bytes in compressed form
+        required bytes signature = 5;                // the trusted party's signature of the CoinJoin request digest
+    }
+}
+
+/**
+ * Response: Device asks for information for signing transaction or returns the last result
+ * If request_index is set, device awaits TxAck<any> matching the request type.
+ * If signature_index is set, 'signature' contains signed input of signature_index's input
+ * @end
+ * @next TxAckInput
+ * @next TxAckOutput
+ * @next TxAckPrevMeta
+ * @next TxAckPrevInput
+ * @next TxAckPrevOutput
+ * @next TxAckPrevExtraData
+ * @next TxAckPaymentRequest
+ */
+message TxRequest {
+    optional RequestType request_type = 1;              // what should be filled in TxAck message?
+    optional TxRequestDetailsType details = 2;          // request for tx details
+    optional TxRequestSerializedType serialized = 3;    // serialized data and request for next
+    /**
+    * Type of information required by transaction signing process
+    */
+    enum RequestType {
+        TXINPUT = 0;
+        TXOUTPUT = 1;
+        TXMETA = 2;
+        TXFINISHED = 3;
+        TXEXTRADATA = 4;
+        TXORIGINPUT = 5;
+        TXORIGOUTPUT = 6;
+        TXPAYMENTREQ = 7;
+    }
+    /**
+    * Structure representing request details
+    */
+    message TxRequestDetailsType {
+        optional uint32 request_index = 1;      // device expects TxAck message from the computer
+        optional bytes tx_hash = 2;             // tx_hash of requested transaction
+        optional uint32 extra_data_len = 3;     // length of requested extra data (only for Dash, Zcash)
+        optional uint32 extra_data_offset = 4;  // offset of requested extra data (only for Dash, Zcash)
+    }
+    /**
+    * Structure representing serialized data
+    */
+    message TxRequestSerializedType {
+        optional uint32 signature_index = 1;    // 'signature' field contains signed input of this index
+        optional bytes signature = 2;           // signature of the signature_index input
+        optional bytes serialized_tx = 3;       // part of serialized and signed transaction
+    }
+}
+
+/**
+ * Request: Reported transaction data (legacy)
+ *
+ * This message contains all possible field that can be sent in response to a TxRequest.
+ * Depending on the request_type, the host is supposed to fill some of these fields.
+ *
+ * The interface is wire-compatible with the new method of specialized TxAck subtypes,
+ * so it can be used in the old way. However, it is now recommended to use more
+ * specialized messages, which have better-configured constraints on field values.
+ *
+ * @next TxRequest
+ */
+message TxAck {
+    option deprecated = true;
+
+    optional TransactionType tx = 1;
+    /**
+    * Structure representing transaction
+    */
+    message TransactionType {
+        optional uint32 version = 1;
+        repeated TxInputType inputs = 2;
+        repeated TxOutputBinType bin_outputs = 3;
+        optional uint32 lock_time = 4;
+        repeated TxOutputType outputs = 5;
+        optional uint32 inputs_cnt = 6;
+        optional uint32 outputs_cnt = 7;
+        optional bytes extra_data = 8;          // only for Dash, Zcash
+        optional uint32 extra_data_len = 9;     // only for Dash, Zcash
+        optional uint32 expiry = 10;            // only for Decred and Zcash
+        optional bool overwintered = 11 [deprecated=true];   // Zcash only; deprecated in 2.3.2, the field is not needed, it can be derived from `version`
+        optional uint32 version_group_id = 12;  // only for Zcash, nVersionGroupId
+        optional uint32 timestamp = 13;         // only for Peercoin
+        optional uint32 branch_id = 14;         // only for Zcash, BRANCH_ID
+        /**
+        * Structure representing transaction input
+        */
+        message TxInputType {
+            repeated uint32 address_n = 1;                                      // BIP-32 path to derive the key from master node
+            required bytes prev_hash = 2;                                       // hash of previous transaction output to spend by this input
+            required uint32 prev_index = 3;                                     // index of previous output to spend
+            optional bytes script_sig = 4;                                      // script signature, unset for tx to sign
+            optional uint32 sequence = 5 [default=4294967295];                  // sequence (default=0xffffffff)
+            optional InputScriptType script_type = 6 [default=SPENDADDRESS];    // defines template of input script
+            optional MultisigRedeemScriptType multisig = 7;                     // Filled if input is going to spend multisig tx
+            optional uint64 amount = 8;                                         // amount of previous transaction output (for segwit only)
+            optional uint32 decred_tree = 9;                                    // only for Decred, 0 is a normal transaction while 1 is a stake transaction
+            // optional uint32 decred_script_version = 10;                         // only for Decred  // deprecated -> only 0 is supported
+            // optional bytes prev_block_hash_bip115 = 11;     // BIP-115 support dropped
+            // optional uint32 prev_block_height_bip115 = 12;  // BIP-115 support dropped
+            optional bytes witness = 13;                                        // witness data, only set for EXTERNAL inputs
+            optional bytes ownership_proof = 14;                                // SLIP-0019 proof of ownership, only set for EXTERNAL inputs
+            optional bytes commitment_data = 15;                                // optional commitment data for the SLIP-0019 proof of ownership
+            optional bytes orig_hash = 16;                                      // tx_hash of the original transaction where this input was spent (used when creating a replacement transaction)
+            optional uint32 orig_index = 17;                                    // index of the input in the original transaction (used when creating a replacement transaction)
+            optional DecredStakingSpendType decred_staking_spend = 18;          // if not None this holds the type of stake spend: revocation or stake generation
+            optional bytes script_pubkey = 19;                                  // scriptPubKey of the previous output spent by this input, only set of EXTERNAL inputs
+            optional uint32 coinjoin_flags = 20 [default=0];                    // bit field of CoinJoin-specific flags
+        }
+        /**
+        * Structure representing compiled transaction output
+        */
+        message TxOutputBinType {
+            required uint64 amount = 1;
+            required bytes script_pubkey = 2;
+            optional uint32 decred_script_version = 3;      // only for Decred, currently only 0 is supported
+        }
+        /**
+        * Structure representing transaction output
+        */
+        message TxOutputType {
+            optional string address = 1;                    // target coin address in Base58 encoding
+            repeated uint32 address_n = 2;                  // BIP-32 path to derive the key from master node; has higher priority than "address"
+            required uint64 amount = 3;                     // amount to spend in satoshis
+            optional OutputScriptType script_type = 4 [default=PAYTOADDRESS];      // output script type
+            optional MultisigRedeemScriptType multisig = 5; // defines multisig address; script_type must be PAYTOMULTISIG
+            optional bytes op_return_data = 6;              // defines op_return data; script_type must be PAYTOOPRETURN, amount must be 0
+            // optional uint32 decred_script_version = 7;      // only for Decred  // deprecated -> only 0 is supported
+            // optional bytes block_hash_bip115 = 8;        // BIP-115 support dropped
+            // optional uint32 block_height_bip115 = 9;     // BIP-115 support dropped
+            optional bytes orig_hash = 10;                  // tx_hash of the original transaction where this output was present (used when creating a replacement transaction)
+            optional uint32 orig_index = 11;                // index of the output in the original transaction (used when creating a replacement transaction)
+            optional uint32 payment_req_index = 12 [(experimental_field)=true]; // index of the PaymentRequest containing this output
+        }
+    }
+}
+
+/** Data type for transaction input to be signed.
+ *
+ * When adding fields, take care to not conflict with PrevInput
+ *
+ * @embed
+ */
+message TxInput {
+    repeated uint32 address_n = 1;                                      // BIP-32 path to derive the key from master node
+    required bytes prev_hash = 2;                                       // hash of previous transaction output to spend by this input
+    required uint32 prev_index = 3;                                     // index of previous output to spend
+    optional bytes script_sig = 4;                                      // script signature, only set for EXTERNAL inputs
+    optional uint32 sequence = 5 [default=0xffffffff];                  // sequence
+    optional InputScriptType script_type = 6 [default=SPENDADDRESS];    // defines template of input script
+    optional MultisigRedeemScriptType multisig = 7;                     // Filled if input is going to spend multisig tx
+    required uint64 amount = 8;                                         // amount of previous transaction output
+    optional uint32 decred_tree = 9;                                    // only for Decred, 0 is a normal transaction while 1 is a stake transaction
+    reserved 10, 11, 12;                                                // fields which are in use, or have been in the past, in TxInputType
+    optional bytes witness = 13;                                        // witness data, only set for EXTERNAL inputs
+    optional bytes ownership_proof = 14;                                // SLIP-0019 proof of ownership, only set for EXTERNAL inputs
+    optional bytes commitment_data = 15;                                // optional commitment data for the SLIP-0019 proof of ownership
+    optional bytes orig_hash = 16;                                      // tx_hash of the original transaction where this input was spent (used when creating a replacement transaction)
+    optional uint32 orig_index = 17;                                    // index of the input in the original transaction (used when creating a replacement transaction)
+    optional DecredStakingSpendType decred_staking_spend = 18; 	        // if not None this holds the type of stake spend: revocation or stake generation
+    optional bytes script_pubkey = 19;                                  // scriptPubKey of the previous output spent by this input, only set of EXTERNAL inputs
+    optional uint32 coinjoin_flags = 20 [default=0];                    // bit field of CoinJoin-specific flags
+}
+
+/** Data type for transaction output to be signed.
+ * @embed
+ */
+message TxOutput {
+    optional string address = 1;                    // destination address in Base58 encoding; script_type must be PAYTOADDRESS
+    repeated uint32 address_n = 2;                  // BIP-32 path to derive the destination (used for change addresses)
+    required uint64 amount = 3;                     // amount to spend in satoshis
+    optional OutputScriptType script_type = 4 [default=PAYTOADDRESS];      // output script type
+    optional MultisigRedeemScriptType multisig = 5; // defines multisig address; script_type must be PAYTOMULTISIG
+    optional bytes op_return_data = 6;              // defines op_return data; script_type must be PAYTOOPRETURN, amount must be 0
+    reserved 7, 8, 9;                               // fields which are in use, or have been in the past, in TxOutputType
+    optional bytes orig_hash = 10;                  // tx_hash of the original transaction where this output was present (used when creating a replacement transaction)
+    optional uint32 orig_index = 11;                // index of the output in the original transaction (used when creating a replacement transaction)
+    optional uint32 payment_req_index = 12 [(experimental_field)=true]; // index of the PaymentRequest containing this output
+}
+
+/** Data type for metadata about previous transaction which contains the UTXO being spent.
+ * @embed
+ */
+message PrevTx {
+    required uint32 version = 1;
+    required uint32 lock_time = 4;
+    required uint32 inputs_count = 6;
+    required uint32 outputs_count = 7;
+    optional uint32 extra_data_len = 9 [default=0];     // only for Dash, Zcash
+    optional uint32 expiry = 10;            // only for Decred and Zcash
+    optional uint32 version_group_id = 12;  // only for Zcash, nVersionGroupId
+    optional uint32 timestamp = 13;         // only for Peercoin
+    optional uint32 branch_id = 14;         // only for Zcash, BRANCH_ID
+
+    // fields which are in use, or have been in the past, in TransactionType
+    reserved 2, 3, 5, 8, 11;
+}
+
+/** Data type for inputs of previous transactions.
+ *
+ * When adding fields, take care to not conflict with TxInput
+ * @embed
+ */
+message PrevInput {
+    required bytes prev_hash = 2;                                       // hash of previous transaction output to spend by this input
+    required uint32 prev_index = 3;                                     // index of previous output to spend
+    required bytes script_sig = 4;                                      // script signature
+    required uint32 sequence = 5;                                       // sequence
+    optional uint32 decred_tree = 9;                                    // only for Decred
+
+    // fields that are in use, or have been in the past, in TxInputType
+    reserved 1, 6, 7, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19;
+}
+
+/** Data type for outputs of previous transactions.
+ * @embed
+ */
+message PrevOutput {
+    required uint64 amount = 1;                     // amount sent to this output
+    required bytes script_pubkey = 2;               // scriptPubkey of this output
+    optional uint32 decred_script_version = 3;      // only for Decred
+}
+
+/** Data type of a payment request for a set of outputs.
+ * @next TxRequest
+ */
+message TxAckPaymentRequest {
+    option (experimental_message) = true;
+
+    optional bytes nonce = 1;              // the nonce used in the signature computation
+    required string recipient_name = 2;    // merchant's name
+    repeated PaymentRequestMemo memos = 3; // any memos that were signed as part of the request
+    optional uint64 amount = 4;            // the sum of the external output amounts requested, required for non-CoinJoin
+    required bytes signature = 5;          // the trusted party's signature of the paymentRequestDigest
+
+    message PaymentRequestMemo {
+        optional TextMemo text_memo = 1;
+        optional RefundMemo refund_memo = 2;
+        optional CoinPurchaseMemo coin_purchase_memo = 3;
+    }
+
+    message TextMemo {
+        required string text = 1;      // plain-text note explaining the purpose of the payment request
+    }
+
+    message RefundMemo {
+        required string address = 1;   // the address where the payment should be refunded if necessary
+        required bytes mac = 2;        // the MAC returned by GetAddress
+    }
+
+    message CoinPurchaseMemo {
+        required uint32 coin_type = 1; // the SLIP-0044 coin type of the address
+        required string amount = 2;    // the amount the address will receive as a human-readable string including units, e.g. "0.025 BTC"
+        required string address = 3;   // the address where the coin purchase will be delivered
+        required bytes mac = 4;        // the MAC returned by GetAddress
+    }
+}
+
+/**
+ * Request: Data about input to be signed.
+ * Wire-alias of TxAck.
+ *
+ * Do not edit this type without considering compatibility with TxAck.
+ * Prefer to modify the inner TxInput type.
+ *
+ * @next TxRequest
+ */
+message TxAckInput {
+    option (wire_type) = 22;
+
+    required TxAckInputWrapper tx = 1;
+
+    message TxAckInputWrapper {
+        required TxInput input = 2;
+    }
+}
+
+/**
+ * Request: Data about output to be signed.
+ * Wire-alias of TxAck.
+ *
+ * Do not edit this type without considering compatibility with TxAck.
+ * Prefer to modify the inner TxOutput type.
+ *
+ * @next TxRequest
+ */
+message TxAckOutput {
+    option (wire_type) = 22;
+
+    required TxAckOutputWrapper tx = 1;
+
+    message TxAckOutputWrapper {
+        required TxOutput output = 5;
+    }
+}
+
+/**
+ * Request: Data about previous transaction metadata
+ * Wire-alias of TxAck.
+ *
+ * Do not edit this type without considering compatibility with TxAck.
+ * Prefer to modify the inner PrevTx type.
+ *
+ * @next TxRequest
+ */
+message TxAckPrevMeta {
+    option (wire_type) = 22;
+
+    required PrevTx tx = 1;
+}
+
+/**
+ * Request: Data about previous transaction input
+ * Wire-alias of TxAck.
+ *
+ * Do not edit this type without considering compatibility with TxAck.
+ * Prefer to modify the inner PrevInput type.
+ *
+ * @next TxRequest
+ */
+message TxAckPrevInput {
+    option (wire_type) = 22;
+
+    required TxAckPrevInputWrapper tx = 1;
+
+    message TxAckPrevInputWrapper {
+        required PrevInput input = 2;
+
+    }
+}
+
+/**
+ * Request: Data about previous transaction output
+ * Wire-alias of TxAck.
+ *
+ * Do not edit this type without considering compatibility with TxAck.
+ * Prefer to modify the inner PrevOutput type.
+ *
+ * @next TxRequest
+ */
+message TxAckPrevOutput {
+    option (wire_type) = 22;
+
+    required TxAckPrevOutputWrapper tx = 1;
+
+    message TxAckPrevOutputWrapper {
+        required PrevOutput output = 3;
+    }
+}
+
+/**
+ * Request: Content of the extra data of a previous transaction
+ * Wire-alias of TxAck.
+ *
+ * Do not edit this type without considering compatibility with TxAck.
+ *
+ * @next TxRequest
+ */
+message TxAckPrevExtraData {
+    option (wire_type) = 22;
+
+    required TxAckPrevExtraDataWrapper tx = 1;
+
+    message TxAckPrevExtraDataWrapper {
+        required bytes extra_data_chunk = 8;
+    }
+}
+
+/**
+ * Request: Ask device for a proof of ownership corresponding to address_n path
+ * @start
+ * @next OwnershipProof
+ * @next Failure
+ */
+message GetOwnershipProof {
+    repeated uint32 address_n = 1;                                      // BIP-32 path to derive the key from master node
+    optional string coin_name = 2 [default='Bitcoin'];                  // coin to use
+    optional InputScriptType script_type = 3 [default=SPENDWITNESS];    // used to distinguish between various scriptPubKey types
+    optional MultisigRedeemScriptType multisig = 4;                     // filled if proof is for a multisig address
+    optional bool user_confirmation = 5 [default=false];                // show a confirmation dialog and set the "user confirmation" bit in the proof
+    repeated bytes ownership_ids = 6;                                   // list of ownership identifiers in case of multisig
+    optional bytes commitment_data = 7 [default=''];                    // additional data to which the proof should commit
+}
+
+/**
+ * Response: Contains the proof of ownership
+ * @end
+ */
+message OwnershipProof {
+    required bytes ownership_proof = 1;     // SLIP-0019 proof of ownership
+    required bytes signature = 2;           // signature of the proof
+}
+
+/**
+ * Request: Ask device to prompt the user to authorize a CoinJoin transaction
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message AuthorizeCoinJoin {
+    required string coordinator = 1;                                    // coordinator identifier to approve as a prefix in commitment data (max. 36 ASCII characters)
+    required uint64 max_rounds = 2;                                     // maximum number of rounds that Trezor is authorized to take part in
+    required uint32 max_coordinator_fee_rate = 3;                       // maximum coordination fee rate in units of 10^-6 percent
+    required uint32 max_fee_per_kvbyte = 4;                             // maximum mining fee rate in units of satoshis per 1000 vbytes
+    repeated uint32 address_n = 5;                                      // prefix of the BIP-32 path leading to the account (m / purpose' / coin_type' / account')
+    optional string coin_name = 6 [default='Bitcoin'];                  // coin to use
+    optional InputScriptType script_type = 7 [default=SPENDADDRESS];    // used to distinguish between various address formats (non-segwit, segwit, etc.)
+    optional AmountUnit amount_unit = 8 [default=BITCOIN];              // show amounts in
+}
+

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-bootloader.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-bootloader.proto
@@ -1,0 +1,44 @@
+syntax = "proto2";
+package hw.trezor.messages.bootloader;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageBootloader";
+
+/**
+ * Request: Ask device to erase its firmware (so it can be replaced via FirmwareUpload)
+ * @start
+ * @next FirmwareRequest
+ */
+message FirmwareErase {
+    optional uint32 length = 1; // length of new firmware
+}
+
+/**
+ * Response: Ask for firmware chunk
+ * @next FirmwareUpload
+ */
+message FirmwareRequest {
+    required uint32 offset = 1; // offset of requested firmware chunk
+    required uint32 length = 2; // length of requested firmware chunk
+}
+
+/**
+ * Request: Send firmware in binary form to the device
+ * @next FirmwareRequest
+ * @next Success
+ * @next Failure
+ */
+message FirmwareUpload {
+    required bytes payload = 1; // firmware to be loaded into device
+    optional bytes hash = 2;    // hash of the payload
+}
+
+/**
+ * Request: Perform a prodtest on T1
+ * @next Success
+ * @next Failure
+ */
+message ProdTestT1 {
+    optional bytes payload = 1; // payload to be used in prodtest
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-cardano.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-cardano.proto
@@ -1,0 +1,502 @@
+syntax = "proto2";
+package hw.trezor.messages.cardano;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageCardano";
+
+import "messages-common.proto";
+
+enum CardanoDerivationType {
+    LEDGER = 0;
+    ICARUS = 1;
+    ICARUS_TREZOR = 2;
+}
+
+/**
+ * Values correspond to address header values given by the spec.
+ * Script addresses are only supported in transaction outputs.
+ */
+enum CardanoAddressType {
+    BASE = 0;
+    BASE_SCRIPT_KEY = 1;
+    BASE_KEY_SCRIPT = 2;
+    BASE_SCRIPT_SCRIPT = 3;
+    POINTER = 4;
+    POINTER_SCRIPT = 5;
+    ENTERPRISE = 6;
+    ENTERPRISE_SCRIPT = 7;
+    BYRON = 8;
+    REWARD = 14;
+    REWARD_SCRIPT = 15;
+}
+
+enum CardanoNativeScriptType {
+    PUB_KEY = 0;
+    ALL = 1;
+    ANY = 2;
+    N_OF_K = 3;
+    INVALID_BEFORE = 4;
+    INVALID_HEREAFTER = 5;
+}
+
+enum CardanoNativeScriptHashDisplayFormat {
+    HIDE = 0;
+    BECH32 = 1;
+    POLICY_ID = 2;
+}
+
+enum CardanoTxOutputSerializationFormat {
+    ARRAY_LEGACY = 0; // legacy_transaction_output in CDDL
+    MAP_BABBAGE = 1;  // post_alonzo_transaction_output in CDDL
+}
+
+enum CardanoCertificateType {
+    STAKE_REGISTRATION = 0;
+    STAKE_DEREGISTRATION = 1;
+    STAKE_DELEGATION = 2;
+    STAKE_POOL_REGISTRATION = 3;
+}
+
+enum CardanoPoolRelayType {
+    SINGLE_HOST_IP = 0;
+    SINGLE_HOST_NAME = 1;
+    MULTIPLE_HOST_NAME = 2;
+}
+
+enum CardanoTxAuxiliaryDataSupplementType {
+    NONE = 0;
+    CVOTE_REGISTRATION_SIGNATURE = 1;
+}
+
+enum CardanoCVoteRegistrationFormat {
+    CIP15 = 0;
+    CIP36 = 1;
+}
+
+enum CardanoTxSigningMode {
+    ORDINARY_TRANSACTION = 0;
+    POOL_REGISTRATION_AS_OWNER = 1;
+    MULTISIG_TRANSACTION = 2;
+    PLUTUS_TRANSACTION = 3;
+}
+
+enum CardanoTxWitnessType {
+    BYRON_WITNESS = 0;
+    SHELLEY_WITNESS = 1;
+}
+
+/**
+ * Structure representing cardano PointerAddress pointer,
+ * which points to a staking key registration certificate.
+ * @embed
+ */
+message CardanoBlockchainPointerType {
+    required uint32 block_index = 1;
+    required uint32 tx_index = 2;
+    required uint32 certificate_index = 3;
+}
+
+/*
+ * @embed
+ */
+message CardanoNativeScript {
+    required CardanoNativeScriptType type = 1;
+    repeated CardanoNativeScript scripts = 2;
+
+    optional bytes key_hash = 3;
+    repeated uint32 key_path = 4;
+    optional uint32 required_signatures_count = 5;
+    optional uint64 invalid_before = 6;
+    optional uint64 invalid_hereafter = 7;
+}
+
+/**
+ * Request: Ask device for Cardano native script hash
+ * @start
+ * @next CardanoNativeScriptHash
+ * @next Failure
+ */
+message CardanoGetNativeScriptHash {
+    required CardanoNativeScript script = 1;
+    required CardanoNativeScriptHashDisplayFormat display_format = 2;   // display hash as bech32 or policy id
+    required CardanoDerivationType derivation_type = 3;
+}
+
+/**
+ * Request: Ask device for Cardano native script hash
+ * @end
+ */
+message CardanoNativeScriptHash {
+    required bytes script_hash = 1;
+}
+
+/**
+ * Structure to represent address parameters so they can be
+ * reused in CardanoGetAddress and CardanoTxOutputType.
+ * NetworkId isn't a part of the parameters, because in a transaction
+ * this will be included separately in the transaction itself, so it
+ * shouldn't be duplicated here.
+ * @embed
+ */
+message CardanoAddressParametersType {
+    required CardanoAddressType address_type = 1;                   // one of the CardanoAddressType-s
+    repeated uint32 address_n = 2;                                  // BIP-32-style path to derive the spending key from master node
+    repeated uint32 address_n_staking = 3;                          // BIP-32-style path to derive staking key from master node
+    optional bytes staking_key_hash = 4;                            // staking key can be derived from address_n_staking, or
+                                                                    // can be sent directly e.g. if it doesn't belong to
+                                                                    // the same account as address_n
+    optional CardanoBlockchainPointerType certificate_pointer = 5;  // a pointer to the staking key registration certificate
+    optional bytes script_payment_hash = 6;
+    optional bytes script_staking_hash = 7;
+}
+
+/**
+ * Request: Ask device for Cardano address
+ * @start
+ * @next CardanoAddress
+ * @next Failure
+ */
+message CardanoGetAddress {
+    // repeated uint32 address_n = 1;                               // moved to address_parameters
+    optional bool show_display = 2 [default=false];                 // optionally prompt for confirmation on trezor display
+    required uint32 protocol_magic = 3;                             // network's protocol magic - needed for Byron addresses on testnets
+    required uint32 network_id = 4;                                 // network id - mainnet or testnet
+    required CardanoAddressParametersType address_parameters = 5;   // parameters used to derive the address
+    required CardanoDerivationType derivation_type = 6;
+    optional bool chunkify = 7;                                     // display the address in chunks of 4 characters
+}
+
+/**
+ * Request: Ask device for Cardano address
+ * @end
+ */
+message CardanoAddress {
+    required string address = 1;    // Base58 cardano address
+}
+
+/**
+ * Request: Ask device for public key corresponding to address_n path
+ * @start
+ * @next CardanoPublicKey
+ * @next Failure
+ */
+message CardanoGetPublicKey {
+    repeated uint32 address_n = 1;  // BIP-32 path to derive the key from master node
+    optional bool show_display = 2; // optionally show on display before sending the result
+    required CardanoDerivationType derivation_type = 3;
+}
+
+/**
+ * Response: Contains public key derived from device private seed
+ * @end
+ */
+message CardanoPublicKey {
+    required string xpub = 1;                               // Xpub key
+    required hw.trezor.messages.common.HDNodeType node = 2; // BIP-32 public node
+}
+
+/**
+ * Request: Initiate the Cardano transaction signing process on the device
+ * @start
+ * @next CardanoTxItemAck
+ * @next Failure
+ */
+message CardanoSignTxInit {
+    required CardanoTxSigningMode signing_mode = 1;
+    required uint32 protocol_magic = 2;                         // network's protocol magic
+    required uint32 network_id = 3;                             // network id - mainnet or testnet
+    required uint32 inputs_count = 4;
+    required uint32 outputs_count = 5;
+    required uint64 fee = 6;                                    // transaction fee - added in shelley
+    optional uint64 ttl = 7;                                    // transaction ttl - added in shelley
+    required uint32 certificates_count = 8;
+    required uint32 withdrawals_count = 9;
+    required bool has_auxiliary_data = 10;
+    optional uint64 validity_interval_start = 11;
+    required uint32 witness_requests_count = 12;
+    required uint32 minting_asset_groups_count = 13;
+    required CardanoDerivationType derivation_type = 14;
+    optional bool include_network_id = 15 [default=false];      // network id included as tx body item
+    optional bytes script_data_hash = 16;
+    required uint32 collateral_inputs_count = 17;
+    required uint32 required_signers_count = 18;
+    optional bool has_collateral_return = 19 [default=false];
+    optional uint64 total_collateral = 20;
+    optional uint32 reference_inputs_count = 21 [default=0];
+    optional bool chunkify = 22;                                // display the address in chunks of 4 characters
+}
+
+/**
+ * Request: Transaction input data
+ * @next CardanoTxItemAck
+ */
+message CardanoTxInput {
+    required bytes prev_hash = 1;   // hash of previous transaction output to spend by this input
+    required uint32 prev_index = 2; // index of previous output to spend
+}
+
+/**
+ * Request: Transaction output data
+ * @next CardanoTxItemAck
+ */
+message CardanoTxOutput {
+    optional string address = 1;                                                    // target coin address in bech32 or base58
+    optional CardanoAddressParametersType address_parameters = 2;                   // parameters used to derive the address
+    required uint64 amount = 3;                                                     // amount to spend
+    required uint32 asset_groups_count = 4;
+    optional bytes datum_hash = 5;
+    optional CardanoTxOutputSerializationFormat format = 6 [default=ARRAY_LEGACY];
+    optional uint32 inline_datum_size = 7 [default=0];                              // 0 means no inline datum
+    optional uint32 reference_script_size = 8 [default=0];                          // 0 means no reference script
+}
+
+/**
+ * Request: Transaction output asset group data
+ * @next CardanoTxItemAck
+ */
+message CardanoAssetGroup {
+    required bytes policy_id = 1;                  // asset group policy id
+    required uint32 tokens_count = 2;
+}
+
+/**
+ * Request: Transaction output asset group token data
+ * @next CardanoTxItemAck
+ */
+message CardanoToken {
+    required bytes asset_name_bytes = 1;     // asset name as bytestring (may be either ascii string or hash)
+    optional uint64 amount = 2;              // asset amount
+    optional sint64 mint_amount = 3;         // mint amount (can also be negative in which case the tokens are burnt)
+}
+
+/**
+ * Request: Transaction output inline datum chunk
+ * @next CardanoTxItemAck
+ */
+message CardanoTxInlineDatumChunk {
+    required bytes data = 1;                // expected maximum chunk size is 1024 bytes
+}
+
+/**
+ * Request: Transaction output reference script chunk
+ * @next CardanoTxItemAck
+ */
+message CardanoTxReferenceScriptChunk {
+    required bytes data = 1;                // expected maximum chunk size is 1024 bytes
+}
+
+/**
+ * Request: Stake pool owner parameters
+ * @next CardanoTxItemAck
+ */
+message CardanoPoolOwner {
+    repeated uint32 staking_key_path = 1;   // BIP-32-style path to derive staking key of the owner
+    optional bytes staking_key_hash = 2;    // owner's staking key if it is an external owner
+}
+
+/**
+ * Request: Stake pool relay parameters
+ * @next CardanoTxItemAck
+ */
+message CardanoPoolRelayParameters {
+    required CardanoPoolRelayType type = 1;   // pool relay type
+    optional bytes ipv4_address = 2;          // ipv4 address of the relay given as 4 bytes
+    optional bytes ipv6_address = 3;          // ipv6 address of the relay given as 16 bytes
+    optional string host_name = 4;            // relay host name given as URL, at most 64 characters
+    optional uint32 port = 5;                 // relay port number in the range 0-65535
+}
+
+/**
+ * Stake pool metadata parameters
+ * @embed
+ */
+message CardanoPoolMetadataType {
+    required string url = 1;   // stake pool url hosting metadata, at most 64 characters
+    required bytes hash = 2;   // stake pool metadata hash
+}
+
+/**
+ * Stake pool parameters
+ * @embed
+ */
+message CardanoPoolParametersType {
+    required bytes pool_id = 1;                         // stake pool cold public key hash (28 bytes)
+    required bytes vrf_key_hash = 2;                    // VRF key hash (32 bytes)
+    required uint64 pledge = 3;                         // pledge amount in lovelace
+    required uint64 cost = 4;                           // cost in lovelace
+    required uint64 margin_numerator = 5;               // pool margin numerator
+    required uint64 margin_denominator = 6;             // pool margin denominator
+    required string reward_account = 7;                 // bech32 reward address where the pool receives rewards
+    // repeated CardanoPoolOwner owners = 8;            // legacy pool owners list - support for pre-tx-streaming firmwares dropped
+    // repeated CardanoPoolRelayParameters relays = 9;  // legacy pool relays list - support for pre-tx-streaming firmwares dropped
+    optional CardanoPoolMetadataType metadata = 10;     // pool metadata
+    required uint32 owners_count = 11;                  // number of pool owners
+    required uint32 relays_count = 12;                  // number of pool relays
+}
+
+/**
+ * Request: Transaction certificate data
+ * @next CardanoTxItemAck
+ */
+message CardanoTxCertificate {
+    required CardanoCertificateType type = 1;                 // certificate type
+    repeated uint32 path = 2;                                 // stake credential key path
+    optional bytes pool = 3;                                  // pool hash
+    optional CardanoPoolParametersType pool_parameters = 4;   // used for stake pool registration certificate
+    optional bytes script_hash = 5;                           // stake credential script hash
+    optional bytes key_hash = 6;                              // stake credential key hash
+}
+
+/**
+ * Request: Transaction withdrawal data
+ * @next CardanoTxItemAck
+ */
+message CardanoTxWithdrawal {
+    repeated uint32 path = 1;           // stake credential key path
+    required uint64 amount = 2;
+    optional bytes script_hash = 3;     // stake credential script hash
+    optional bytes key_hash = 4;        // stake credential key hash
+}
+
+/**
+ * @embed
+ */
+message CardanoCVoteRegistrationDelegation {
+    required bytes vote_public_key = 1;
+    required uint32 weight = 2;
+}
+
+/**
+ * @embed
+ */
+message CardanoCVoteRegistrationParametersType {
+    optional bytes vote_public_key = 1; // mutually exclusive with delegations
+    repeated uint32 staking_path = 2;
+    optional CardanoAddressParametersType payment_address_parameters = 3; // mutually exclusive with payment_address
+    required uint64 nonce = 4;
+    optional CardanoCVoteRegistrationFormat format = 5 [default=CIP15];
+    repeated CardanoCVoteRegistrationDelegation delegations = 6;  // mutually exclusive with vote_public_key; max 32 delegations
+    optional uint64 voting_purpose = 7;
+    optional string payment_address = 8; // mutually exclusive with payment_address_parameters
+}
+
+/**
+ * Request: Transaction auxiliary data
+ * @next CardanoTxItemAck
+ * @next CardanoTxAuxiliaryDataSupplement
+ */
+message CardanoTxAuxiliaryData {
+    optional CardanoCVoteRegistrationParametersType cvote_registration_parameters = 1;
+    optional bytes hash = 2;
+}
+
+/**
+ * Request: Transaction mint
+ * @next CardanoTxItemAck
+ */
+message CardanoTxMint {
+    required uint32 asset_groups_count = 1;
+}
+
+/**
+ * Request: Transaction collateral input data
+ * @next CardanoTxItemAck
+ */
+message CardanoTxCollateralInput {
+    required bytes prev_hash = 1;
+    required uint32 prev_index = 2;
+}
+
+/**
+ * Request: Transaction required signer
+ * @next CardanoTxItemAck
+ */
+message CardanoTxRequiredSigner {
+    optional bytes key_hash = 1;
+    repeated uint32 key_path = 2;
+}
+
+/**
+ * Request: Transaction reference input data
+ * @next CardanoTxItemAck
+ */
+message CardanoTxReferenceInput {
+    required bytes prev_hash = 1;
+    required uint32 prev_index = 2;
+}
+
+/**
+ * Response: Acknowledgement of the last transaction item received
+ * @next CardanoTxInput
+ * @next CardanoTxOutput
+ * @next CardanoAssetGroup
+ * @next CardanoToken
+ * @next CardanoTxInlineDatumChunk
+ * @next CardanoTxReferenceScriptChunk
+ * @next CardanoTxCertificate
+ * @next CardanoPoolOwner
+ * @next CardanoPoolRelayParameters
+ * @next CardanoTxWithdrawal
+ * @next CardanoTxAuxiliaryData
+ * @next CardanoTxWitnessRequest
+ * @next CardanoTxMint
+ * @next CardanoTxCollateralInput
+ * @next CardanoTxRequiredSigner
+ * @next CardanoTxReferenceInput
+ */
+message CardanoTxItemAck {
+}
+
+/**
+ * Response: Device-generated supplement for the auxiliary data
+ * @next CardanoTxWitnessRequest
+ */
+message CardanoTxAuxiliaryDataSupplement {
+    required CardanoTxAuxiliaryDataSupplementType type = 1;
+    optional bytes auxiliary_data_hash = 2;
+    optional bytes cvote_registration_signature = 3;
+}
+
+/**
+ * Request: Ask the device to sign a witness path
+ * @next CardanoTxWitnessResponse
+ */
+message CardanoTxWitnessRequest {
+    repeated uint32 path = 1;
+}
+
+/**
+ * Response: Signature corresponding to the requested witness path
+ * @next CardanoTxWitnessRequest
+ * @next CardanoTxHostAck
+ */
+message CardanoTxWitnessResponse {
+    required CardanoTxWitnessType type = 1;
+    required bytes pub_key = 2;
+    required bytes signature = 3;
+    optional bytes chain_code = 4;
+}
+
+/**
+ * Request: Acknowledgement of the last response received
+ * @next CardanoTxBodyHash
+ * @next CardanoSignTxFinished
+ */
+message CardanoTxHostAck {
+}
+
+/**
+ * Response: Hash of the serialized transaction body
+ * @next CardanoTxHostAck
+ */
+message CardanoTxBodyHash {
+    required bytes tx_hash = 1;
+}
+
+/**
+ * Response: Confirm the successful completion of the signing process
+ * @end
+ */
+message CardanoSignTxFinished {
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-common.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-common.proto
@@ -1,0 +1,165 @@
+syntax = "proto2";
+package hw.trezor.messages.common;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageCommon";
+
+option (include_in_bitcoin_only) = true;
+
+import "messages.proto";
+
+/**
+ * Response: Success of the previous request
+ * @end
+ */
+message Success {
+    optional string message = 1 [default=""]; // human readable description of action or request-specific payload
+}
+
+/**
+ * Response: Failure of the previous request
+ * @end
+ */
+message Failure {
+    optional FailureType code = 1;  // computer-readable definition of the error state
+    optional string message = 2;    // human-readable message of the error state
+    enum FailureType {
+        Failure_UnexpectedMessage = 1;
+        Failure_ButtonExpected = 2;
+        Failure_DataError = 3;
+        Failure_ActionCancelled = 4;
+        Failure_PinExpected = 5;
+        Failure_PinCancelled = 6;
+        Failure_PinInvalid = 7;
+        Failure_InvalidSignature = 8;
+        Failure_ProcessError = 9;
+        Failure_NotEnoughFunds = 10;
+        Failure_NotInitialized = 11;
+        Failure_PinMismatch = 12;
+        Failure_WipeCodeMismatch = 13;
+        Failure_InvalidSession = 14;
+        Failure_FirmwareError = 99;
+    }
+}
+
+/**
+ * Response: Device is waiting for HW button press.
+ * @auxstart
+ * @next ButtonAck
+ */
+message ButtonRequest {
+    optional ButtonRequestType code = 1;  // enum identifier of the screen
+    optional uint32 pages = 2;            // if the screen is paginated, number of pages
+    /**
+    * Type of button request
+    */
+    enum ButtonRequestType {
+        ButtonRequest_Other = 1;
+        ButtonRequest_FeeOverThreshold = 2;
+        ButtonRequest_ConfirmOutput = 3;
+        ButtonRequest_ResetDevice = 4;
+        ButtonRequest_ConfirmWord = 5;
+        ButtonRequest_WipeDevice = 6;
+        ButtonRequest_ProtectCall = 7;
+        ButtonRequest_SignTx = 8;
+        ButtonRequest_FirmwareCheck = 9;
+        ButtonRequest_Address = 10;
+        ButtonRequest_PublicKey = 11;
+        ButtonRequest_MnemonicWordCount = 12;
+        ButtonRequest_MnemonicInput = 13;
+        _Deprecated_ButtonRequest_PassphraseType = 14 [deprecated=true];
+        ButtonRequest_UnknownDerivationPath = 15;
+        ButtonRequest_RecoveryHomepage = 16;
+        ButtonRequest_Success = 17;
+        ButtonRequest_Warning = 18;
+        ButtonRequest_PassphraseEntry = 19;
+        ButtonRequest_PinEntry = 20;
+    }
+}
+
+/**
+ * Request: Computer agrees to wait for HW button press
+ * @auxend
+ */
+message ButtonAck {
+}
+
+/**
+ * Response: Device is asking computer to show PIN matrix and awaits PIN encoded using this matrix scheme
+ * @auxstart
+ * @next PinMatrixAck
+ */
+message PinMatrixRequest {
+    optional PinMatrixRequestType type = 1;
+    /**
+    * Type of PIN request
+    */
+    enum PinMatrixRequestType {
+        PinMatrixRequestType_Current = 1;
+        PinMatrixRequestType_NewFirst = 2;
+        PinMatrixRequestType_NewSecond = 3;
+        PinMatrixRequestType_WipeCodeFirst = 4;
+        PinMatrixRequestType_WipeCodeSecond = 5;
+    }
+}
+
+/**
+ * Request: Computer responds with encoded PIN
+ * @auxend
+ */
+message PinMatrixAck {
+    required string pin = 1;    // matrix encoded PIN entered by user
+}
+
+/**
+ * Response: Device awaits encryption passphrase
+ * @auxstart
+ * @next PassphraseAck
+ */
+message PassphraseRequest {
+    optional bool _on_device = 1 [deprecated=true];  // <2.3.0
+}
+
+/**
+ * Request: Send passphrase back
+ * @auxend
+ */
+message PassphraseAck {
+    optional string passphrase = 1;
+    optional bytes _state = 2 [deprecated=true];  // <2.3.0
+    optional bool on_device = 3;    // user wants to enter passphrase on the device
+}
+
+/**
+ * Response: Device awaits passphrase state
+ * Deprecated in 2.3.0
+ * @next Deprecated_PassphraseStateAck
+ */
+message Deprecated_PassphraseStateRequest {
+    option deprecated = true;
+    optional bytes state = 1;       // actual device state
+}
+
+/**
+ * Request: Send passphrase state back
+ * Deprecated in 2.3.0
+ * @auxend
+ */
+message Deprecated_PassphraseStateAck {
+    option deprecated = true;
+}
+
+/**
+ * Structure representing BIP32 (hierarchical deterministic) node
+ * Used for imports of private key into the device and exporting public key out of device
+ * @embed
+ */
+message HDNodeType {
+    required uint32 depth = 1;
+    required uint32 fingerprint = 2;
+    required uint32 child_num = 3;
+    required bytes chain_code = 4;
+    optional bytes private_key = 5;
+    required bytes public_key = 6;
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-crypto.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-crypto.proto
@@ -1,0 +1,132 @@
+syntax = "proto2";
+package hw.trezor.messages.crypto;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageCrypto";
+
+option (include_in_bitcoin_only) = true;
+
+import "messages.proto";
+
+/**
+ * Request: Ask device to encrypt or decrypt value of given key
+ * @start
+ * @next CipheredKeyValue
+ * @next Failure
+ */
+message CipherKeyValue {
+    repeated uint32 address_n = 1;      // BIP-32 path to derive the key from master node
+    required string key = 2;            // key component of key:value
+    required bytes value = 3;           // value component of key:value
+    optional bool encrypt = 4;          // are we encrypting (True) or decrypting (False)?
+    optional bool ask_on_encrypt = 5;   // should we ask on encrypt operation?
+    optional bool ask_on_decrypt = 6;   // should we ask on decrypt operation?
+    optional bytes iv = 7;              // initialization vector (will be computed if not set)
+}
+
+/**
+ * Response: Return ciphered/deciphered value
+ * @end
+ */
+message CipheredKeyValue {
+    required bytes value = 1;           // ciphered/deciphered value
+}
+
+/**
+ * Structure representing identity data
+ * @embed
+ */
+message IdentityType {
+    optional string proto = 1;              // proto part of URI
+    optional string user = 2;               // user part of URI
+    optional string host = 3;               // host part of URI
+    optional string port = 4;               // port part of URI
+    optional string path = 5;               // path part of URI
+    optional uint32 index = 6 [default=0];  // identity index
+}
+
+/**
+ * Request: Ask device to sign identity
+ * @start
+ * @next SignedIdentity
+ * @next Failure
+ */
+message SignIdentity {
+    required IdentityType identity = 1;                  // identity
+    optional bytes challenge_hidden = 2 [default=""];    // non-visible challenge
+    optional string challenge_visual = 3 [default=""];   // challenge shown on display (e.g. date+time)
+    optional string ecdsa_curve_name = 4;                // ECDSA curve name to use
+}
+
+/**
+ * Response: Device provides signed identity
+ * @end
+ */
+message SignedIdentity {
+    optional string address = 1;    // identity address
+    required bytes public_key = 2;  // identity public key
+    required bytes signature = 3;   // signature of the identity data
+}
+
+/**
+ * Request: Ask device to generate ECDH session key
+ * @start
+ * @next ECDHSessionKey
+ * @next Failure
+ */
+message GetECDHSessionKey {
+    required IdentityType identity = 1;     // identity
+    required bytes peer_public_key = 2;     // peer's public key
+    optional string ecdsa_curve_name = 3;   // ECDSA curve name to use
+}
+
+/**
+ * Response: Device provides ECDH session key
+ * @end
+ */
+message ECDHSessionKey {
+    required bytes session_key = 1;     // ECDH session key
+    optional bytes public_key = 2;  // identity public key
+}
+
+/**
+ * Request: Ask device to commit to CoSi signing
+ * @start
+ * @next CosiCommitment
+ * @next Failure
+ */
+message CosiCommit {
+    repeated uint32 address_n = 1;              // BIP-32 path to derive the key from master node
+    optional bytes data = 2 [deprecated=true];  // Data to be signed. Deprecated in 1.10.2, the field is not needed, since CoSi commitments are no longer deterministic.
+}
+
+/**
+ * Response: Contains a CoSi commitment
+ * @end
+ */
+message CosiCommitment {
+    required bytes commitment = 1;  // Commitment
+    required bytes pubkey = 2;      // Public key
+}
+
+/**
+ * Request: Ask device to sign using CoSi
+ * @start
+ * @next CosiSignature
+ * @next Failure
+ */
+message CosiSign {
+    repeated uint32 address_n = 1;          // BIP-32 path to derive the key from master node
+    required bytes data = 2;                // Data to be signed
+    required bytes global_commitment = 3;   // Aggregated commitment
+    required bytes global_pubkey = 4;       // Aggregated public key
+}
+
+/**
+ * Response: Contains a CoSi signature
+ * @end
+ */
+message CosiSignature {
+    required bytes signature = 1;   // Signature
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-debug.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-debug.proto
@@ -1,0 +1,206 @@
+syntax = "proto2";
+package hw.trezor.messages.debug;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageDebug";
+
+option (include_in_bitcoin_only) = true;
+
+import "messages.proto";
+import "messages-common.proto";
+import "messages-management.proto";
+
+/**
+ * Request: "Press" the button on the device
+ * @start
+ * @next DebugLinkLayout
+ */
+message DebugLinkDecision {
+    optional DebugButton button = 1;  // button press
+    optional DebugSwipeDirection swipe = 2;  // swipe direction
+    optional string input = 3;  // keyboard input
+    /**
+    * Structure representing swipe direction
+    */
+    enum DebugSwipeDirection {
+        UP = 0;
+        DOWN = 1;
+        LEFT = 2;
+        RIGHT = 3;
+    }
+
+    /**
+    * Structure representing button presses
+    */
+    enum DebugButton {
+        NO = 0;
+        YES = 1;
+        INFO = 2;
+    }
+
+    /**
+    * Structure representing model R button presses
+    */
+    // TODO: probably delete the middle_btn as it is not a physical one
+    enum DebugPhysicalButton {
+        LEFT_BTN = 0;
+        MIDDLE_BTN = 1;
+        RIGHT_BTN = 2;
+    }
+
+    optional uint32 x = 4;                             // touch X coordinate
+    optional uint32 y = 5;                             // touch Y coordinate
+    optional bool wait = 6;                            // wait for layout change
+    optional uint32 hold_ms = 7;                       // touch hold duration
+    optional DebugPhysicalButton physical_button = 8;  // physical button press
+}
+
+/**
+ * Response: Device text layout as a list of tokens as returned by Rust
+ * @end
+ */
+message DebugLinkLayout {
+    repeated string tokens = 1;
+}
+
+/**
+ * Request: Re-seed RNG with given value
+ * @start
+ * @next Success
+ */
+message DebugLinkReseedRandom {
+    optional uint32 value = 1;
+}
+
+/**
+ * Request: Start or stop recording screen changes into given target directory
+ * @start
+ * @next Success
+ */
+message DebugLinkRecordScreen {
+    optional string target_directory = 1;           // empty or missing to stop recording
+    optional uint32 refresh_index = 2 [default=0];  // which index to give the screenshots (after emulator restarts)
+}
+
+/**
+ * Request: Computer asks for device state
+ * @start
+ * @next DebugLinkState
+ */
+message DebugLinkGetState {
+    optional bool wait_word_list = 1;  // Trezor T only - wait until mnemonic words are shown
+    optional bool wait_word_pos = 2;   // Trezor T only - wait until reset word position is requested
+    optional bool wait_layout = 3;     // wait until current layout changes
+}
+
+/**
+ * Response: Device current state
+ * @end
+ */
+message DebugLinkState {
+    optional bytes layout = 1;                              // raw buffer of display
+    optional string pin = 2;                                // current PIN, blank if PIN is not set/enabled
+    optional string matrix = 3;                             // current PIN matrix
+    optional bytes mnemonic_secret = 4;                     // current mnemonic secret
+    optional common.HDNodeType node = 5; // current BIP-32 node
+    optional bool passphrase_protection = 6;                // is node/mnemonic encrypted using passphrase?
+    optional string reset_word = 7;                         // word on device display during ResetDevice workflow
+    optional bytes reset_entropy = 8;                       // current entropy during ResetDevice workflow
+    optional string recovery_fake_word = 9;                 // (fake) word on display during RecoveryDevice workflow
+    optional uint32 recovery_word_pos = 10;                 // index of mnemonic word the device is expecting during RecoveryDevice workflow
+    optional uint32 reset_word_pos = 11;                    // index of mnemonic word the device is expecting during ResetDevice workflow
+    optional management.BackupType mnemonic_type = 12;      // current mnemonic type (BIP-39/SLIP-39)
+    repeated string tokens = 13;                            // current layout represented as a list of string tokens
+}
+
+/**
+ * Request: Ask device to restart
+ * @start
+ */
+message DebugLinkStop {
+}
+
+/**
+ * Response: Device wants host to log event
+ * @ignore
+ */
+message DebugLinkLog {
+    optional uint32 level = 1;
+    optional string bucket = 2;
+    optional string text = 3;
+}
+
+/**
+ * Request: Read memory from device
+ * @start
+ * @next DebugLinkMemory
+ */
+message DebugLinkMemoryRead {
+    optional uint32 address = 1;
+    optional uint32 length = 2;
+}
+
+/**
+ * Response: Device sends memory back
+ * @end
+ */
+message DebugLinkMemory {
+    optional bytes memory = 1;
+}
+
+/**
+ * Request: Write memory to device.
+ * WARNING: Writing to the wrong location can irreparably break the device.
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message DebugLinkMemoryWrite {
+    optional uint32 address = 1;
+    optional bytes memory = 2;
+    optional bool flash = 3;
+}
+
+/**
+ * Request: Erase block of flash on device
+ * WARNING: Writing to the wrong location can irreparably break the device.
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message DebugLinkFlashErase {
+    optional uint32 sector = 1;
+}
+
+
+/**
+ * Request: Erase the SD card
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message DebugLinkEraseSdCard {
+    optional bool format = 1;  // if true, the card will be formatted to FAT32.
+                               // if false, it will be all 0xFF bytes.
+}
+
+
+/**
+ * Request: Start or stop tracking layout changes
+ * @start
+ * @next Success
+ */
+message DebugLinkWatchLayout {
+    optional bool watch = 1;  // if true, start watching layout.
+                              // if false, stop.
+}
+
+
+/**
+ * Request: Remove all the previous debug event state
+ * @start
+ * @next Success
+ */
+message DebugLinkResetDebugEvents {
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-eos.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-eos.proto
@@ -1,0 +1,283 @@
+syntax = "proto2";
+package hw.trezor.messages.eos;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageEos";
+
+/**
+ * Request: Ask device for Eos public key corresponding to address_n path
+ * @start
+ * @next EosPublicKey
+ * @next Failure
+ */
+message EosGetPublicKey {
+    repeated uint32 address_n = 1;  // BIP-32 path to derive the key from master node 44'/194'/0'
+    optional bool show_display = 2; // optionally show on display before sending the result
+    optional bool chunkify = 3;     // display the address in chunks of 4 characters
+}
+
+/**
+ * Response: Contains an Eos public key derived from device private seed
+ * @end
+ */
+message EosPublicKey {
+    required string wif_public_key = 1; // EOS pub key in Base58 encoding
+    required bytes raw_public_key = 2;  // Raw public key
+}
+
+/**
+ * Request: Ask device to sign transaction
+ * @start
+ * @next EosTxRequest
+ * @next Failure
+ */
+message EosSignTx {
+    repeated uint32 address_n = 1;   // BIP-32 path to derive the key from master node 44'/194'/0'
+    required bytes chain_id = 2;     // 256-bit long chain id
+    required EosTxHeader header = 3; // EOS transaction header
+    required uint32 num_actions = 4; // number of actions
+    optional bool chunkify = 5;      // display the address in chunks of 4 characters
+
+    /**
+     * Structure representing EOS transaction header
+     */
+    message EosTxHeader {
+        required uint32 expiration = 1;          // time at which transaction expires
+        required uint32 ref_block_num = 2;       // 16-bit specifies a block num in the last 2^16 blocks.
+        required uint32 ref_block_prefix = 3;    // specifies the lower 32 bits of the blockid at get_ref_blocknum
+        required uint32 max_net_usage_words = 4; // upper limit on total network bandwidth (in 8 byte words) billed for this transaction
+        required uint32 max_cpu_usage_ms = 5;    // 8-bit upper limit on the total CPU time billed for this transaction
+        required uint32 delay_sec = 6;           // number of seconds to delay this transaction for during which it may be canceled.
+    }
+}
+
+/**
+ * Response: Device asks to upload next action
+ * @next EosTxActionAck
+ */
+message EosTxActionRequest {
+    optional uint32 data_size = 1;
+}
+
+/**
+ * Request: Next action data that needs to be uploaded
+ * @next EosTxActionRequest
+ * @next EosSignedTx
+ * @next Failure
+ */
+message EosTxActionAck {
+    required EosActionCommon common = 1;
+    optional EosActionTransfer transfer = 2;
+    optional EosActionDelegate delegate = 3;
+    optional EosActionUndelegate undelegate = 4;
+    optional EosActionRefund refund = 5;
+    optional EosActionBuyRam buy_ram = 6;
+    optional EosActionBuyRamBytes buy_ram_bytes = 7;
+    optional EosActionSellRam sell_ram = 8;
+    optional EosActionVoteProducer vote_producer = 9;
+    optional EosActionUpdateAuth update_auth = 10;
+    optional EosActionDeleteAuth delete_auth = 11;
+    optional EosActionLinkAuth link_auth = 12;
+    optional EosActionUnlinkAuth unlink_auth = 13;
+    optional EosActionNewAccount new_account = 14;
+    optional EosActionUnknown unknown = 15;
+
+    /**
+     * Structure representing asset type
+     */
+    message EosAsset {
+        required sint64 amount = 1;
+        required uint64 symbol = 2; // Lowest 8 bits used for precision.
+    }
+
+    /**
+     * Structure representing action permission level
+     */
+    message EosPermissionLevel {
+        required uint64 actor = 1;
+        required uint64 permission = 2;
+    }
+
+    /**
+     * Structure representing auth key
+     */
+    message EosAuthorizationKey {
+        required uint32 type = 1;
+        optional bytes key = 2;        // Explicit public key bytes; when present, address_n must be empty
+        repeated uint32 address_n = 3; // BIP-32 path to derive key; when filled out, key must not be present
+        required uint32 weight = 4;
+    }
+
+    /**
+     * Structure representing auth account
+     */
+    message EosAuthorizationAccount {
+        required EosPermissionLevel account = 1;
+        required uint32 weight = 2;
+    }
+
+    /**
+     * Structure representing auth delays
+     */
+    message EosAuthorizationWait {
+        required uint32 wait_sec = 1;
+        required uint32 weight = 2;
+    }
+
+    /**
+     * Structure representing authorization settings
+     */
+    message EosAuthorization {
+        required uint32 threshold = 1;
+        repeated EosAuthorizationKey keys = 2;
+        repeated EosAuthorizationAccount accounts = 3;
+        repeated EosAuthorizationWait waits = 4;
+    }
+
+    /**
+     * Structure representing the common part of every action
+     */
+    message EosActionCommon {
+        required uint64 account = 1; // Contract name
+        required uint64 name = 2;    // Action name
+        repeated EosPermissionLevel authorization = 3;
+    }
+
+    /**
+     * Structure representing transfer data structure
+     */
+    message EosActionTransfer {
+        required uint64 sender = 1; // Asset sender
+        required uint64 receiver = 2;
+        required EosAsset quantity = 3;
+        required string memo = 4;
+    }
+
+    /**
+     * Structure representing delegation data structure
+     */
+    message EosActionDelegate {
+        required uint64 sender = 1;
+        required uint64 receiver = 2;
+        required EosAsset net_quantity = 3; // Asset format '1.0000 EOS'
+        required EosAsset cpu_quantity = 4; // Asset format '1.0000 EOS'
+        required bool transfer = 5;         // Transfer delegated tokens or not.
+    }
+
+    /**
+     * Structure representing the removal of delegated resources from `sender`
+     */
+    message EosActionUndelegate {
+        required uint64 sender = 1;
+        required uint64 receiver = 2;
+        required EosAsset net_quantity = 3; // Asset format '1.0000 EOS'
+        required EosAsset cpu_quantity = 4; // Asset format '1.0000 EOS'
+    }
+
+    /**
+     * Structure representing fallback if undelegate wasnt executed automaticaly.
+     */
+    message EosActionRefund {
+        required uint64 owner = 1;
+    }
+
+    /**
+     * Structure representing buying RAM operation for EOS tokens
+     */
+    message EosActionBuyRam {
+        required uint64 payer = 1;
+        required uint64 receiver = 2;
+        required EosAsset quantity = 3; // Asset format '1.0000 EOS'
+    }
+
+    /**
+     * Structure representing buying bytes according to RAM market price.
+     */
+    message EosActionBuyRamBytes {
+        required uint64 payer = 1;
+        required uint64 receiver = 2;
+        required uint32 bytes = 3; // Number of bytes
+    }
+
+    /**
+     * Structure representing sell RAM
+     */
+    message EosActionSellRam {
+        required uint64 account = 1;
+        required uint64 bytes = 2; // Number of bytes
+    }
+
+    /**
+     * Structure representing voting. Currently, there could be up to 30 producers.
+     */
+    message EosActionVoteProducer {
+        required uint64 voter = 1;     // Voter account
+        required uint64 proxy = 2;     // Proxy voter account
+        repeated uint64 producers = 3; // List of producers
+    }
+
+    /**
+     * Structure representing update authorization.
+     */
+    message EosActionUpdateAuth {
+        required uint64 account = 1;
+        required uint64 permission = 2;
+        required uint64 parent = 3;
+        required EosAuthorization auth = 4;
+    }
+
+    /**
+     * Structure representing delete authorization.
+     */
+    message EosActionDeleteAuth {
+        required uint64 account = 1;
+        required uint64 permission = 2;
+    }
+
+    /**
+     * Structure representing link authorization to action.
+     */
+    message EosActionLinkAuth {
+        required uint64 account = 1;
+        required uint64 code = 2;
+        required uint64 type = 3;
+        required uint64 requirement = 4;
+    }
+
+    /**
+     * Structure representing unlink authorization from action.
+     */
+    message EosActionUnlinkAuth {
+        required uint64 account = 1;
+        required uint64 code = 2;
+        required uint64 type = 3;
+    }
+
+    /**
+     * Structure representing creation of a new account.
+     */
+    message EosActionNewAccount {
+        required uint64 creator = 1;
+        required uint64 name = 2;
+        required EosAuthorization owner = 3;
+        required EosAuthorization active = 4;
+    }
+
+    /**
+     * Structure representing actions not implemented above.
+     */
+    message EosActionUnknown {
+        required uint32 data_size = 1;
+        required bytes data_chunk = 2;
+    }
+}
+
+/**
+ * Response: Device returns the signature.
+ * The signature_* fields contain the computed transaction signature. All three fields will be present.
+ * @end
+ */
+message EosSignedTx {
+    required string signature = 1; // Computed signature
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-ethereum-definitions.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-ethereum-definitions.proto
@@ -1,0 +1,60 @@
+syntax = "proto2";
+package hw.trezor.messages.ethereum_definitions;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageEthereumDefinitions";
+
+
+/**
+ * Ethereum definitions type enum.
+ * Used to check the encoded EthereumNetworkInfo or EthereumTokenInfo message.
+ */
+ enum EthereumDefinitionType {
+    NETWORK = 0;
+    TOKEN = 1;
+}
+
+/**
+ * Ethereum network definition. Used to (de)serialize the definition.
+ *
+ * Definition types should not be cross-parseable, i.e., it should not be possible to
+ * incorrectly parse network info as token info or vice versa.
+ * To achieve that, the first field is wire type varint while the second field is wire type
+ * length-delimited. Both are a mismatch for the token definition.
+ *
+ * @embed
+ */
+message EthereumNetworkInfo {
+    required uint64 chain_id = 1;
+    required string symbol = 2;
+    required uint32 slip44 = 3;
+    required string name = 4;
+}
+
+/**
+ * Ethereum token definition. Used to (de)serialize the definition.
+ *
+ * Definition types should not be cross-parseable, i.e., it should not be possible to
+ * incorrectly parse network info as token info or vice versa.
+ * To achieve that, the first field is wire type length-delimited while the second field
+ * is wire type varint. Both are a mismatch for the network definition.
+ *
+ * @embed
+ */
+message EthereumTokenInfo {
+    required bytes address = 1;
+    required uint64 chain_id = 2;
+    required string symbol = 3;
+    required uint32 decimals = 4;
+    required string name = 5;
+}
+
+/**
+ * Contains an encoded Ethereum network and/or token definition. See ethereum-definitions.md for details.
+ * @embed
+ */
+message EthereumDefinitions {
+    optional bytes encoded_network = 1; // encoded Ethereum network
+    optional bytes encoded_token = 2;   // encoded Ethereum token
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-ethereum-eip712.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-ethereum-eip712.proto
@@ -1,0 +1,92 @@
+syntax = "proto2";
+package hw.trezor.messages.ethereum_eip712;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageEthereumEIP712";
+
+import "messages-ethereum-definitions.proto";
+
+
+// Separated from messages-ethereum.proto as it is not implemented on T1 side
+// and defining all the messages and fields could be even impossible as recursive
+// messages are used here
+
+
+/**
+ * Request: Ask device to sign typed data
+ * @start
+ * @next EthereumTypedDataStructRequest
+ * @next EthereumTypedDataValueRequest
+ * @next EthereumTypedDataSignature
+ * @next Failure
+ */
+message EthereumSignTypedData {
+    repeated uint32 address_n = 1;                                      // BIP-32 path to derive the key from master node
+    required string primary_type = 2;                                   // name of the root message struct
+    optional bool metamask_v4_compat = 3 [default=true];                // use MetaMask v4 (see https://github.com/MetaMask/eth-sig-util/issues/106)
+    optional ethereum_definitions.EthereumDefinitions definitions = 4;  // network and/or token definitions
+}
+
+/**
+ * Response: Device asks for type information about a struct.
+ * @next EthereumTypedDataStructAck
+ */
+message EthereumTypedDataStructRequest {
+    required string name = 1; // name of the requested struct
+}
+
+/**
+ * Request: Type information about a struct.
+ * @next EthereumTypedDataStructRequest
+ */
+message EthereumTypedDataStructAck {
+    repeated EthereumStructMember members = 1;
+
+    message EthereumStructMember {
+        required EthereumFieldType type = 1;
+        required string name = 2;
+    }
+
+    message EthereumFieldType {
+        required EthereumDataType data_type = 1;
+        optional uint32 size = 2;                   // for integer types: size in bytes (uint8 has size 1, uint256 has size 32)
+                                                    // for bytes types: size in bytes, or unset for dynamic
+                                                    // for arrays: size in elements, or unset for dynamic
+                                                    // for structs: number of members
+                                                    // for string, bool and address: unset
+        optional EthereumFieldType entry_type = 3;  // for array types, type of single entry
+        optional string struct_name = 4;            // for structs: its name
+    }
+
+    enum EthereumDataType {
+        UINT = 1;
+        INT = 2;
+        BYTES = 3;
+        STRING = 4;
+        BOOL = 5;
+        ADDRESS = 6;
+        ARRAY = 7;
+        STRUCT = 8;
+    }
+}
+
+/**
+ * Response: Device asks for data at the specific member path.
+ * @next EthereumTypedDataValueAck
+ */
+message EthereumTypedDataValueRequest {
+    repeated uint32 member_path = 1; // member path requested by device
+}
+
+/**
+ * Request: Single value of a specific atomic field.
+ * @next EthereumTypedDataValueRequest
+ */
+message EthereumTypedDataValueAck {
+    required bytes value = 1;
+    // * atomic types: value of the member.
+    //   Length must match the `size` of the corresponding field type, unless the size is dynamic.
+    // * array types: number of elements, encoded as uint16.
+    // * struct types: undefined, Trezor will not query a struct field.
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-ethereum.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-ethereum.proto
@@ -1,0 +1,183 @@
+syntax = "proto2";
+package hw.trezor.messages.ethereum;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageEthereum";
+
+import "messages-common.proto";
+import "messages-ethereum-definitions.proto";
+
+
+/**
+ * Request: Ask device for public key corresponding to address_n path
+ * @start
+ * @next EthereumPublicKey
+ * @next Failure
+ */
+message EthereumGetPublicKey {
+    repeated uint32 address_n = 1;      // BIP-32 path to derive the key from master node
+    optional bool show_display = 2;     // optionally show on display before sending the result
+}
+
+/**
+ * Response: Contains public key derived from device private seed
+ * @end
+ */
+message EthereumPublicKey {
+    required hw.trezor.messages.common.HDNodeType node = 1;        // BIP32 public node
+    required string xpub = 2;        // serialized form of public node
+}
+
+/**
+ * Request: Ask device for Ethereum address corresponding to address_n path
+ * @start
+ * @next EthereumAddress
+ * @next Failure
+ */
+message EthereumGetAddress {
+    repeated uint32 address_n = 1;      // BIP-32 path to derive the key from master node
+    optional bool show_display = 2;     // optionally show on display before sending the result
+    optional bytes encoded_network = 3; // encoded Ethereum network, see ethereum-definitions.md for details
+    optional bool chunkify = 4;         // display the address in chunks of 4 characters
+}
+
+/**
+ * Response: Contains an Ethereum address derived from device private seed
+ * @end
+ */
+message EthereumAddress {
+    optional bytes _old_address = 1 [deprecated=true];  // trezor <1.8.0, <2.1.0 - raw bytes of Ethereum address
+    optional string address = 2;                       // Ethereum address as hex-encoded string
+}
+
+/**
+ * Request: Ask device to sign transaction
+ * gas_price, gas_limit and chain_id must be provided and non-zero.
+ * All other fields are optional and default to value `0` if missing.
+ * Note: the first at most 1024 bytes of data MUST be transmitted as part of this message.
+ * @start
+ * @next EthereumTxRequest
+ * @next Failure
+ */
+message EthereumSignTx {
+    repeated uint32 address_n = 1;                                       // BIP-32 path to derive the key from master node
+    optional bytes nonce = 2 [default=''];                               // <=256 bit unsigned big endian
+    required bytes gas_price = 3;                                        // <=256 bit unsigned big endian (in wei)
+    required bytes gas_limit = 4;                                        // <=256 bit unsigned big endian
+    optional string to = 11 [default=''];                                // recipient address
+    optional bytes value = 6 [default=''];                               // <=256 bit unsigned big endian (in wei)
+    optional bytes data_initial_chunk = 7 [default=''];                  // The initial data chunk (<= 1024 bytes)
+    optional uint32 data_length = 8 [default=0];                         // Length of transaction payload
+    required uint64 chain_id = 9;                                        // Chain Id for EIP 155
+    optional uint32 tx_type = 10;                                        // Used for Wanchain
+    optional ethereum_definitions.EthereumDefinitions definitions = 12;  // network and/or token definitions for tx
+    optional bool chunkify = 13;                                         // display the address in chunks of 4 characters
+}
+
+/**
+ * Request: Ask device to sign EIP1559 transaction
+ * Note: the first at most 1024 bytes of data MUST be transmitted as part of this message.
+ * @start
+ * @next EthereumTxRequest
+ * @next Failure
+ */
+message EthereumSignTxEIP1559 {
+    repeated uint32 address_n = 1;                                             // BIP-32 path to derive the key from master node
+    required bytes nonce = 2;                                                  // <=256 bit unsigned big endian
+    required bytes max_gas_fee = 3;                                            // <=256 bit unsigned big endian (in wei)
+    required bytes max_priority_fee = 4;                                       // <=256 bit unsigned big endian (in wei)
+    required bytes gas_limit = 5;                                              // <=256 bit unsigned big endian
+    optional string to = 6 [default=''];                                       // recipient address
+    required bytes value = 7;                                                  // <=256 bit unsigned big endian (in wei)
+    optional bytes data_initial_chunk = 8 [default=''];                        // The initial data chunk (<= 1024 bytes)
+    required uint32 data_length = 9;                                           // Length of transaction payload
+    required uint64 chain_id = 10;                                             // Chain Id for EIP 155
+    repeated EthereumAccessList access_list = 11;                              // Access List
+    optional ethereum_definitions.EthereumDefinitions definitions = 12;        // network and/or token definitions for tx
+    optional bool chunkify = 13;                                               // display the address in chunks of 4 characters
+
+    message EthereumAccessList {
+        required string address = 1;
+        repeated bytes storage_keys = 2;
+    }
+}
+
+/**
+ * Response: Device asks for more data from transaction payload, or returns the signature.
+ * If data_length is set, device awaits that many more bytes of payload.
+ * Otherwise, the signature_* fields contain the computed transaction signature. All three fields will be present.
+ * @end
+ * @next EthereumTxAck
+ */
+message EthereumTxRequest {
+    optional uint32 data_length = 1;    // Number of bytes being requested (<= 1024)
+    optional uint32 signature_v = 2;    // Computed signature (recovery parameter, limited to 27 or 28)
+    optional bytes signature_r = 3;     // Computed signature R component (256 bit)
+    optional bytes signature_s = 4;     // Computed signature S component (256 bit)
+}
+
+/**
+ * Request: Transaction payload data.
+ * @next EthereumTxRequest
+ */
+message EthereumTxAck {
+    required bytes data_chunk = 1;  // Bytes from transaction payload (<= 1024 bytes)
+}
+
+/**
+ * Request: Ask device to sign message
+ * @start
+ * @next EthereumMessageSignature
+ * @next Failure
+ */
+message EthereumSignMessage {
+    repeated uint32 address_n = 1;      // BIP-32 path to derive the key from master node
+    required bytes message = 2;         // message to be signed
+    optional bytes encoded_network = 3; // encoded Ethereum network, see ethereum-definitions.md for details
+    optional bool chunkify = 4;         // display the address in chunks of 4 characters
+}
+
+/**
+ * Response: Signed message
+ * @end
+ */
+message EthereumMessageSignature {
+    required bytes signature = 2;   // signature of the message
+    required string address = 3;     // address used to sign the message
+}
+
+/**
+ * Request: Ask device to verify message
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message EthereumVerifyMessage {
+    required bytes signature = 2;       // signature to verify
+    required bytes message = 3;         // message to verify
+    required string address = 4;        // address to verify
+    optional bool chunkify = 5;         // display the address in chunks of 4 characters
+}
+
+/**
+ * Request: Ask device to sign hash of typed data
+ * @start
+ * @next EthereumTypedDataSignature
+ * @next Failure
+ */
+message EthereumSignTypedHash {
+    repeated uint32 address_n = 1;              // BIP-32 path to derive the key from master node
+    required bytes domain_separator_hash = 2;   // Hash of domainSeparator of typed data to be signed
+    optional bytes message_hash = 3;            // Hash of the data of typed data to be signed (empty if domain-only data)
+    optional bytes encoded_network = 4;         // encoded Ethereum network, see ethereum-definitions.md for details
+}
+
+/**
+ * Response: Signed typed data
+ * @end
+ */
+message EthereumTypedDataSignature {
+    required bytes signature = 1;    // signature of the typed data
+    required string address = 2;     // address used to sign the typed data
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-management.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-management.proto
@@ -1,0 +1,604 @@
+syntax = "proto2";
+package hw.trezor.messages.management;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageManagement";
+
+option (include_in_bitcoin_only) = true;
+
+import "messages.proto";
+
+/**
+ * Type of the mnemonic backup given/received by the device during reset/recovery.
+ */
+enum BackupType {
+    Bip39 = 0;              // also called "Single Backup", see BIP-0039
+    Slip39_Basic = 1;       // also called "Shamir Backup", see SLIP-0039
+    Slip39_Advanced = 2;    // also called "Super Shamir" or "Shamir with Groups", see SLIP-0039#two-level-scheme
+}
+
+/**
+ * Level of safety checks for unsafe actions like spending from invalid path namespace or setting high transaction fee.
+ */
+enum SafetyCheckLevel {
+    Strict = 0;             // disallow unsafe actions, this is the default
+    PromptAlways = 1;       // ask user before unsafe action
+    PromptTemporarily = 2;  // like PromptAlways but reverts to Strict after reboot
+}
+
+
+/**
+ * Format of the homescreen image
+ */
+enum HomescreenFormat {
+    Toif = 1;   // full-color toif
+    Jpeg = 2;   // jpeg
+    ToiG = 3;   // greyscale toif
+}
+
+/**
+ * Request: Reset device to default state and ask for device details
+ * @start
+ * @next Features
+ */
+message Initialize {
+    optional bytes session_id = 1;     // assumed device session id; Trezor clears caches if it is different or empty
+    optional bool _skip_passphrase = 2 [deprecated=true]; // removed as part of passphrase redesign
+    optional bool derive_cardano = 3;  // whether to derive Cardano Icarus root keys in this session
+}
+
+/**
+ * Request: Ask for device details (no device reset)
+ * @start
+ * @next Features
+ */
+message GetFeatures {
+}
+
+/**
+ * Response: Reports various information about the device
+ * @end
+ */
+message Features {
+    optional string vendor = 1;                 // name of the manufacturer, e.g. "trezor.io"
+    required uint32 major_version = 2;          // major version of the firmware/bootloader, e.g. 1
+    required uint32 minor_version = 3;          // minor version of the firmware/bootloader, e.g. 0
+    required uint32 patch_version = 4;          // patch version of the firmware/bootloader, e.g. 0
+    optional bool bootloader_mode = 5;          // is device in bootloader mode?
+    optional string device_id = 6;              // device's unique identifier
+    optional bool pin_protection = 7;           // is device protected by PIN?
+    optional bool passphrase_protection = 8;    // is node/mnemonic encrypted using passphrase?
+    optional string language = 9;               // device language
+    optional string label = 10;                 // device description label
+    optional bool initialized = 12;             // does device contain seed?
+    optional bytes revision = 13;               // SCM revision of firmware
+    optional bytes bootloader_hash = 14;        // hash of the bootloader
+    optional bool imported = 15;                // was storage imported from an external source?
+    optional bool unlocked = 16;                // is the device unlocked? called "pin_cached" previously
+    optional bool _passphrase_cached = 17 [deprecated=true]; // is passphrase already cached in session?
+    optional bool firmware_present = 18;        // is valid firmware loaded?
+    optional bool needs_backup = 19;            // does storage need backup? (equals to Storage.needs_backup)
+    optional uint32 flags = 20;                 // device flags (equals to Storage.flags)
+    optional string model = 21;                 // device hardware model
+    optional uint32 fw_major = 22;              // reported firmware version if in bootloader mode
+    optional uint32 fw_minor = 23;              // reported firmware version if in bootloader mode
+    optional uint32 fw_patch = 24;              // reported firmware version if in bootloader mode
+    optional string fw_vendor = 25;             // reported firmware vendor if in bootloader mode
+    // optional bytes fw_vendor_keys = 26;      // obsoleted, use fw_vendor
+    optional bool unfinished_backup = 27;       // report unfinished backup (equals to Storage.unfinished_backup)
+    optional bool no_backup = 28;               // report no backup (equals to Storage.no_backup)
+    optional bool recovery_mode = 29;           // is recovery mode in progress
+    repeated Capability capabilities = 30;      // list of supported capabilities
+    enum Capability {
+        option (has_bitcoin_only_values) = true;
+
+        Capability_Bitcoin = 1 [(bitcoin_only) = true];
+        Capability_Bitcoin_like = 2;                    // Altcoins based on the Bitcoin source code
+        Capability_Binance = 3;
+        Capability_Cardano = 4;
+        Capability_Crypto = 5 [(bitcoin_only) = true];  // generic crypto operations for GPG, SSH, etc.
+        Capability_EOS = 6;
+        Capability_Ethereum = 7;
+        Capability_Lisk = 8 [deprecated = true];
+        Capability_Monero = 9;
+        Capability_NEM = 10;
+        Capability_Ripple = 11;
+        Capability_Stellar = 12;
+        Capability_Tezos = 13;
+        Capability_U2F = 14;
+        Capability_Shamir = 15 [(bitcoin_only) = true];
+        Capability_ShamirGroups = 16 [(bitcoin_only) = true];
+        Capability_PassphraseEntry = 17 [(bitcoin_only) = true];  // the device is capable of passphrase entry directly on the device
+        Capability_Solana = 18;
+        Capability_Translations = 19 [(bitcoin_only) = true];
+    }
+    optional BackupType backup_type = 31;       // type of device backup (BIP-39 / SLIP-39 basic / SLIP-39 advanced)
+    optional bool sd_card_present = 32;         // is SD card present
+    optional bool sd_protection = 33;           // is SD Protect enabled
+    optional bool wipe_code_protection = 34;    // is wipe code protection enabled
+    optional bytes session_id = 35;
+    optional bool passphrase_always_on_device = 36;  // device enforces passphrase entry on Trezor
+    optional SafetyCheckLevel safety_checks = 37;            // safety check level, set to Prompt to limit path namespace enforcement
+    optional uint32 auto_lock_delay_ms = 38;    // number of milliseconds after which the device locks itself
+    optional uint32 display_rotation = 39;      // in degrees from North
+    optional bool experimental_features = 40;   // are experimental message types enabled?
+    optional bool busy = 41;                    // is the device busy, showing "Do not disconnect"?
+    optional HomescreenFormat homescreen_format = 42;   // format of the homescreen, 1 = TOIf, 2 = jpg, 3 = TOIG
+    optional bool hide_passphrase_from_host = 43;   // should we hide the passphrase when it comes from host?
+    optional string internal_model = 44;        // internal model name
+    optional uint32 unit_color = 45;          // color of the unit/device
+    optional bool unit_btconly = 46;          // unit/device is intended as bitcoin only
+    optional uint32 homescreen_width = 47;         // homescreen width in pixels
+    optional uint32 homescreen_height = 48;         // homescreen height in pixels
+    optional bool bootloader_locked = 49;       // bootloader is locked
+    optional bool language_version_matches = 50 [default=true];  // translation blob version matches firmware version
+}
+
+/**
+ * Request: soft-lock the device. Following actions will require PIN. Passphrases remain cached.
+ * @start
+ * @next Success
+ */
+message LockDevice {
+}
+
+/**
+ * Request: Show a "Do not disconnect" dialog instead of the standard homescreen.
+ * @start
+ * @next Success
+ */
+message SetBusy {
+    optional uint32 expiry_ms = 1;  // The time in milliseconds after which the dialog will automatically disappear. Overrides any previously set expiry. If not set, then the dialog is hidden.
+}
+
+/**
+ * Request: end the current sesson. Following actions must call Initialize again.
+ * Cache for the current session is discarded, other sessions remain intact.
+ * Device is not PIN-locked.
+ * @start
+ * @next Success
+ */
+message EndSession {
+}
+
+/**
+ * Request: change some property of the device, e.g. label or homescreen
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message ApplySettings {
+    optional string language = 1 [deprecated=true];
+    optional string label = 2;
+    optional bool use_passphrase = 3;
+    optional bytes homescreen = 4;
+    optional uint32 _passphrase_source = 5 [deprecated=true];   // ASK = 0; DEVICE = 1; HOST = 2;
+    optional uint32 auto_lock_delay_ms = 6;
+    optional uint32 display_rotation = 7;  // in degrees from North
+    optional bool passphrase_always_on_device = 8;  // do not prompt for passphrase, enforce device entry
+    optional SafetyCheckLevel safety_checks = 9;  // Safety check level, set to Prompt to limit path namespace enforcement
+    optional bool experimental_features = 10;  // enable experimental message types
+    optional bool hide_passphrase_from_host = 11;  // do not show passphrase coming from host
+}
+
+/**
+ * Request: change the device language via translation data.
+ * Does not send the translation data itself, as they are too large for one message.
+ * Device will request the translation data in chunks.
+ * @start
+ * @next TranslationDataRequest
+ * @next Failure
+ */
+message ChangeLanguage {
+    // byte length of the whole translation blob (set to 0 for default language - english)
+    required uint32 data_length = 1;
+    // Prompt the user on screen.
+    // In certain conditions (such as freshly installed device), the confirmation prompt
+    // is not mandatory. Setting show_display=false will skip the prompt if that's
+    // the case. If the device does not allow skipping the prompt, a request with
+    // show_display=false will return a failure. (This way the host can safely try
+    // to change the language without invoking a prompt.)
+    // Setting show_display to true will always show the prompt.
+    // Leaving the option unset will show the prompt only when necessary.
+    optional bool show_display = 2;
+}
+
+/**
+ * Response: Device asks for more data from transaction payload.
+ * @end
+ * @next TranslationDataAck
+ */
+ message TranslationDataRequest {
+    required uint32 data_length = 1;    // Number of bytes being requested
+    required uint32 data_offset = 2;    // Offset of the first byte being requested
+}
+
+/**
+ * Request: Translation payload data.
+ * @next TranslationDataRequest
+ * @next Success
+ */
+message TranslationDataAck {
+    required bytes data_chunk = 1;  // Bytes from translation payload
+}
+
+/**
+ * Request: set flags of the device
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message ApplyFlags {
+    required uint32 flags = 1;  // bitmask, can only set bits, not unset
+}
+
+/**
+ * Request: Starts workflow for setting/changing/removing the PIN
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message ChangePin {
+    optional bool remove = 1;   // is PIN removal requested?
+}
+
+/**
+ * Request: Starts workflow for setting/removing the wipe code
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message ChangeWipeCode {
+    optional bool remove = 1;   // is wipe code removal requested?
+}
+
+/**
+ * Request: Starts workflow for enabling/regenerating/disabling SD card protection
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message SdProtect {
+    required SdProtectOperationType operation = 1;
+    /**
+    * Structure representing SD card protection operation
+    */
+    enum SdProtectOperationType {
+        DISABLE = 0;
+        ENABLE = 1;
+        REFRESH = 2;
+    }
+}
+
+/**
+ * Request: Test if the device is alive, device sends back the message in Success response
+ * @start
+ * @next Success
+ */
+message Ping {
+    optional string message = 1 [default=""];   // message to send back in Success message
+    optional bool button_protection = 2;        // ask for button press
+}
+
+/**
+ * Request: Abort last operation that required user interaction
+ * @start
+ * @next Failure
+ */
+message Cancel {
+}
+
+/**
+ * Request: Request a sample of random data generated by hardware RNG. May be used for testing.
+ * @start
+ * @next Entropy
+ * @next Failure
+ */
+message GetEntropy {
+    required uint32 size = 1;       // size of requested entropy
+}
+
+/**
+ * Response: Reply with random data generated by internal RNG
+ * @end
+ */
+message Entropy {
+    required bytes entropy = 1;     // chunk of random generated bytes
+}
+
+/**
+ * Request: Get a hash of the installed firmware combined with an optional challenge.
+ * @start
+ * @next FirmwareHash
+ * @next Failure
+ */
+message GetFirmwareHash {
+    optional bytes challenge = 1;   // Blake2s key up to 32 bytes in length.
+}
+
+/**
+ * Response: Hash of the installed firmware combined with the optional challenge.
+ * @end
+ */
+message FirmwareHash {
+    required bytes hash = 1;
+}
+
+/**
+ * Request: Request a signature of the provided challenge.
+ * @start
+ * @next AuthenticityProof
+ * @next Failure
+ */
+message AuthenticateDevice {
+    required bytes challenge = 1;  // A random challenge to sign.
+}
+
+/**
+ * Response: Signature of the provided challenge along with a certificate issued by the Trezor company.
+ * @end
+ */
+message AuthenticityProof {
+    repeated bytes certificates = 1;  // A certificate chain starting with the device certificate, followed by intermediate CA certificates, the last of which is signed by Trezor company's root CA.
+    required bytes signature = 2;     // A DER-encoded signature of "\0x13AuthenticateDevice:" + length-prefixed challenge that should be verified using the device certificate.
+}
+
+/**
+ * Request: Request device to wipe all sensitive data and settings
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message WipeDevice {
+}
+
+/**
+ * Request: Load seed and related internal settings from the computer
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message LoadDevice {
+    repeated string mnemonics = 1;                          // seed encoded as mnemonic (12, 18 or 24 words for BIP39, 20 or 33 for SLIP39)
+    optional string pin = 3;                                // set PIN protection
+    optional bool passphrase_protection = 4;                // enable master node encryption using passphrase
+    optional string language = 5 [deprecated=true];         // deprecated (use ChangeLanguage)
+    optional string label = 6;                              // device label
+    optional bool skip_checksum = 7;                        // do not test mnemonic for valid BIP-39 checksum
+    optional uint32 u2f_counter = 8;                        // U2F counter
+    optional bool needs_backup = 9;                         // set "needs backup" flag
+    optional bool no_backup = 10;                           // indicate that no backup is going to be made
+}
+
+/**
+ * Request: Ask device to do initialization involving user interaction
+ * @start
+ * @next EntropyRequest
+ * @next Failure
+ */
+message ResetDevice {
+    optional bool display_random = 1;                       // display entropy generated by the device before asking for additional entropy
+    optional uint32 strength = 2 [default=256];             // strength of seed in bits
+    optional bool passphrase_protection = 3;                // enable master node encryption using passphrase
+    optional bool pin_protection = 4;                       // enable PIN protection
+    optional string language = 5 [deprecated=true];         // deprecated (use ChangeLanguage)
+    optional string label = 6;                              // device label
+    optional uint32 u2f_counter = 7;                        // U2F counter
+    optional bool skip_backup = 8;                          // postpone seed backup to BackupDevice workflow
+    optional bool no_backup = 9;                            // indicate that no backup is going to be made
+    optional BackupType backup_type = 10 [default=Bip39];   // type of the mnemonic backup
+}
+
+/**
+ * Request: Perform backup of the device seed if not backed up using ResetDevice
+ * @start
+ * @next Success
+ */
+message BackupDevice {
+}
+
+/**
+ * Response: Ask for additional entropy from host computer
+ * @next EntropyAck
+ */
+message EntropyRequest {
+}
+
+/**
+ * Request: Provide additional entropy for seed generation function
+ * @next Success
+ */
+message EntropyAck {
+    required bytes entropy = 1;     // 256 bits (32 bytes) of random data
+}
+
+/**
+ * Request: Start recovery workflow asking user for specific words of mnemonic
+ * Used to recovery device safely even on untrusted computer.
+ * @start
+ * @next WordRequest
+ */
+message RecoveryDevice {
+    optional uint32 word_count = 1;                     // number of words in BIP-39 mnemonic
+    optional bool passphrase_protection = 2;            // enable master node encryption using passphrase
+    optional bool pin_protection = 3;                   // enable PIN protection
+    optional string language = 4 [deprecated=true];     // deprecated (use ChangeLanguage)
+    optional string label = 5;                          // device label
+    optional bool enforce_wordlist = 6;                 // enforce BIP-39 wordlist during the process
+    // 7 reserved for unused recovery method
+    optional RecoveryDeviceType type = 8;               // supported recovery type
+    optional uint32 u2f_counter = 9;                    // U2F counter
+    optional bool dry_run = 10;                         // perform dry-run recovery workflow (for safe mnemonic validation)
+    /**
+     * Type of recovery procedure. These should be used as bitmask, e.g.,
+     * `RecoveryDeviceType_ScrambledWords | RecoveryDeviceType_Matrix`
+     * listing every method supported by the host computer.
+     *
+     * Note that ScrambledWords must be supported by every implementation
+     * for backward compatibility; there is no way to not support it.
+     */
+    enum RecoveryDeviceType {
+        // use powers of two when extending this field
+        RecoveryDeviceType_ScrambledWords = 0;        // words in scrambled order
+        RecoveryDeviceType_Matrix = 1;                // matrix recovery type
+    }
+}
+
+/**
+ * Response: Device is waiting for user to enter word of the mnemonic
+ * Its position is shown only on device's internal display.
+ * @next WordAck
+ */
+message WordRequest {
+    required WordRequestType type = 1;
+    /**
+    * Type of Recovery Word request
+    */
+    enum WordRequestType {
+        WordRequestType_Plain = 0;
+        WordRequestType_Matrix9 = 1;
+        WordRequestType_Matrix6 = 2;
+    }
+}
+
+/**
+ * Request: Computer replies with word from the mnemonic
+ * @next WordRequest
+ * @next Success
+ * @next Failure
+ */
+message WordAck {
+    required string word = 1;           // one word of mnemonic on asked position
+}
+
+/**
+ * Request: Set U2F counter
+ * @start
+ * @next Success
+ */
+message SetU2FCounter {
+    required uint32 u2f_counter = 1;
+}
+
+/**
+ * Request: Set U2F counter
+ * @start
+ * @next NextU2FCounter
+ */
+message GetNextU2FCounter {
+}
+
+/**
+ * Request: Set U2F counter
+ * @end
+ */
+message NextU2FCounter {
+    required uint32 u2f_counter = 1;
+}
+
+/**
+ * Request: Ask device to prepare for a preauthorized operation.
+ * @start
+ * @next PreauthorizedRequest
+ * @next Failure
+ */
+message DoPreauthorized {
+}
+
+/**
+ * Request: Device awaits a preauthorized operation.
+ * @start
+ * @next SignTx
+ * @next GetOwnershipProof
+ */
+message PreauthorizedRequest {
+}
+
+/**
+ * Request: Cancel any outstanding authorization in the current session.
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message CancelAuthorization {
+}
+
+/**
+ * Request: Reboot firmware to bootloader
+ * @start
+ * @next Success
+ */
+message RebootToBootloader {
+    // Action to be performed after rebooting to bootloader
+    optional BootCommand boot_command = 1 [default=STOP_AND_WAIT];
+    // Firmware header to be flashed after rebooting to bootloader
+    optional bytes firmware_header = 2;
+    // Length of language blob to be installed before upgrading firmware
+    optional uint32 language_data_length = 3 [default=0];
+
+    enum BootCommand {
+        // Go to bootloader menu
+        STOP_AND_WAIT = 0;
+        // Connect to host and wait for firmware update
+        INSTALL_UPGRADE = 1;
+    }
+}
+
+/**
+ * Request: Ask device to generate a random nonce and store it in the session's cache
+ * @start
+ * @next Nonce
+ */
+message GetNonce {
+    option (experimental_message) = true;
+}
+
+/**
+ * Response: Contains a random nonce
+ * @end
+ */
+message Nonce {
+    option (experimental_message) = true;
+
+    required bytes nonce = 1; // a 32-byte random value generated by Trezor
+}
+
+/**
+ * Request: Ask device to unlock a subtree of the keychain.
+ * @start
+ * @next UnlockedPathRequest
+ * @next Failure
+ */
+message UnlockPath {
+    repeated uint32 address_n = 1;     // prefix of the BIP-32 path leading to the account (m / purpose')
+    optional bytes mac = 2;            // the MAC returned by UnlockedPathRequest
+}
+
+/**
+ * Request: Device awaits an operation.
+ * @start
+ * @next SignTx
+ * @next GetPublicKey
+ * @next GetAddress
+ */
+message UnlockedPathRequest {
+    optional bytes mac = 1;            // authentication code for future UnlockPath calls
+}
+
+/**
+ * Request: Show tutorial screens on the device
+ * @start
+ * @next Success
+ */
+message ShowDeviceTutorial {
+}
+
+/**
+ * Request: Unlocks bootloader, !irreversible!
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message UnlockBootloader {
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-monero.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-monero.proto
@@ -1,0 +1,504 @@
+syntax = "proto2";
+package hw.trezor.messages.monero;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageMonero";
+
+enum MoneroNetworkType {
+    MAINNET = 0;
+    TESTNET = 1;
+    STAGENET = 2;
+    FAKECHAIN = 3;
+}
+
+/**
+ * Structure representing Monero transaction source entry, UTXO
+ * @embed
+ */
+message MoneroTransactionSourceEntry {
+    repeated MoneroOutputEntry outputs = 1;  // all outputs including decoys (forms the ring)
+    optional uint64 real_output = 2;  // index denoting which item in `outputs` is our real output (not a decoy)
+    optional bytes real_out_tx_key = 3;  // tx key located in the real output's tx
+    repeated bytes real_out_additional_tx_keys = 4;  // additional tx keys if applicable
+    optional uint64 real_output_in_tx_index = 5;  // index of our real output in the tx (aka which output was it in the transaction)
+    optional uint64 amount = 6;
+    optional bool rct = 7;  // is RingCT used (true for newer UTXOs)
+    optional bytes mask = 8;
+    optional MoneroMultisigKLRki multisig_kLRki = 9;
+    optional uint32 subaddr_minor = 10;  // minor subaddr index UTXO was sent to
+    message MoneroOutputEntry {
+        optional uint64 idx = 1;
+        optional MoneroRctKeyPublic key = 2;
+        message MoneroRctKeyPublic {
+            required bytes dest = 1;
+            required bytes commitment = 2;
+        }
+    }
+    message MoneroMultisigKLRki {
+        optional bytes K = 1;
+        optional bytes L = 2;
+        optional bytes R = 3;
+        optional bytes ki = 4;
+    }
+}
+
+/**
+ * Structure representing Monero transaction destination entry
+ * @embed
+ */
+message MoneroTransactionDestinationEntry {
+    optional uint64 amount = 1;
+    optional MoneroAccountPublicAddress addr = 2;
+    optional bool is_subaddress = 3;
+    optional bytes original = 4;
+    optional bool is_integrated = 5;
+    /**
+     * Structure representing Monero public address
+     */
+    message MoneroAccountPublicAddress {
+        optional bytes spend_public_key = 1;
+        optional bytes view_public_key = 2;
+    }
+}
+
+/**
+ * Range sig parameters / data.
+ * @embed
+ */
+message MoneroTransactionRsigData {
+    optional uint32 rsig_type = 1;  // range signature (aka proof) type
+    optional uint32 offload_type = 2;
+    repeated uint64 grouping = 3;  // aggregation scheme for BP
+
+    optional bytes mask = 4;       // mask vector
+    optional bytes rsig = 5;       // range sig data, all of it or partial (based on rsig_parts)
+    repeated bytes rsig_parts = 6;
+    optional uint32 bp_version = 7;  // Bulletproof version
+}
+
+/**
+ * Request: Ask device for public address derived from seed and address_n
+ * @start
+ * @next MoneroAddress
+ * @next Failure
+ */
+message MoneroGetAddress {
+    repeated uint32 address_n = 1;          // BIP-32 path to derive the key from master node
+    optional bool show_display = 2;         // Optionally show on display before sending the result
+    optional MoneroNetworkType network_type = 3 [default=MAINNET]; // Network type
+    optional uint32 account = 4;            // Major subaddr index
+    optional uint32 minor = 5;              // Minor subaddr index
+    optional bytes payment_id = 6;          // Payment ID for integrated address
+    optional bool chunkify = 7;             // display the address in chunks of 4 characters
+}
+
+/**
+ * Response: Contains Monero watch-only credentials derived from device private seed
+ * @end
+ */
+message MoneroAddress {
+    optional bytes address = 1;
+}
+
+/**
+ * Request: Ask device for watch only credentials
+ * @start
+ * @next MoneroWatchKey
+ * @next Failure
+ */
+message MoneroGetWatchKey {
+    repeated uint32 address_n = 1;          // BIP-32 path to derive the key from master node
+    optional MoneroNetworkType network_type = 2 [default=MAINNET]; // Network type
+}
+
+/**
+ * Response: Contains Monero watch-only credentials derived from device private seed
+ * @end
+ */
+message MoneroWatchKey {
+    optional bytes watch_key = 1;
+    optional bytes address = 2;
+}
+
+/**
+ * Request: Sub request of MoneroTransactionSign. Initializes transaction signing.
+ * @start
+ * @next MoneroTransactionInitAck
+ */
+message MoneroTransactionInitRequest {
+    optional uint32 version = 1;
+    repeated uint32 address_n = 2;
+    optional MoneroNetworkType network_type = 3 [default=MAINNET]; // Network type
+    optional MoneroTransactionData tsx_data = 4;
+    /**
+     * Structure representing Monero initial transaction information
+     */
+    message MoneroTransactionData {
+        optional uint32 version = 1;
+        optional bytes payment_id = 2;
+        optional uint64 unlock_time = 3;
+        repeated MoneroTransactionDestinationEntry outputs = 4;
+        optional MoneroTransactionDestinationEntry change_dts = 5;
+        optional uint32 num_inputs = 6;
+        optional uint32 mixin = 7;
+        optional uint64 fee = 8;
+        optional uint32 account = 9;
+        repeated uint32 minor_indices = 10;
+        optional MoneroTransactionRsigData rsig_data = 11;
+        repeated uint32 integrated_indices = 12;
+        optional uint32 client_version = 13;  // connected client version
+        optional uint32 hard_fork = 14;       // transaction hard fork number
+        optional bytes monero_version = 15;   // monero software version
+        optional bool chunkify = 16;          // display the address in chunks of 4 characters
+    }
+}
+
+/**
+ * Response: Response to transaction signing initialization.
+ * @next MoneroTransactionSetInputRequest
+ */
+message MoneroTransactionInitAck {
+    repeated bytes hmacs = 1;
+    optional MoneroTransactionRsigData rsig_data = 2;
+}
+
+/**
+ * Request: Sub request of MoneroTransactionSign. Sends one UTXO to device
+ * @next MoneroTransactionSetInputAck
+ */
+message MoneroTransactionSetInputRequest {
+    optional MoneroTransactionSourceEntry src_entr = 1;
+}
+
+/**
+ * Response: Response to setting UTXO for signature. Contains sealed values needed for further protocol steps.
+ * @next MoneroTransactionSetInputAck
+ * @next MoneroTransactionInputViniRequest
+ */
+message MoneroTransactionSetInputAck {
+    optional bytes vini = 1;      // xmrtypes.TxinToKey
+    optional bytes vini_hmac = 2;
+    optional bytes pseudo_out = 3;
+    optional bytes pseudo_out_hmac = 4;
+    optional bytes pseudo_out_alpha = 5;
+    optional bytes spend_key = 6;
+}
+
+/**
+ * Request: Sub request of MoneroTransactionSign. Sends one UTXO to device together with sealed values.
+ * @next MoneroTransactionInputViniAck
+ */
+message MoneroTransactionInputViniRequest {
+    optional MoneroTransactionSourceEntry src_entr = 1;
+    optional bytes vini = 2;      // xmrtypes.TxinToKey
+    optional bytes vini_hmac = 3;
+    optional bytes pseudo_out = 4;
+    optional bytes pseudo_out_hmac = 5;
+    optional uint32 orig_idx = 6;  // original sort index, before sorting by key-images
+}
+
+/**
+ * Response: Response to setting UTXO to the device
+ * @next MoneroTransactionInputViniRequest
+ * @next MoneroTransactionAllInputsSetRequest
+ */
+message MoneroTransactionInputViniAck {
+}
+
+/**
+ * Request: Sub request of MoneroTransactionSign. Sent after all inputs have been sent. Useful for rangeisg offloading.
+ * @next MoneroTransactionAllInputsSetAck
+ */
+message MoneroTransactionAllInputsSetRequest {
+}
+
+/**
+ * Response: Response to after all inputs have been set.
+ * @next MoneroTransactionSetOutputRequest
+ */
+message MoneroTransactionAllInputsSetAck {
+    optional MoneroTransactionRsigData rsig_data = 1;
+}
+
+/**
+ * Request: Sub request of MoneroTransactionSign. Sends one transaction destination to device (HMACed)
+ * @next MoneroTransactionSetOutputAck
+ */
+message MoneroTransactionSetOutputRequest {
+    optional MoneroTransactionDestinationEntry dst_entr = 1;
+    optional bytes dst_entr_hmac = 2;
+    optional MoneroTransactionRsigData rsig_data = 3;
+    optional bool is_offloaded_bp = 4;  // Extra message, with offloaded BP.
+}
+
+/**
+ * Response: Response to setting transaction destination. Contains sealed values needed for further protocol steps.
+ * @next MoneroTransactionSetOutputRequest
+ * @next MoneroTransactionAllOutSetRequest
+ */
+message MoneroTransactionSetOutputAck {
+    optional bytes tx_out = 1;  // xmrtypes.TxOut
+    optional bytes vouti_hmac = 2;
+    optional MoneroTransactionRsigData rsig_data = 3;
+    optional bytes out_pk = 4;
+    optional bytes ecdh_info = 5;
+}
+
+/**
+ * Request: Sub request of MoneroTransactionSign. Sent after all outputs are sent.
+ * @next MoneroTransactionAllOutSetAck
+ */
+message MoneroTransactionAllOutSetRequest {
+    optional MoneroTransactionRsigData rsig_data = 1;
+}
+
+/**
+ * Response: After all outputs are sent the initial RCT signature fields are sent.
+ * @next MoneroTransactionSignInputRequest
+ */
+message MoneroTransactionAllOutSetAck {
+    optional bytes extra = 1;
+    optional bytes tx_prefix_hash = 2;
+    optional MoneroRingCtSig rv = 4;  // xmrtypes.RctSig
+    optional bytes full_message_hash = 5;
+
+    /*
+     * Structure represents initial fields of the Monero RCT signature
+     */
+    message MoneroRingCtSig {
+        optional uint64 txn_fee = 1;
+        optional bytes message = 2;
+        optional uint32 rv_type = 3;
+    }
+}
+
+/**
+ * Request: Sub request of MoneroTransactionSign. Sends UTXO for the signing.
+ * @next MoneroTransactionSignInputAck
+ */
+message MoneroTransactionSignInputRequest {
+    optional MoneroTransactionSourceEntry src_entr = 1;
+    optional bytes vini = 2;     // xmrtypes.TxinToKey
+    optional bytes vini_hmac = 3;
+    optional bytes pseudo_out = 4;
+    optional bytes pseudo_out_hmac = 5;
+    optional bytes pseudo_out_alpha = 6;
+    optional bytes spend_key = 7;
+    optional uint32 orig_idx = 8;  // original sort index, before sorting by key-images
+}
+
+/**
+ * Response: Contains full MG signature of the UTXO + multisig data if applicable.
+ * @next MoneroTransactionSignInputRequest
+ * @next MoneroTransactionFinalRequest
+ */
+message MoneroTransactionSignInputAck {
+    optional bytes signature = 1;
+    optional bytes pseudo_out = 2;  // updated pseudo-out after mask correction
+}
+
+/**
+ * Request: Sub request of MoneroTransactionSign. Final message of the procol after all UTXOs are signed
+ * @next MoneroTransactionFinalAck
+ */
+message MoneroTransactionFinalRequest {
+}
+
+/**
+ * Response: Contains transaction metadata and encryption keys needed for further transaction operations (e.g. multisig, send proof).
+ * @end
+ */
+message MoneroTransactionFinalAck {
+    optional bytes cout_key = 1;
+    optional bytes salt = 2;
+    optional bytes rand_mult = 3;
+    optional bytes tx_enc_keys = 4;
+    optional bytes opening_key = 5;  // enc master key to decrypt CLSAGs after protocol finishes correctly
+}
+
+/**
+ * Request: Sub request of MoneroKeyImageSync. Initializing key image sync.
+ * @start
+ * @next MoneroKeyImageExportInitAck
+ */
+message MoneroKeyImageExportInitRequest {
+    required uint64 num = 1;
+    required bytes hash = 2;
+    repeated uint32 address_n = 3;               // BIP-32 path to derive the key from master node
+    optional MoneroNetworkType network_type = 4 [default=MAINNET]; // network type
+    repeated MoneroSubAddressIndicesList subs = 5;
+    /**
+     * Structure representing Monero list of sub-addresses
+     */
+    message MoneroSubAddressIndicesList {
+        required uint32 account = 1;
+        repeated uint32 minor_indices = 2;
+    }
+}
+
+/**
+ * Response: Response to key image sync initialization.
+ * @next MoneroKeyImageSyncStepRequest
+ */
+message MoneroKeyImageExportInitAck {
+}
+
+/**
+ * Request: Sub request of MoneroKeyImageSync. Contains batch of the UTXO to export key image for.
+ * @next MoneroKeyImageSyncStepAck
+ */
+message MoneroKeyImageSyncStepRequest {
+    repeated MoneroTransferDetails tdis = 1;
+    /**
+     * Structure representing Monero UTXO for key image sync
+     */
+    message MoneroTransferDetails {
+        required bytes out_key = 1;
+        required bytes tx_pub_key = 2;
+        repeated bytes additional_tx_pub_keys = 3;
+        required uint64 internal_output_index = 4;
+        optional uint32 sub_addr_major = 5;
+        optional uint32 sub_addr_minor = 6;
+    }
+}
+
+/**
+ * Response: Response to key image sync step. Contains encrypted exported key image.
+ * @next MoneroKeyImageSyncStepRequest
+ * @next MoneroKeyImageSyncFinalRequest
+ */
+message MoneroKeyImageSyncStepAck {
+    repeated MoneroExportedKeyImage kis = 1;
+    /**
+     * Structure representing Monero encrypted exported key image
+     */
+    message MoneroExportedKeyImage {
+        optional bytes iv = 1;
+        optional bytes blob = 3;
+    }
+}
+
+/**
+ * Request: Sub request of MoneroKeyImageSync. Final message of the sync protocol.
+ * @next MoneroKeyImageSyncFinalAck
+ */
+message MoneroKeyImageSyncFinalRequest {
+}
+
+/**
+ * Response: Response to key image sync step. Contains encryption keys for exported key images.
+ * @end
+ */
+message MoneroKeyImageSyncFinalAck {
+    optional bytes enc_key = 1;
+}
+
+/**
+ * Request: Decrypt tx private keys blob
+ * @next MoneroGetTxKeyAck
+ */
+message MoneroGetTxKeyRequest {
+    repeated uint32 address_n = 1;          // BIP-32 path to derive the key from master node
+    optional MoneroNetworkType network_type = 2 [default=MAINNET]; // network type
+
+    required bytes salt1 = 3;
+    required bytes salt2 = 4;
+    required bytes tx_enc_keys = 5;
+    required bytes tx_prefix_hash = 6;
+    optional uint32 reason = 7;  // reason to display for user. e.g., tx_proof
+    optional bytes view_public_key = 8;   // addr for derivation
+}
+
+/**
+ * Response: Response with the re-encrypted private keys and derivations blob under view key
+ * @end
+ */
+message MoneroGetTxKeyAck {
+    optional bytes salt = 1;
+    optional bytes tx_keys = 2;
+    optional bytes tx_derivations = 3;
+}
+
+/**
+ * Request: Starts live refresh flow. Asks user permission, switches state
+ * @next MoneroLiveRefreshStartAck
+ */
+message MoneroLiveRefreshStartRequest {
+    repeated uint32 address_n = 1;          // BIP-32 path to derive the key from master node
+    optional MoneroNetworkType network_type = 2 [default=MAINNET]; // network type
+}
+
+/**
+ * Response after user gave permission
+ * @next MoneroLiveRefreshStepRequest
+ * @next MoneroLiveRefreshFinalRequest
+ */
+message MoneroLiveRefreshStartAck {
+
+}
+
+/**
+ * Request: Request to compute a single key image during live sync
+ * @next MoneroLiveRefreshStepAck
+ */
+message MoneroLiveRefreshStepRequest {
+    required bytes out_key = 1;
+    required bytes recv_deriv = 2;
+    required uint64 real_out_idx = 3;
+    required uint32 sub_addr_major = 4;
+    required uint32 sub_addr_minor = 5;
+}
+
+/**
+ * Response: Response with the encrypted key image + signature
+ * @next MoneroLiveRefreshStepRequest
+ * @next MoneroLiveRefreshFinishedRequest
+ */
+message MoneroLiveRefreshStepAck {
+    optional bytes salt = 1;
+    optional bytes key_image = 2;
+}
+
+/**
+ * Request: Request terminating live refresh mode.
+ * @next MoneroLiveRefreshFinishedAck
+ */
+message MoneroLiveRefreshFinalRequest {
+
+}
+
+/**
+ * Response: Response on termination of live refresh mode.
+ * @end
+ */
+message MoneroLiveRefreshFinalAck {
+
+}
+
+/**
+ * Request: Universal Monero protocol implementation diagnosis request.
+ * @start
+ * @next DebugMoneroDiagAck
+ */
+message DebugMoneroDiagRequest {
+    optional uint64 ins = 1;
+    optional uint64 p1 = 2;
+    optional uint64 p2 = 3;
+    repeated uint64 pd = 4;
+    optional bytes data1 = 5;
+    optional bytes data2 = 6;
+}
+
+/**
+ * Response: Response to Monero diagnosis protocol.
+ * @end
+ */
+message DebugMoneroDiagAck {
+    optional uint64 ins = 1;
+    optional uint64 p1 = 2;
+    optional uint64 p2 = 3;
+    repeated uint64 pd = 4;
+    optional bytes data1 = 5;
+    optional bytes data2 = 6;
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-nem.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-nem.proto
@@ -1,0 +1,201 @@
+syntax = "proto2";
+package hw.trezor.messages.nem;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageNem";
+
+/**
+ * Request: Ask device for NEM address corresponding to address_n path
+ * @start
+ * @next NEMAddress
+ * @next Failure
+ */
+message NEMGetAddress {
+    repeated uint32 address_n = 1;              // BIP-32 path to derive the key from master node
+    optional uint32 network = 2 [default=0x68]; // Network ID (0x68 = Mainnet, 0x98 = Testnet, 0x60 = Mijin)
+    optional bool show_display = 3;             // Optionally show on display before sending the result
+    optional bool chunkify = 4;                 // display the address in chunks of 4 characters
+}
+
+/**
+ * Response: Contains NEM address derived from device private seed
+ * @end
+ */
+message NEMAddress {
+    required string address = 1;    // NEM address in Base32 encoding
+}
+
+/**
+ * Request: Ask device to sign transaction
+ * @start
+ * @next NEMSignedTx
+ * @next Failure
+ */
+message NEMSignTx {
+    required NEMTransactionCommon transaction = 1;                  // Common part of transaction
+    optional NEMTransactionCommon multisig = 2;                     // Common part of inner transaction for multisig transactions
+    optional NEMTransfer transfer = 3;                              // Transfer transaction part
+    optional bool cosigning = 4;                                    // Whether cosigning or initiating the multisig transaction
+    optional NEMProvisionNamespace provision_namespace = 5;         // Provision namespace part
+    optional NEMMosaicCreation mosaic_creation = 6;                 // Mosaic definition creation part
+    optional NEMMosaicSupplyChange supply_change = 7;               // Mosaic supply change part
+    optional NEMAggregateModification aggregate_modification = 8;   // Aggregate modification part
+    optional NEMImportanceTransfer importance_transfer = 9;         // Importance transfer part
+    optional bool chunkify = 10;                                    // display the address in chunks of 4 characters
+
+    /**
+    * Structure representing the common part for NEM transactions
+    */
+    message NEMTransactionCommon {
+        repeated uint32 address_n = 1;              // BIP-32 path to derive the key from master node
+        optional uint32 network = 2 [default=0x68]; // Network ID (0x68 = Mainnet, 0x98 = Testnet, 0x60 = Mijin)
+        required uint32 timestamp = 3;              // Number of seconds elapsed since the creation of the nemesis block
+        required uint64 fee = 4;                    // Fee for the transaction
+        required uint32 deadline = 5;               // Deadline of the transaction
+        optional bytes signer = 6;                  // Public key of the account (for multisig transactions)
+    }
+    /**
+    * Structure representing the transfer transaction part for NEM transactions
+    */
+    message NEMTransfer {
+        required string recipient = 1;              // Address of the recipient
+        required uint64 amount = 2;                 // Amount of micro NEM that is transferred
+        optional bytes payload = 3;                 // Actual message data (unencrypted)
+        optional bytes public_key = 4;              // Public key of the recipient (for encrypted payloads)
+        repeated NEMMosaic mosaics = 5;             // Attached mosaics
+        /**
+        * Structure representing the mosaic attachment for NEM transfer transactions
+        */
+        message NEMMosaic {
+            required string namespace = 1;  // Fully qualified name of the namespace
+            required string mosaic = 2;     // Name of the mosaic definition
+            required uint64 quantity = 3;   // Mosaic quantity, always given in smallest units
+        }
+    }
+    /**
+    * Structure representing the provision namespace part for NEM transactions
+    */
+    message NEMProvisionNamespace {
+        required string namespace = 1;  // New part concatenated to the parent
+        optional string parent = 2;     // Parent namespace (for child namespaces)
+        required string sink = 3;       // Rental fee sink address
+        required uint64 fee = 4;        // Rental fee
+    }
+    /**
+    * Structure representing the mosaic definition creation part for NEM transactions
+    */
+    message NEMMosaicCreation {
+        required NEMMosaicDefinition definition = 1;    // Mosaic definition
+        required string sink = 2;                       // Creation fee sink address
+        required uint64 fee = 3;                        // Creation fee
+        /**
+        * Structure representing a mosaic definition
+        */
+        message NEMMosaicDefinition {
+            optional string name = 1;               // User-friendly name of the mosaic (for whitelisted mosaics)
+            optional string ticker = 2;             // Ticker of the mosaic (for whitelisted mosaics)
+            required string namespace = 3;          // Fully qualified name of the namespace
+            required string mosaic = 4;             // Name of the mosaic definition
+            optional uint32 divisibility = 5;       // Number of decimal places that a mosaic can be divided into
+            optional NEMMosaicLevy levy = 6;        // Levy type
+            optional uint64 fee = 7;                // Levy fee (interpretation depends on levy type)
+            optional string levy_address = 8;       // Levy address
+            optional string levy_namespace = 9;     // Fully qualified name of the namespace of the levy mosaic
+            optional string levy_mosaic = 10;       // Name of the levy mosaic
+            optional uint64 supply = 11;            // Initial supply to create, always given in entire units
+            optional bool mutable_supply = 12;      // Mutable supply
+            optional bool transferable = 13;        // Mosaic allows transfers among accounts other than the creator
+            required string description = 14;       // Mosaic description
+            repeated uint32 networks = 15;          // Networks that the mosaic is valid on (for whitelisted mosaics)
+            /**
+            * Type of levy which will be used for mosaic
+            */
+            enum NEMMosaicLevy {
+                MosaicLevy_Absolute = 1;
+                MosaicLevy_Percentile = 2;
+            }
+        }
+    }
+    /**
+    * Structure representing the mosaic supply change part for NEM transactions
+    */
+    message NEMMosaicSupplyChange {
+        required string namespace = 1;          // Fully qualified name of the namespace
+        required string mosaic = 2;             // Name of the mosaic definition
+        required NEMSupplyChangeType type = 3;  // Type of supply change
+        required uint64 delta = 4;              // Supply delta
+        /**
+        * Type of supply change which will be applied to mosaic
+        */
+        enum NEMSupplyChangeType {
+            SupplyChange_Increase = 1;
+            SupplyChange_Decrease = 2;
+        }
+    }
+    /**
+    * Structure representing the aggregate modification part for NEM transactions
+    */
+    message NEMAggregateModification {
+        repeated NEMCosignatoryModification modifications = 1;  // Cosignatory modifications
+        optional sint32 relative_change = 2;                    // Relative change of the minimum cosignatories
+        /**
+        * Structure representing the cosignatory modification for aggregate modification transactions
+        */
+        message NEMCosignatoryModification {
+            required NEMModificationType type = 1;  // Type of cosignatory modification
+            required bytes public_key = 2;          // Public key of the cosignatory
+            /**
+            * Type of cosignatory modification
+            */
+            enum NEMModificationType {
+                CosignatoryModification_Add = 1;
+                CosignatoryModification_Delete = 2;
+            }
+        }
+    }
+    /**
+    * Structure representing the importance transfer part for NEM transactions
+    */
+    message NEMImportanceTransfer {
+        required NEMImportanceTransferMode mode = 1;    // Mode of importance transfer
+        required bytes public_key = 2;                  // Public key of the remote account
+        /**
+        * Mode of importance transfer
+        */
+        enum NEMImportanceTransferMode {
+            ImportanceTransfer_Activate = 1;
+            ImportanceTransfer_Deactivate = 2;
+        }
+    }
+}
+
+/**
+ * Response: Contains NEM transaction data and signature
+ * @end
+ */
+message NEMSignedTx {
+    required bytes data = 1;        // Transaction data
+    required bytes signature = 2;   // Signature for the transaction
+}
+
+/**
+ * Request: Ask device to decrypt NEM transaction payload
+ * @start
+ * @next NEMDecryptedMessage
+ * @next Failure
+ */
+message NEMDecryptMessage {
+    repeated uint32 address_n = 1;  // BIP-32 path to derive the key from master node
+    optional uint32 network = 2;    // Network ID (0x68 = Mainnet, 0x98 = Testnet, 0x60 = Mijin)
+    optional bytes public_key = 3;  // Public key of the other party
+    optional bytes payload = 4;     // Actual message data (encrypted)
+}
+
+/**
+ * Response: Contains decrypted NEM transaction payload
+ * @end
+ */
+message NEMDecryptedMessage {
+    required bytes payload = 1;     // Actual message data (unencrypted)
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-ripple.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-ripple.proto
@@ -1,0 +1,61 @@
+syntax = "proto2";
+package hw.trezor.messages.ripple;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageRipple";
+
+/**
+ * Request: Address at the specified index
+ * @start
+ * @next RippleAddress
+ */
+message RippleGetAddress {
+    repeated uint32 address_n = 1;              // BIP-32 path. For compatibility with other wallets, must be m/44'/144'/index'
+    optional bool show_display = 2;             // optionally show on display before sending the result
+    optional bool chunkify = 3;                 // display the address in chunks of 4 characters
+}
+
+/**
+ * Response: Address for the given index
+ * @end
+ */
+message RippleAddress {
+    required string address = 1;                // Address in Ripple format (base58 of a pubkey with checksum)
+}
+
+/**
+ * Request: ask device to sign Ripple transaction
+ * @start
+ * @next RippleSignedTx
+ */
+message RippleSignTx {
+    repeated uint32 address_n = 1;              // BIP-32 path. For compatibility with other wallets, must be m/44'/144'/index'
+    required uint64 fee = 2;                    // fee (in drops) for the transaction
+    optional uint32 flags = 3 [default=0];      // transaction flags
+    required uint32 sequence = 4;               // transaction sequence number
+    optional uint32 last_ledger_sequence = 5;   // see https://developers.ripple.com/reliable-transaction-submission.html#lastledgersequence
+    required RipplePayment payment = 6;         // Payment transaction type
+    optional bool chunkify = 7;                 // display the address in chunks of 4 characters
+
+    /**
+     * Payment transaction type
+     * - simple A sends money to B
+     * - only a subset of fields is supported
+     * - see https://developers.ripple.com/payment.html
+     */
+    message RipplePayment {
+        required uint64 amount = 1;             // only XRP is supported at the moment so this an integer
+        required string destination = 2;        // destination account address
+        optional uint32 destination_tag = 3;    // destination tag to identify payments
+    }
+}
+
+/**
+ * Response: signature for transaction
+ * @end
+ */
+message RippleSignedTx {
+    required bytes signature = 1;
+    required bytes serialized_tx = 2;
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-solana.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-solana.proto
@@ -1,0 +1,78 @@
+syntax = "proto2";
+package hw.trezor.messages.solana;
+
+/**
+ * Request: Ask device for public key corresponding to address_n path
+ * @start
+ * @next SolanaPublicKey
+ * @next Failure
+ */
+message SolanaGetPublicKey {
+    repeated uint32 address_n = 1;  // BIP-32 path to derive the key from master node
+    optional bool show_display = 2; // optionally show on display before sending the result
+}
+
+/**
+ * Response: Contains public key derived from device private seed
+ * @end
+ */
+message SolanaPublicKey {
+    required bytes public_key = 1;
+}
+
+/**
+ * Request: Ask device for Solana address
+ * @start
+ * @next SolanaAddress
+ * @next Failure
+ */
+message SolanaGetAddress {
+    repeated uint32 address_n = 1;  // BIP-32 path to derive the key from master node
+    optional bool show_display = 2; // optionally show on display before sending the result
+    optional bool chunkify = 3;     // display the address in chunks of 4 characters
+}
+
+/**
+ * Response: Contains a Solana address derived from device private seed
+ * @end
+ */
+message SolanaAddress {
+    required string address = 1; // Solana address as Base58 encoded string
+}
+
+/**
+ * @embed
+ */
+message SolanaTxTokenAccountInfo {
+    required string base_address = 1;
+    required string token_program = 2;
+    required string token_mint = 3;
+    required string token_account = 4;
+}
+
+/**
+ * @embed
+ */
+message SolanaTxAdditionalInfo {
+    repeated SolanaTxTokenAccountInfo token_accounts_infos = 1;
+}
+
+/**
+ * Request: Ask device to sign a Solana transaction
+ * @start
+ * @next SolanaTxSignature
+ * @next Failure
+ */
+message SolanaSignTx {
+    repeated uint32 address_n = 1;      // BIP-32 path to derive the key to sign with
+    required bytes serialized_tx = 2;   // serialized tx to be signed
+    optional SolanaTxAdditionalInfo additional_info = 3;
+}
+
+/**
+ * Response: Contains the transaction signature
+ * @end
+ */
+message SolanaTxSignature {
+    required bytes signature = 1;   // tx signature
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-stellar.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-stellar.proto
@@ -1,0 +1,289 @@
+syntax = "proto2";
+package hw.trezor.messages.stellar;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageStellar";
+
+// https://github.com/stellar/stellar-core/blob/02d26858069de7c0eefe065056fb0a19bf72ea56/src/xdr/Stellar-ledger-entries.x#L25-L31
+enum StellarAssetType {
+    NATIVE = 0;
+    ALPHANUM4 = 1;
+    ALPHANUM12 = 2;
+}
+
+/**
+ * Describes a Stellar asset
+ * @embed
+ */
+message StellarAsset {
+    required StellarAssetType type = 1;
+    optional string code = 2;       // for non-native assets, string describing the code
+    optional string issuer = 3;     // issuing address
+
+}
+
+/**
+ * Request: Address at the specified index
+ * @start
+ * @next StellarAddress
+ */
+message StellarGetAddress {
+    repeated uint32 address_n = 1;  // BIP-32 path. For compatibility with other wallets, must be m/44'/148'/index'
+    optional bool show_display = 2; // optionally show on display before sending the result
+    optional bool chunkify = 3;     // display the address in chunks of 4 characters
+}
+
+/**
+ * Response: Address for the given index
+ * @end
+ */
+message StellarAddress {
+    required string address = 1;    // Address in Stellar format (base32 of a pubkey with checksum)
+}
+
+/**
+ * Request: ask device to sign Stellar transaction
+ * @start
+ * @next StellarTxOpRequest
+ */
+message StellarSignTx {
+    repeated uint32 address_n = 2;           // BIP-32 path. For compatibility with other wallets, must be m/44'/148'/index'
+    required string network_passphrase = 3;  // passphrase for signing messages on the destination network
+    required string source_account = 4;      // source account address
+    required uint32 fee = 5;                 // Fee (in stroops) for the transaction
+    required uint64 sequence_number = 6;     // transaction sequence number
+    required uint32 timebounds_start = 8;    // unix timestamp (client must truncate this to 32 bytes)
+    required uint32 timebounds_end = 9;      // unix timestamp (client must truncate this to 32 bytes)
+    required StellarMemoType memo_type = 10; // type of memo attached to the transaction
+    optional string memo_text = 11;          // up to 28 characters (4 bytes are for length)
+    optional uint64 memo_id = 12;            // 8-byte uint64
+    optional bytes memo_hash = 13;           // 32 bytes representing a hash
+    required uint32 num_operations = 14;     // number of operations in this transaction
+
+    // https://github.com/stellar/stellar-core/blob/02d26858069de7c0eefe065056fb0a19bf72ea56/src/xdr/Stellar-transaction.x#L506-L513
+    enum StellarMemoType {
+        NONE = 0;
+        TEXT = 1;
+        ID = 2;
+        HASH = 3;
+        RETURN = 4;
+    }
+}
+
+/**
+ * Response: device is ready for client to send the next operation
+ * @next StellarPaymentOp
+ * @next StellarCreateAccountOp
+ * @next StellarPathPaymentStrictReceiveOp
+ * @next StellarPathPaymentStrictSendOp
+ * @next StellarManageSellOfferOp
+ * @next StellarManageBuyOfferOp
+ * @next StellarCreatePassiveSellOfferOp
+ * @next StellarSetOptionsOp
+ * @next StellarChangeTrustOp
+ * @next StellarAllowTrustOp
+ * @next StellarAccountMergeOp
+ * @next StellarManageDataOp
+ * @next StellarBumpSequenceOp
+ */
+message StellarTxOpRequest {
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarPaymentOp {
+    optional string source_account = 1;         // (optional) source account address
+    required string destination_account = 2;    // destination account address
+    required StellarAsset asset = 3;        // asset involved in the operation
+    required sint64 amount = 4;                 // amount of the given asset to pay
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarCreateAccountOp {
+    optional string source_account = 1;     // (optional) source account address
+    required string new_account = 2;        // account address to create
+    required sint64 starting_balance = 3;   // initial starting balance for the new account
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarPathPaymentStrictReceiveOp {
+    optional string source_account = 1;           // (optional) source address
+    required StellarAsset send_asset = 2;         // asset we pay with
+    required sint64 send_max = 3;                 // the maximum amount of sendAsset to send (excluding fees)
+    required string destination_account = 4;      // recipient of the payment
+    required StellarAsset destination_asset = 5;  // what they end up with
+    required sint64 destination_amount = 6;       // amount they end up with
+    repeated StellarAsset paths = 7;              // additional hops it must go through to get there
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarPathPaymentStrictSendOp {
+    optional string source_account = 1;           // (optional) source address
+    required StellarAsset send_asset = 2;         // asset we pay with
+    required sint64 send_amount = 3;              // amount of sendAsset to send (excluding fees)
+    required string destination_account = 4;      // recipient of the payment
+    required StellarAsset destination_asset = 5;  // what they end up with
+    required sint64 destination_min = 6;          // the minimum amount of dest asset to be received
+    repeated StellarAsset paths = 7;              //additional hops it must go through to get there
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarManageSellOfferOp {
+    optional string source_account = 1;             // (optional) source account address
+    required StellarAsset selling_asset = 2;
+    required StellarAsset buying_asset = 3;
+    required sint64 amount = 4;
+    required uint32 price_n = 5;                    // Price numerator
+    required uint32 price_d = 6;                    // Price denominator
+    required uint64 offer_id = 7;                   // Offer ID for updating an existing offer
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarManageBuyOfferOp {
+    optional string source_account = 1;             // (optional) source account address
+    required StellarAsset selling_asset = 2;
+    required StellarAsset buying_asset = 3;
+    required sint64 amount = 4;
+    required uint32 price_n = 5;                    // Price numerator
+    required uint32 price_d = 6;                    // Price denominator
+    required uint64 offer_id = 7;                   // Offer ID for updating an existing offer
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarCreatePassiveSellOfferOp {
+    optional string source_account = 1;             // (optional) source account address
+    required StellarAsset selling_asset = 2;
+    required StellarAsset buying_asset = 3;
+    required sint64 amount = 4;
+    required uint32 price_n = 5;                    // Price numerator
+    required uint32 price_d = 6;                    // Price denominator
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarSetOptionsOp {
+    optional string source_account = 1;                 // (optional) source account address
+    optional string inflation_destination_account = 2;  // (optional) inflation destination address
+    optional uint32 clear_flags = 3;
+    optional uint32 set_flags = 4;
+    optional uint32 master_weight = 5;
+    optional uint32 low_threshold = 6;
+    optional uint32 medium_threshold = 7;
+    optional uint32 high_threshold = 8;
+    optional string home_domain = 9;
+    optional StellarSignerType signer_type = 10;
+    optional bytes signer_key = 11;
+    optional uint32 signer_weight = 12;
+
+    // https://github.com/stellar/stellar-core/blob/02d26858069de7c0eefe065056fb0a19bf72ea56/src/xdr/Stellar-types.x#L32-L37
+    enum StellarSignerType {
+        ACCOUNT = 0;
+        PRE_AUTH = 1;
+        HASH = 2;
+    }
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarChangeTrustOp {
+    optional string source_account = 1;     // (optional) source account address
+    required StellarAsset asset = 2;
+    required uint64 limit = 3;
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarAllowTrustOp {
+    optional string source_account = 1;     // (optional) source account address
+    required string trusted_account = 2;    // The account being allowed to hold the asset
+    required StellarAssetType asset_type = 3;
+    optional string asset_code = 4;         // human-readable asset code
+    required bool is_authorized = 5;
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarAccountMergeOp {
+    optional string source_account = 1;         // (optional) source account address
+    required string destination_account = 2;    // destination account address
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarManageDataOp {
+    optional string source_account = 1; // (optional) source account address
+    required string key = 2;
+    optional bytes value = 3;           // 64 bytes of arbitrary data
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarBumpSequenceOp {
+    optional string source_account = 1; // (optional) source account address
+    required uint64 bump_to = 2;        // new sequence number
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarClaimClaimableBalanceOp {
+    optional string source_account = 1; // (optional) source account address
+    required bytes balance_id = 2;      // balance id, 4 bytes of type flag, 32 bytes of data
+}
+
+/**
+ * Response: signature for transaction
+ * @end
+ */
+message StellarSignedTx {
+    required bytes public_key = 1;  // public key for the private key used to sign data
+    required bytes signature = 2;   // signature suitable for sending to the Stellar network
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-tezos.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-tezos.proto
@@ -1,0 +1,174 @@
+syntax = "proto2";
+package hw.trezor.messages.tezos;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageTezos";
+
+/**
+ * Request: Ask device for Tezos address corresponding to address_n path
+ * @start
+ * @next TezosAddress
+ * @next Failure
+ */
+message TezosGetAddress {
+    repeated uint32 address_n = 1;      // BIP-32 path to derive the key from master node
+    optional bool show_display = 2;     // optionally show on display before sending the result
+    optional bool chunkify = 3;         // display the address in chunks of 4 characters
+}
+
+/**
+ * Response: Contains Tezos address derived from device private seed
+ * @end
+ */
+message TezosAddress {
+    required string address = 1;        // Coin address in Base58 encoding
+}
+
+/**
+ * Request: Ask device for Tezos public key corresponding to address_n path
+ * @start
+ * @next TezosPublicKey
+ */
+message TezosGetPublicKey {
+    repeated uint32 address_n = 1;          // BIP-32 path to derive the key from master node
+    optional bool show_display = 2;         // Optionally show on display before sending the result
+    optional bool chunkify = 3;             // display the public key in chunks of 4 characters
+}
+
+/**
+ * Response: Contains Tezos public key derived from device private seed
+ * @end
+ */
+message TezosPublicKey {
+    required string public_key = 1;          // b58 encoded Tezos public key with prefix
+}
+
+/**
+ * Request: Ask device to sign Tezos transaction
+ * @start
+ * @next TezosSignedTx
+ */
+message TezosSignTx {
+    repeated uint32 address_n = 1;                  // BIP-32 path to derive the key from master node
+    required bytes branch = 2;
+
+    optional TezosRevealOp reveal = 3;              // Tezos reveal operation (may be bundled with other op)
+    optional TezosTransactionOp transaction = 4;    // Tezos transaction operation
+    optional TezosOriginationOp origination = 5;    // Tezos origination operation
+    optional TezosDelegationOp delegation = 6;      // Tezos delegation operation
+    optional TezosProposalOp proposal = 7;          // Tezos proposal operation
+    optional TezosBallotOp ballot = 8;              // Tezos ballot operation
+    optional bool chunkify = 9;                     // display the address in chunks of 4 characters
+
+    /*
+     * Tezos contract ID
+     */
+    message TezosContractID {
+        required TezosContractType tag = 1;
+        required bytes hash = 2;                    // Implicit = 21B, originated = 20B + 1B padding
+        /*
+         * Type of Tezos Contract type
+         */
+        enum TezosContractType {
+            Implicit = 0;
+            Originated = 1;
+        }
+    }
+    /**
+     * Structure representing information for reveal
+     */
+    message TezosRevealOp {
+        required bytes source = 7;
+        required uint64 fee = 2;
+        required uint64 counter = 3;
+        required uint64 gas_limit = 4;
+        required uint64 storage_limit = 5;
+        required bytes public_key = 6;
+    }
+    /**
+     * Structure representing information for transaction
+     */
+    message TezosTransactionOp {
+        required bytes source = 9;
+        required uint64 fee = 2;
+        required uint64 counter = 3;
+        required uint64 gas_limit = 4;
+        required uint64 storage_limit = 5;
+        required uint64 amount = 6;
+        required TezosContractID destination = 7;
+        optional bytes parameters = 8;
+        optional TezosParametersManager parameters_manager = 10;
+
+        message TezosParametersManager {
+            optional bytes set_delegate = 1;
+            optional bool cancel_delegate = 2;
+            optional TezosManagerTransfer transfer = 3;
+
+            message TezosManagerTransfer {
+                required TezosContractID destination = 1;
+                required uint64 amount = 2;
+            }
+        }
+    }
+    /**
+     * Structure representing information for origination
+     */
+    message TezosOriginationOp {
+        required bytes source = 12;
+        required uint64 fee = 2;
+        required uint64 counter = 3;
+        required uint64 gas_limit = 4;
+        required uint64 storage_limit = 5;
+        optional bytes manager_pubkey = 6;
+        required uint64 balance = 7;
+        optional bool spendable = 8;
+        optional bool delegatable = 9;
+        optional bytes delegate = 10;
+        required bytes script = 11;
+    }
+    /**
+     * Structure representing information for delegation
+     */
+    message TezosDelegationOp {
+        required bytes source = 7;
+        required uint64 fee = 2;
+        required uint64 counter = 3;
+        required uint64 gas_limit = 4;
+        required uint64 storage_limit = 5;
+        required bytes delegate = 6;
+    }
+    /**
+     * Structure representing information for proposal
+     */
+    message TezosProposalOp {
+        required bytes source = 1;                  //Contains only public_key_hash, not to be confused with TezosContractID
+        required uint64 period = 2;
+        repeated bytes proposals = 4;
+    }
+    /**
+     * Structure representing information for ballot
+     */
+    message TezosBallotOp {
+        required bytes source = 1;                  //Contains only public_key_hash, not to be confused with TezosContractID
+        required uint64 period = 2;
+        required bytes proposal = 3;
+        required TezosBallotType ballot = 4;
+
+        enum TezosBallotType {
+            Yay = 0;
+            Nay = 1;
+            Pass = 2;
+        }
+    }
+}
+
+/**
+ * Response: Contains Tezos transaction signature
+ * @end
+ */
+message TezosSignedTx {
+    required string signature = 1;          // Tezos b58 encoded transaction signature with prefix
+    required bytes sig_op_contents = 2;     // operation_bytes + signed operation_bytes
+    required string operation_hash = 3;     // b58 encoded hashed operation contents with prefix
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages-webauthn.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages-webauthn.proto
@@ -1,0 +1,59 @@
+syntax = "proto2";
+package hw.trezor.messages.webauthn;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageWebAuthn";
+
+/**
+ * Request: List resident credentials
+ * @start
+ * @next WebAuthnCredentials
+ * @next Failure
+ */
+message WebAuthnListResidentCredentials {
+}
+
+/**
+ * Request: Add resident credential
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message WebAuthnAddResidentCredential {
+    optional bytes credential_id = 1;
+}
+
+/**
+ * Request: Remove resident credential
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message WebAuthnRemoveResidentCredential {
+    optional uint32 index = 1;
+}
+
+
+/**
+ * Response: Resident credential list
+ * @start
+ * @next end
+ */
+message WebAuthnCredentials {
+    repeated WebAuthnCredential credentials = 1;
+    message WebAuthnCredential {
+        optional uint32 index = 1;
+        optional bytes id = 2;
+        optional string rp_id = 3;
+        optional string rp_name = 4;
+        optional bytes user_id = 5;
+        optional string user_name = 6;
+        optional string user_display_name = 7;
+        optional uint32 creation_time = 8;
+        optional bool hmac_secret = 9;
+        optional bool use_sign_count = 10;
+        optional sint32 algorithm = 11;
+        optional sint32 curve = 12;
+    }
+}

--- a/lib/trezor_protocol/shared/protobuf/messages_raw/messages.proto
+++ b/lib/trezor_protocol/shared/protobuf/messages_raw/messages.proto
@@ -1,0 +1,378 @@
+syntax = "proto2";
+package hw.trezor.messages;
+
+/**
+ * Messages for Trezor communication
+ */
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessage";
+
+option (include_in_bitcoin_only) = true;
+
+import "google/protobuf/descriptor.proto";
+
+/************************* WARNING ***********************
+Due to the way extensions are accessed in pb2py, there needs to be a globally unique
+name-ID mapping for extensions. That means that two different extensions, e.g. for
+EnumValueOptions and FieldOptions, MUST NOT have the same ID.
+
+Using the same ID indicates the same purpose (protobuf does not allow multiple
+extensions with the same name), such as EnumValueOptions.bitcoin_only and
+FileOptions.include_in_bitcoin_only. pb2py can then find the extension under
+either name.
+
+The convention to achieve this is as follows:
+ - extensions specific to a type have the same prefix:
+   * 50xxx for EnumValueOptions
+   * 51xxx for EnumOptions
+   * 52xxx for MessageOptions
+   * 53xxx for FieldOptions
+ - extensions that might be used across types have the same "global" prefix 60xxx
+*/
+/**
+ * Options for specifying message direction and type of wire (normal/debug)
+ */
+extend google.protobuf.EnumValueOptions {
+    optional bool wire_in = 50002;              // message can be transmitted via wire from PC to Trezor
+    optional bool wire_out = 50003;             // message can be transmitted via wire from Trezor to PC
+    optional bool wire_debug_in = 50004;        // message can be transmitted via debug wire from PC to Trezor
+    optional bool wire_debug_out = 50005;       // message can be transmitted via debug wire from Trezor to PC
+    optional bool wire_tiny = 50006;            // message is handled by Trezor when the USB stack is in tiny mode
+    optional bool wire_bootloader = 50007;      // message is only handled by Trezor Bootloader
+    optional bool wire_no_fsm = 50008;          // message is not handled by Trezor unless the USB stack is in tiny mode
+
+    optional bool bitcoin_only = 60000;         // enum value is available on BITCOIN_ONLY build
+                                                // (messages not marked bitcoin_only will be EXCLUDED)
+}
+
+/** Options for tagging enum types */
+extend google.protobuf.EnumOptions {
+    optional bool has_bitcoin_only_values = 51001;  // indicate that some values should be excluded on BITCOIN_ONLY builds
+}
+
+/** Options for tagging message types */
+extend google.protobuf.MessageOptions {
+    optional bool experimental_message = 52001;   // indicate that a message is intended for development and beta testing only and its definition may change at any time
+    optional uint32 wire_type = 52002;   // override wire type specified in the MessageType enum
+}
+
+/** Options for tagging field types */
+extend google.protobuf.FieldOptions {
+    optional bool experimental_field = 53001;   // indicate that a field is intended for development and beta testing only
+}
+
+/** Options for tagging files with protobuf definitions */
+extend google.protobuf.FileOptions {
+    optional bool include_in_bitcoin_only = 60000;  // definitions are available on BITCOIN_ONLY build
+                                                    // intentionally identical to `bitcoin_only` from enum
+}
+
+
+/**
+ * Mapping between Trezor wire identifier (uint) and a protobuf message
+ */
+enum MessageType {
+    option (has_bitcoin_only_values) = true;
+
+    // Management
+    MessageType_Initialize = 0 [(bitcoin_only) = true, (wire_in) = true, (wire_tiny) = true];
+    MessageType_Ping = 1 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_Success = 2 [(bitcoin_only) = true, (wire_out) = true, (wire_debug_out) = true];
+    MessageType_Failure = 3 [(bitcoin_only) = true, (wire_out) = true, (wire_debug_out) = true];
+    MessageType_ChangePin = 4 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_WipeDevice = 5 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_GetEntropy = 9 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_Entropy = 10 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_LoadDevice = 13 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_ResetDevice = 14 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_SetBusy = 16 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_Features = 17 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_PinMatrixRequest = 18 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_PinMatrixAck = 19 [(bitcoin_only) = true, (wire_in) = true, (wire_tiny) = true, (wire_no_fsm) = true];
+    MessageType_Cancel = 20 [(bitcoin_only) = true, (wire_in) = true, (wire_tiny) = true];
+    MessageType_LockDevice = 24 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_ApplySettings = 25 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_ButtonRequest = 26 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_ButtonAck = 27 [(bitcoin_only) = true, (wire_in) = true, (wire_tiny) = true, (wire_no_fsm) = true];
+    MessageType_ApplyFlags = 28 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_GetNonce = 31 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_Nonce = 33 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_BackupDevice = 34 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_EntropyRequest = 35 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_EntropyAck = 36 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_PassphraseRequest = 41 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_PassphraseAck = 42 [(bitcoin_only) = true, (wire_in) = true, (wire_tiny) = true, (wire_no_fsm) = true];
+    MessageType_RecoveryDevice = 45 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_WordRequest = 46 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_WordAck = 47 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_GetFeatures = 55 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_SdProtect = 79 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_ChangeWipeCode = 82 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_EndSession = 83 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_DoPreauthorized = 84 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_PreauthorizedRequest = 85 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_CancelAuthorization = 86 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_RebootToBootloader = 87 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_GetFirmwareHash = 88 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_FirmwareHash = 89 [(bitcoin_only) = true, (wire_out) = true];
+    reserved 90 to 92;
+    MessageType_UnlockPath = 93 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_UnlockedPathRequest = 94 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_ShowDeviceTutorial = 95 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_UnlockBootloader = 96 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_AuthenticateDevice = 97 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_AuthenticityProof = 98 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_ChangeLanguage = 990 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_TranslationDataRequest = 991 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_TranslationDataAck = 992 [(bitcoin_only) = true, (wire_in) = true];
+
+    MessageType_SetU2FCounter = 63 [(wire_in) = true];
+    MessageType_GetNextU2FCounter = 80 [(wire_in) = true];
+    MessageType_NextU2FCounter = 81 [(wire_out) = true];
+
+    // Deprecated messages, kept for protobuf compatibility.
+    // Both are marked wire_out so that we don't need to implement incoming handler for legacy
+    MessageType_Deprecated_PassphraseStateRequest = 77 [deprecated = true];
+    MessageType_Deprecated_PassphraseStateAck = 78 [deprecated = true];
+
+    // Bootloader
+    MessageType_FirmwareErase = 6 [(bitcoin_only) = true, (wire_in) = true, (wire_bootloader) = true];
+    MessageType_FirmwareUpload = 7 [(bitcoin_only) = true, (wire_in) = true, (wire_bootloader) = true];
+    MessageType_FirmwareRequest = 8 [(bitcoin_only) = true, (wire_out) = true, (wire_bootloader) = true];
+    MessageType_ProdTestT1 = 32 [(bitcoin_only) = true, (wire_in) = true, (wire_bootloader) = true];
+
+    // Bitcoin
+    MessageType_GetPublicKey = 11 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_PublicKey = 12 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_SignTx = 15 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_TxRequest = 21 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_TxAck = 22 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_GetAddress = 29 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_Address = 30 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_TxAckPaymentRequest = 37 [(wire_in) = true];
+    MessageType_SignMessage = 38 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_VerifyMessage = 39 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_MessageSignature = 40 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_GetOwnershipId = 43 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_OwnershipId = 44 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_GetOwnershipProof = 49 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_OwnershipProof = 50 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_AuthorizeCoinJoin = 51 [(bitcoin_only) = true, (wire_in) = true];
+
+    // Crypto
+    MessageType_CipherKeyValue = 23 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_CipheredKeyValue = 48 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_SignIdentity = 53 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_SignedIdentity = 54 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_GetECDHSessionKey = 61 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_ECDHSessionKey = 62 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_CosiCommit = 71 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_CosiCommitment = 72 [(bitcoin_only) = true, (wire_out) = true];
+    MessageType_CosiSign = 73 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_CosiSignature = 74 [(bitcoin_only) = true, (wire_out) = true];
+
+    // Debug
+    MessageType_DebugLinkDecision = 100 [(bitcoin_only) = true, (wire_debug_in) = true, (wire_tiny) = true, (wire_no_fsm) = true];
+    MessageType_DebugLinkGetState = 101 [(bitcoin_only) = true, (wire_debug_in) = true, (wire_tiny) = true];
+    MessageType_DebugLinkState = 102 [(bitcoin_only) = true, (wire_debug_out) = true];
+    MessageType_DebugLinkStop = 103 [(bitcoin_only) = true, (wire_debug_in) = true];
+    MessageType_DebugLinkLog = 104 [(bitcoin_only) = true, (wire_debug_out) = true];
+    MessageType_DebugLinkMemoryRead = 110 [(bitcoin_only) = true, (wire_debug_in) = true];
+    MessageType_DebugLinkMemory = 111 [(bitcoin_only) = true, (wire_debug_out) = true];
+    MessageType_DebugLinkMemoryWrite = 112 [(bitcoin_only) = true, (wire_debug_in) = true];
+    MessageType_DebugLinkFlashErase = 113 [(bitcoin_only) = true, (wire_debug_in) = true];
+    MessageType_DebugLinkLayout = 9001 [(bitcoin_only) = true, (wire_debug_out) = true];
+    MessageType_DebugLinkReseedRandom = 9002 [(bitcoin_only) = true, (wire_debug_in) = true];
+    MessageType_DebugLinkRecordScreen = 9003 [(bitcoin_only) = true, (wire_debug_in) = true];
+    MessageType_DebugLinkEraseSdCard = 9005 [(bitcoin_only) = true, (wire_debug_in) = true];
+    MessageType_DebugLinkWatchLayout = 9006 [(bitcoin_only) = true, (wire_debug_in) = true];
+    MessageType_DebugLinkResetDebugEvents = 9007 [(bitcoin_only) = true, (wire_debug_in) = true];
+
+    // Ethereum
+    MessageType_EthereumGetPublicKey = 450 [(wire_in) = true];
+    MessageType_EthereumPublicKey = 451 [(wire_out) = true];
+    MessageType_EthereumGetAddress = 56 [(wire_in) = true];
+    MessageType_EthereumAddress = 57 [(wire_out) = true];
+    MessageType_EthereumSignTx = 58 [(wire_in) = true];
+    MessageType_EthereumSignTxEIP1559 = 452 [(wire_in) = true];
+    MessageType_EthereumTxRequest = 59 [(wire_out) = true];
+    MessageType_EthereumTxAck = 60 [(wire_in) = true];
+    MessageType_EthereumSignMessage = 64 [(wire_in) = true];
+    MessageType_EthereumVerifyMessage = 65 [(wire_in) = true];
+    MessageType_EthereumMessageSignature = 66 [(wire_out) = true];
+    MessageType_EthereumSignTypedData = 464 [(wire_in) = true];
+    MessageType_EthereumTypedDataStructRequest = 465 [(wire_out) = true];
+    MessageType_EthereumTypedDataStructAck = 466 [(wire_in) = true];
+    MessageType_EthereumTypedDataValueRequest = 467 [(wire_out) = true];
+    MessageType_EthereumTypedDataValueAck = 468 [(wire_in) = true];
+    MessageType_EthereumTypedDataSignature = 469 [(wire_out) = true];
+    MessageType_EthereumSignTypedHash = 470 [(wire_in) = true];
+
+    // NEM
+    MessageType_NEMGetAddress = 67 [(wire_in) = true];
+    MessageType_NEMAddress = 68 [(wire_out) = true];
+    MessageType_NEMSignTx = 69 [(wire_in) = true];
+    MessageType_NEMSignedTx = 70 [(wire_out) = true];
+    MessageType_NEMDecryptMessage = 75 [(wire_in) = true];
+    MessageType_NEMDecryptedMessage = 76 [(wire_out) = true];
+
+    // Lisk
+    /*
+    MessageType_LiskGetAddress = 114 [(wire_in) = true];
+    MessageType_LiskAddress = 115 [(wire_out) = true];
+    MessageType_LiskSignTx = 116 [(wire_in) = true];
+    MessageType_LiskSignedTx = 117 [(wire_out) = true];
+    MessageType_LiskSignMessage = 118 [(wire_in) = true];
+    MessageType_LiskMessageSignature = 119 [(wire_out) = true];
+    MessageType_LiskVerifyMessage = 120 [(wire_in) = true];
+    MessageType_LiskGetPublicKey = 121 [(wire_in) = true];
+    MessageType_LiskPublicKey = 122 [(wire_out) = true];
+    */
+    reserved 114 to 122;
+
+    // Tezos
+    MessageType_TezosGetAddress = 150 [(wire_in) = true];
+    MessageType_TezosAddress = 151 [(wire_out) = true];
+    MessageType_TezosSignTx = 152 [(wire_in) = true];
+    MessageType_TezosSignedTx = 153 [(wire_out) = true];
+    MessageType_TezosGetPublicKey = 154 [(wire_in) = true];
+    MessageType_TezosPublicKey = 155 [(wire_out) = true];
+
+    // Stellar
+    MessageType_StellarSignTx = 202 [(wire_in) = true];
+    MessageType_StellarTxOpRequest = 203 [(wire_out) = true];
+    MessageType_StellarGetAddress = 207 [(wire_in) = true];
+    MessageType_StellarAddress = 208 [(wire_out) = true];
+    MessageType_StellarCreateAccountOp = 210 [(wire_in) = true];
+    MessageType_StellarPaymentOp = 211 [(wire_in) = true];
+    MessageType_StellarPathPaymentStrictReceiveOp = 212 [(wire_in) = true];
+    MessageType_StellarManageSellOfferOp = 213 [(wire_in) = true];
+    MessageType_StellarCreatePassiveSellOfferOp = 214 [(wire_in) = true];
+    MessageType_StellarSetOptionsOp = 215 [(wire_in) = true];
+    MessageType_StellarChangeTrustOp = 216 [(wire_in) = true];
+    MessageType_StellarAllowTrustOp = 217 [(wire_in) = true];
+    MessageType_StellarAccountMergeOp = 218 [(wire_in) = true];
+    reserved 219;  // omitted: StellarInflationOp
+    MessageType_StellarManageDataOp = 220 [(wire_in) = true];
+    MessageType_StellarBumpSequenceOp = 221 [(wire_in) = true];
+    MessageType_StellarManageBuyOfferOp = 222 [(wire_in) = true];
+    MessageType_StellarPathPaymentStrictSendOp = 223 [(wire_in) = true];
+    reserved 224;  // omitted: StellarCreateClaimableBalanceOp
+    MessageType_StellarClaimClaimableBalanceOp = 225 [(wire_in) = true];
+    MessageType_StellarSignedTx = 230 [(wire_out) = true];
+
+    // Cardano
+    // dropped Sign/VerifyMessage ids 300-302
+    // dropped TxRequest/TxAck ids 304 and 309 (shelley update)
+    // dropped SignTx/SignedTx/SignedTxChunk/SignedTxChunkAck ids 303, 310, 311 and 312
+    reserved 300 to 304, 309 to 312;
+    MessageType_CardanoGetPublicKey = 305 [(wire_in) = true];
+    MessageType_CardanoPublicKey = 306 [(wire_out) = true];
+    MessageType_CardanoGetAddress = 307 [(wire_in) = true];
+    MessageType_CardanoAddress = 308 [(wire_out) = true];
+    MessageType_CardanoTxItemAck = 313 [(wire_out) = true];
+    MessageType_CardanoTxAuxiliaryDataSupplement = 314 [(wire_out) = true];
+    MessageType_CardanoTxWitnessRequest = 315 [(wire_in) = true];
+    MessageType_CardanoTxWitnessResponse = 316 [(wire_out) = true];
+    MessageType_CardanoTxHostAck = 317 [(wire_in) = true];
+    MessageType_CardanoTxBodyHash = 318 [(wire_out) = true];
+    MessageType_CardanoSignTxFinished = 319 [(wire_out) = true];
+    MessageType_CardanoSignTxInit = 320 [(wire_in) = true];
+    MessageType_CardanoTxInput = 321 [(wire_in) = true];
+    MessageType_CardanoTxOutput = 322 [(wire_in) = true];
+    MessageType_CardanoAssetGroup = 323 [(wire_in) = true];
+    MessageType_CardanoToken = 324 [(wire_in) = true];
+    MessageType_CardanoTxCertificate = 325 [(wire_in) = true];
+    MessageType_CardanoTxWithdrawal = 326 [(wire_in) = true];
+    MessageType_CardanoTxAuxiliaryData = 327 [(wire_in) = true];
+    MessageType_CardanoPoolOwner = 328 [(wire_in) = true];
+    MessageType_CardanoPoolRelayParameters = 329 [(wire_in) = true];
+    MessageType_CardanoGetNativeScriptHash = 330 [(wire_in) = true];
+    MessageType_CardanoNativeScriptHash = 331 [(wire_out) = true];
+    MessageType_CardanoTxMint = 332 [(wire_in) = true];
+    MessageType_CardanoTxCollateralInput = 333 [(wire_in) = true];
+    MessageType_CardanoTxRequiredSigner = 334 [(wire_in) = true];
+    MessageType_CardanoTxInlineDatumChunk = 335 [(wire_in) = true];
+    MessageType_CardanoTxReferenceScriptChunk = 336 [(wire_in) = true];
+    MessageType_CardanoTxReferenceInput = 337 [(wire_in) = true];
+
+    // Ripple
+    MessageType_RippleGetAddress = 400 [(wire_in) = true];
+    MessageType_RippleAddress = 401 [(wire_out) = true];
+    MessageType_RippleSignTx = 402 [(wire_in) = true];
+    MessageType_RippleSignedTx = 403 [(wire_in) = true];
+
+    // Monero
+    MessageType_MoneroTransactionInitRequest = 501 [(wire_out) = true];
+    MessageType_MoneroTransactionInitAck = 502 [(wire_out) = true];
+    MessageType_MoneroTransactionSetInputRequest = 503 [(wire_out) = true];
+    MessageType_MoneroTransactionSetInputAck = 504 [(wire_out) = true];
+    MessageType_MoneroTransactionInputViniRequest = 507 [(wire_out) = true];
+    MessageType_MoneroTransactionInputViniAck = 508 [(wire_out) = true];
+    MessageType_MoneroTransactionAllInputsSetRequest = 509 [(wire_out) = true];
+    MessageType_MoneroTransactionAllInputsSetAck = 510 [(wire_out) = true];
+    MessageType_MoneroTransactionSetOutputRequest = 511 [(wire_out) = true];
+    MessageType_MoneroTransactionSetOutputAck = 512 [(wire_out) = true];
+    MessageType_MoneroTransactionAllOutSetRequest = 513 [(wire_out) = true];
+    MessageType_MoneroTransactionAllOutSetAck = 514 [(wire_out) = true];
+    MessageType_MoneroTransactionSignInputRequest = 515 [(wire_out) = true];
+    MessageType_MoneroTransactionSignInputAck = 516 [(wire_out) = true];
+    MessageType_MoneroTransactionFinalRequest = 517 [(wire_out) = true];
+    MessageType_MoneroTransactionFinalAck = 518 [(wire_out) = true];
+    MessageType_MoneroKeyImageExportInitRequest = 530 [(wire_out) = true];
+    MessageType_MoneroKeyImageExportInitAck = 531 [(wire_out) = true];
+    MessageType_MoneroKeyImageSyncStepRequest = 532 [(wire_out) = true];
+    MessageType_MoneroKeyImageSyncStepAck = 533 [(wire_out) = true];
+    MessageType_MoneroKeyImageSyncFinalRequest = 534 [(wire_out) = true];
+    MessageType_MoneroKeyImageSyncFinalAck = 535 [(wire_out) = true];
+    MessageType_MoneroGetAddress = 540 [(wire_in) = true];
+    MessageType_MoneroAddress = 541 [(wire_out) = true];
+    MessageType_MoneroGetWatchKey = 542 [(wire_in) = true];
+    MessageType_MoneroWatchKey = 543 [(wire_out) = true];
+    MessageType_DebugMoneroDiagRequest = 546 [(wire_in) = true];
+    MessageType_DebugMoneroDiagAck = 547 [(wire_out) = true];
+    MessageType_MoneroGetTxKeyRequest = 550 [(wire_in) = true];
+    MessageType_MoneroGetTxKeyAck = 551 [(wire_out) = true];
+    MessageType_MoneroLiveRefreshStartRequest = 552 [(wire_in) = true];
+    MessageType_MoneroLiveRefreshStartAck = 553 [(wire_out) = true];
+    MessageType_MoneroLiveRefreshStepRequest = 554 [(wire_in) = true];
+    MessageType_MoneroLiveRefreshStepAck = 555 [(wire_out) = true];
+    MessageType_MoneroLiveRefreshFinalRequest = 556 [(wire_in) = true];
+    MessageType_MoneroLiveRefreshFinalAck = 557 [(wire_out) = true];
+
+    // EOS
+    MessageType_EosGetPublicKey = 600 [(wire_in) = true];
+    MessageType_EosPublicKey = 601 [(wire_out) = true];
+    MessageType_EosSignTx = 602 [(wire_in) = true];
+    MessageType_EosTxActionRequest = 603 [(wire_out) = true];
+    MessageType_EosTxActionAck = 604 [(wire_in) = true];
+    MessageType_EosSignedTx = 605 [(wire_out) = true];
+
+    // Binance
+    MessageType_BinanceGetAddress = 700 [(wire_in) = true];
+    MessageType_BinanceAddress = 701 [(wire_out) = true];
+    MessageType_BinanceGetPublicKey = 702 [(wire_in) = true];
+    MessageType_BinancePublicKey = 703 [(wire_out) = true];
+    MessageType_BinanceSignTx = 704 [(wire_in) = true];
+    MessageType_BinanceTxRequest = 705 [(wire_out) = true];
+    MessageType_BinanceTransferMsg = 706 [(wire_in) = true];
+    MessageType_BinanceOrderMsg = 707 [(wire_in) = true];
+    MessageType_BinanceCancelMsg = 708 [(wire_in) = true];
+    MessageType_BinanceSignedTx = 709 [(wire_out) = true];
+
+    // WebAuthn
+    MessageType_WebAuthnListResidentCredentials = 800 [(wire_in) = true];
+    MessageType_WebAuthnCredentials = 801 [(wire_out) = true];
+    MessageType_WebAuthnAddResidentCredential = 802 [(wire_in) = true];
+    MessageType_WebAuthnRemoveResidentCredential = 803 [(wire_in) = true];
+
+    // Solana
+    MessageType_SolanaGetPublicKey = 900 [(wire_in) = true];
+    MessageType_SolanaPublicKey = 901 [(wire_out) = true];
+    MessageType_SolanaGetAddress = 902 [(wire_in) = true];
+    MessageType_SolanaAddress = 903 [(wire_out) = true];
+    MessageType_SolanaSignTx = 904 [(wire_in) = true];
+    MessageType_SolanaTxSignature = 905 [(wire_out) = true];
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -359,10 +359,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   mime:
     dependency: transitive
     description:
@@ -419,6 +419,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  protobuf:
+    dependency: "direct main"
+    description:
+      name: protobuf
+      sha256: "68645b24e0716782e58948f8467fd42a880f255096a821f9e7d0ec625b00c84d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   provider:
     dependency: transitive
     description:
@@ -508,18 +516,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
@@ -548,26 +556,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "13b41f318e2a5751c3169137103b60c584297353d4b1761b66029bae6411fe46"
+      sha256: a1f7595805820fcc05e5c52e3a231aedd0b72972cb333e8c738a8b1239448b6f
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.3"
+    version: "1.24.9"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "99806e9e6d95c7b059b7a0fc08f07fc53fabe54a829497f0d9676299f1e8637e"
+      sha256: a757b14fc47507060a162cc2530d9a4a2f92f5100a952c7443b5cad5ef5b106a
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.3"
+    version: "0.5.9"
   timing:
     dependency: transitive
     description:
@@ -612,10 +620,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.3.0"
   web_socket_channel:
     dependency: transitive
     description:
@@ -641,5 +649,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.5 <4.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=3.13.9"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mirage
 description: Desktop application connecting SNGGLE with PC
 publish_to: 'none'
-version: 0.0.1
+version: 0.0.2
 
 environment:
   sdk: ">=3.1.5"
@@ -27,6 +27,9 @@ dependencies:
   # Small, easy to use and extensible logger which prints beautiful logs.
   # https://pub.dev/packages/logger
   logger: ^2.0.2+1
+
+  # Provides runtime support for a Dart implementation of protobufs.
+  protobuf: ^3.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This branch prepares files that define messages to communicate with MetaMask using Trezor Protocol. Trezor uses Protobuf messages, which need to be defined as .proto files. The messages prepared for Trezor Protocol were found in the official Trezor Emulator repository.

List of changes:
- added protobuf library to pubspec.yaml
- copied .proto files from the Trezor Emulator project
- compiled .proto files to .dart
- disabled linter for the compiled files