### PR TITLE
Feature: Protobuf serializer

### DIFF
--- a/lib/shared/utils/bytes_utils.dart
+++ b/lib/shared/utils/bytes_utils.dart
@@ -1,0 +1,50 @@
+import 'dart:typed_data';
+
+class BytesUtils {
+  static int convertHexToInt(String hex) {
+    Uint8List bytes = convertHexToBytes(hex);
+    return convertBytesToInt(bytes);
+  }
+
+  static String convertBytesToHex(Uint8List bytes) {
+    return bytes.map((int byte) => byte.toRadixString(16).padLeft(2, '0')).join();
+  }
+
+  static int convertBytesToInt(Uint8List bytes) {
+    int result = 0;
+    for (int i = 0; i < bytes.lengthInBytes; i++) {
+      result += bytes[i] << (8 * (bytes.lengthInBytes - 1 - i));
+    }
+    return result;
+  }
+
+  static Uint8List convertHexToBytes(String hex) {
+    if (hex.length % 2 != 0) {
+      throw const FormatException('Invalid hexadecimal string length');
+    }
+
+    int length = hex.length ~/ 2;
+    Uint8List result = Uint8List(length);
+
+    for (int i = 0; i < length; i++) {
+      String byte = hex.substring(i * 2, i * 2 + 2);
+      result[i] = int.parse(byte, radix: 16);
+    }
+
+    return result;
+  }
+
+  static Uint8List convertIntToBytes(int intToConvert, int length) {
+    Uint8List bytes = Uint8List(length);
+
+    for (int i = length - 1; i >= 0; i--) {
+      bytes[i] = (intToConvert >> (8 * (length - 1 - i))) & 0xFF;
+    }
+
+    return bytes;
+  }
+
+  static Uint8List mergeUint8Lists(List<Uint8List> lists) {
+    return Uint8List.fromList(lists.expand((Uint8List list) => list).toList());
+  }
+}

--- a/lib/trezor_protocol/shared/protobuf/protobuf_msg_mapper.dart
+++ b/lib/trezor_protocol/shared/protobuf/protobuf_msg_mapper.dart
@@ -1,0 +1,51 @@
+import 'dart:typed_data';
+
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-bitcoin.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-common.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-management.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages.pbenum.dart';
+import 'package:protobuf/protobuf.dart' as protobuf;
+
+class ProtobufMsgMapper {
+  /// This method facilitates deserialization of protobuf messages, it handles inbound messages only.
+  static protobuf.GeneratedMessage getMsgFromType(MessageType messageType, Uint8List msgContents) {
+    switch (messageType) {
+      case MessageType.MessageType_Initialize:
+        return Initialize.fromBuffer(msgContents);
+      case MessageType.MessageType_GetPublicKey:
+        return GetPublicKey.fromBuffer(msgContents);
+      case MessageType.MessageType_ButtonAck:
+        return ButtonAck.fromBuffer(msgContents);
+      case MessageType.MessageType_GetAddress:
+        return GetAddress.fromBuffer(msgContents);
+      case MessageType.MessageType_PassphraseAck:
+        return PassphraseAck.fromBuffer(msgContents);
+      case MessageType.MessageType_GetFeatures:
+        return GetFeatures.fromBuffer(msgContents);
+      case MessageType.MessageType_EthereumSignTxEIP1559:
+        return EthereumSignTxEIP1559.fromBuffer(msgContents);
+      default:
+        throw ArgumentError('Unknown message type: $messageType');
+    }
+  }
+
+  /// This method facilitates serialization of protobuf messages, it handles outbound messages only.
+  static int getMsgTypeNumber(protobuf.GeneratedMessage msg) {
+    if (msg is PublicKey) {
+      return 12; // hex: 000c
+    } else if (msg is Features) {
+      return 17; // hex: 0011
+    } else if (msg is ButtonRequest) {
+      return 26; // hex: 001a
+    } else if (msg is Address) {
+      return 30; // hex: 001e
+    } else if (msg is PassphraseRequest) {
+      return 41; // hex: 0029
+    } else if (msg is EthereumTxRequest) {
+      return 59; // hex: 003b
+    } else {
+      throw ArgumentError('Unknown message: $msg');
+    }
+  }
+}

--- a/lib/trezor_protocol/shared/protobuf/protobuf_msg_serializer.dart
+++ b/lib/trezor_protocol/shared/protobuf/protobuf_msg_serializer.dart
@@ -1,0 +1,58 @@
+import 'dart:typed_data';
+
+import 'package:mirage/shared/utils/bytes_utils.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages.pbenum.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/protobuf_msg_mapper.dart';
+import 'package:protobuf/protobuf.dart' as protobuf;
+
+/// Mirage receives buffers from connect.trezor.io in the http POST requests with "call" path parameter.
+/// The buffer structure looks as follows:
+/// The first 2 bytes represent the numerical message type in BE uint16_t format.
+/// The next 4 bytes represent the message size in BE uint32_t.
+/// The rest of the bytes are the actual message contents in uint8_t format, that can be decoded with protobuf.
+
+/// Example: 001d0000002108ac80808008088180808008088080808008080008001207546573746e6574280000000000000000000000000000000000000000000000
+/// Message type => 00 1d => 29 => MessageType_GetAddress (the message numbers are defined in messages.proto)
+/// Message size => 00 00 00 21 => 33 => The message consists of 33 bytes
+/// Actual message contents => 08 ac 80 80 80 08 08 81 80 80 80 08 08 80 80 80 80 08 08 00 08 00 12 07 54 65 73 74 6e 65 74 28 00
+/// Deserialized message:
+/// GetAddress(
+///   addressN: <int>[2147483692, 2147483649, 2147483648, 0, 0],
+///   coinName: 'Testnet',
+///   scriptType: InputScriptType.SPENDADDRESS,
+/// );
+
+/// NOTE: Similar description for the buffer format can be found in the Trezor Emulator repository:
+/// https://github.com/trezor/trezor-firmware/blob/0fbfda7762eedf6b46092b08b1e816ac7625b9e7/common/protob/protocol.md#L4
+/// However, this format is slightly different, because it includes the communication with Trezor Bridge via UDP.
+/// Since the Trezor Bridge is integrated in Mirage, there is no need for magic constants and 64 bytes chunks.
+class ProtobufMsgSerializer {
+  static protobuf.GeneratedMessage deserialize(String buffer) {
+    Uint8List inputBytes = BytesUtils.convertHexToBytes(buffer);
+    Uint8List msgContents = inputBytes.sublist(6, 6 + _getMsgSize(buffer));
+    try {
+      MessageType? messageType = MessageType.valueOf(_getMsgType(buffer));
+      return ProtobufMsgMapper.getMsgFromType(messageType!, msgContents);
+    } catch (e) {
+      throw ArgumentError('Could not interpret bytes: $buffer');
+    }
+  }
+
+  static String serialize(protobuf.GeneratedMessage protobufMsg) {
+    int msgType = ProtobufMsgMapper.getMsgTypeNumber(protobufMsg);
+    Uint8List msgBuffer = protobufMsg.writeToBuffer();
+
+    int msgSize = msgBuffer.length;
+    Uint8List msgTypeBytes = BytesUtils.convertIntToBytes(msgType, 2);
+    Uint8List msgSizeBytes = BytesUtils.convertIntToBytes(msgSize, 4);
+
+    Uint8List mergedBytes = BytesUtils.mergeUint8Lists(<Uint8List>[msgTypeBytes, msgSizeBytes, msgBuffer]);
+
+    String buffer = BytesUtils.convertBytesToHex(mergedBytes);
+    return buffer;
+  }
+
+  static int _getMsgType(String inputBuffer) => BytesUtils.convertHexToInt(inputBuffer.substring(0, 4));
+
+  static int _getMsgSize(String inputBuffer) => BytesUtils.convertHexToInt(inputBuffer.substring(4, 12));
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mirage
 description: Desktop application connecting SNGGLE with PC
 publish_to: 'none'
-version: 0.0.2
+version: 0.0.3
 
 environment:
   sdk: ">=3.1.5"

--- a/test/unit/example_test.dart
+++ b/test/unit/example_test.dart
@@ -1,7 +1,0 @@
-import 'package:flutter_test/flutter_test.dart';
-
-void main() {
-  test('Empty test to enable CI/CD launch', () {
-    expect(true, true);
-  });
-}

--- a/test/unit/shared/utils/bytes_utils_test.dart
+++ b/test/unit/shared/utils/bytes_utils_test.dart
@@ -1,0 +1,115 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mirage/shared/utils/bytes_utils.dart';
+
+void main() {
+  group('Tests of BytesUtils.convertHexToInt()', () {
+    test('Should [return int] calculated from HEX', () {
+      // Arrange
+      String actualHexInput = '1a2b3c';
+
+      // Act
+      int actualInt = BytesUtils.convertHexToInt(actualHexInput);
+
+      // Assert
+      int expectedInt = 1715004;
+
+      expect(actualInt, expectedInt);
+    });
+  });
+
+  group('Tests of BytesUtils.convertBytesToHex()', () {
+    test('Should [return hex bytes] calculated from BYTES', () {
+      // Arrange
+      Uint8List actualBytesInput = Uint8List.fromList(<int>[215, 21, 5, 90]);
+
+      // Act
+      String actualHex = BytesUtils.convertBytesToHex(actualBytesInput);
+
+      // Assert
+      String expectedHex = 'd715055a';
+
+      expect(actualHex, expectedHex);
+    });
+  });
+
+  group('Tests of BytesUtils.convertBytesToInt()', () {
+    test('Should [return int] calculated from BYTES', () {
+      // Arrange
+      Uint8List actualBytesInput = Uint8List.fromList(<int>[215, 21, 5, 90]);
+
+      // Act
+      int actualInt = BytesUtils.convertBytesToInt(actualBytesInput);
+
+      // Assert
+      int expectedInt = 3608479066;
+
+      expect(actualInt, expectedInt);
+    });
+  });
+
+  group('Tests of BytesUtils.convertHexToBytes()', () {
+    test('Should [return bytes] calculated from HEX', () {
+      // Arrange
+      String actualHexInput = '4d5e6f';
+
+      // Act
+      Uint8List actualBytes = BytesUtils.convertHexToBytes(actualHexInput);
+
+      // Assert
+      Uint8List expectedBytes = Uint8List.fromList(<int>[77, 94, 111]);
+
+      expect(actualBytes, expectedBytes);
+    });
+  });
+
+  group('Tests of BytesUtils.convertIntToBytes()', () {
+    test('Should [return bytes] representing given int (length = 2)', () {
+      // Arrange
+      int actualIntToConvert = 452;
+      int actualLength = 2;
+
+      // Act
+      Uint8List actualBytes = BytesUtils.convertIntToBytes(actualIntToConvert, actualLength);
+
+      // Assert
+      Uint8List expectedBytes = Uint8List.fromList(<int>[1, 196]);
+
+      expect(actualBytes, expectedBytes);
+    });
+
+    test('Should [return bytes] representing given int (length = 4)', () {
+      // Arrange
+      int actualIntToConvert = 452;
+      int actualLength = 4;
+
+      // Act
+      Uint8List actualBytes = BytesUtils.convertIntToBytes(actualIntToConvert, actualLength);
+
+      // Assert
+      Uint8List expectedBytes = Uint8List.fromList(<int>[0, 0, 1, 196]);
+
+      expect(actualBytes, expectedBytes);
+    });
+  });
+
+  group('Tests of BytesUtils.mergeUint8Lists()', () {
+    test('Should [return merged Uint8List] from multiple Uint8Lists', () {
+      // Arrange
+      Uint8List actualUint8listA = Uint8List.fromList(<int>[1, 2, 3, 4]);
+      Uint8List actualUint8listB = Uint8List.fromList(<int>[5, 6, 7, 8]);
+      Uint8List actualUint8listC = Uint8List.fromList(<int>[9, 10, 11, 12]);
+
+      List<Uint8List> actualUint8listsToMerge = <Uint8List>[actualUint8listA, actualUint8listB, actualUint8listC];
+
+      // Act
+      Uint8List actualMergedUint8List = BytesUtils.mergeUint8Lists(actualUint8listsToMerge);
+
+      // Assert
+      Uint8List expectedMergedUint8List = Uint8List.fromList(<int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+
+      expect(actualMergedUint8List, expectedMergedUint8List);
+    });
+  });
+}

--- a/test/unit/trezor_protocol/shared/protobuf/protobuf_msg_mapper_test.dart
+++ b/test/unit/trezor_protocol/shared/protobuf/protobuf_msg_mapper_test.dart
@@ -1,0 +1,187 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-bitcoin.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-common.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-management.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/protobuf_msg_mapper.dart';
+import 'package:protobuf/protobuf.dart' as protobuf;
+
+void main() {
+  Uint8List actualMsgEmptyContents = Uint8List.fromList(<int>[]);
+
+  group('Tests of ProtobufMsgMapper.getMsgFromType() (for incoming messages)', () {
+    test('Should [return Initialize] from given message type and contents', () {
+      // Arrange
+      MessageType actualMessageType = MessageType.MessageType_Initialize;
+
+      // Act
+      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getMsgFromType(actualMessageType, actualMsgEmptyContents);
+
+      // Assert
+      protobuf.GeneratedMessage expectedProtobufMsg = Initialize();
+
+      expect(actualProtobufMsg, expectedProtobufMsg);
+    });
+
+    test('Should [return GetPublicKey] from given message type and contents', () {
+      // Arrange
+      MessageType actualMessageType = MessageType.MessageType_GetPublicKey;
+
+      // Act
+      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getMsgFromType(actualMessageType, actualMsgEmptyContents);
+
+      // Assert
+      protobuf.GeneratedMessage expectedProtobufMsg = GetPublicKey();
+
+      expect(actualProtobufMsg, expectedProtobufMsg);
+    });
+
+    test('Should [return ButtonAck] from given message type and contents', () {
+      // Arrange
+      MessageType actualMessageType = MessageType.MessageType_ButtonAck;
+
+      // Act
+      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getMsgFromType(actualMessageType, actualMsgEmptyContents);
+
+      // Assert
+      protobuf.GeneratedMessage expectedProtobufMsg = ButtonAck();
+
+      expect(actualProtobufMsg, expectedProtobufMsg);
+    });
+
+    test('Should [return GetAddress] from given message type and contents', () {
+      // Arrange
+      MessageType actualMessageType = MessageType.MessageType_GetAddress;
+
+      // Act
+      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getMsgFromType(actualMessageType, actualMsgEmptyContents);
+
+      // Assert
+      protobuf.GeneratedMessage expectedProtobufMsg = GetAddress();
+
+      expect(actualProtobufMsg, expectedProtobufMsg);
+    });
+
+    test('Should [return PassphraseAck] from given message type and contents', () {
+      // Arrange
+      MessageType actualMessageType = MessageType.MessageType_PassphraseAck;
+
+      // Act
+      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getMsgFromType(actualMessageType, actualMsgEmptyContents);
+
+      // Assert
+      protobuf.GeneratedMessage expectedProtobufMsg = PassphraseAck();
+
+      expect(actualProtobufMsg, expectedProtobufMsg);
+    });
+
+    test('Should [return GetFeatures] from given message type and contents', () {
+      // Arrange
+      MessageType actualMessageType = MessageType.MessageType_GetFeatures;
+
+      // Act
+      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getMsgFromType(actualMessageType, actualMsgEmptyContents);
+
+      // Assert
+      protobuf.GeneratedMessage expectedProtobufMsg = GetFeatures();
+
+      expect(actualProtobufMsg, expectedProtobufMsg);
+    });
+
+    test('Should [return EthereumSignTxEIP1559] from given message type and contents', () {
+      // Arrange
+      MessageType actualMessageType = MessageType.MessageType_EthereumSignTxEIP1559;
+
+      // Act
+      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getMsgFromType(actualMessageType, actualMsgEmptyContents);
+
+      // Assert
+      protobuf.GeneratedMessage expectedProtobufMsg = EthereumSignTxEIP1559();
+
+      expect(actualProtobufMsg, expectedProtobufMsg);
+    });
+  });
+
+  group('Tests of ProtobufMsgMapper.getMsgTypeNumber() (for outgoing messages)', () {
+    test('Should [return 12] if the message is PublicKey', () {
+      // Arrange
+      PublicKey actualMessage = PublicKey();
+
+      // Act
+      int actualMsgTypeNumber = ProtobufMsgMapper.getMsgTypeNumber(actualMessage);
+
+      // Assert
+      int expectedMsgTypeNumber = 12;
+
+      expect(actualMsgTypeNumber, expectedMsgTypeNumber);
+    });
+
+    test('Should [return 17] if the message is Features', () {
+      // Arrange
+      Features actualMessage = Features();
+
+      // Act
+      int actualMsgTypeNumber = ProtobufMsgMapper.getMsgTypeNumber(actualMessage);
+
+      // Assert
+      int expectedMsgTypeNumber = 17;
+
+      expect(actualMsgTypeNumber, expectedMsgTypeNumber);
+    });
+
+    test('Should [return 26] if the message is ButtonRequest', () {
+      // Arrange
+      ButtonRequest actualMessage = ButtonRequest();
+
+      // Act
+      int actualMsgTypeNumber = ProtobufMsgMapper.getMsgTypeNumber(actualMessage);
+
+      // Assert
+      int expectedMsgTypeNumber = 26;
+
+      expect(actualMsgTypeNumber, expectedMsgTypeNumber);
+    });
+
+    test('Should [return 26] if the message is Address', () {
+      // Arrange
+      Address actualMessage = Address();
+
+      // Act
+      int actualMsgTypeNumber = ProtobufMsgMapper.getMsgTypeNumber(actualMessage);
+
+      // Assert
+      int expectedMsgTypeNumber = 30;
+
+      expect(actualMsgTypeNumber, expectedMsgTypeNumber);
+    });
+
+    test('Should [return 26] if the message is PassphraseRequest', () {
+      // Arrange
+      PassphraseRequest actualMessage = PassphraseRequest();
+
+      // Act
+      int actualMsgTypeNumber = ProtobufMsgMapper.getMsgTypeNumber(actualMessage);
+
+      // Assert
+      int expectedMsgTypeNumber = 41;
+
+      expect(actualMsgTypeNumber, expectedMsgTypeNumber);
+    });
+
+    test('Should [return 26] if the message is EthereumTxRequest', () {
+      // Arrange
+      EthereumTxRequest actualMessage = EthereumTxRequest();
+
+      // Act
+      int actualMsgTypeNumber = ProtobufMsgMapper.getMsgTypeNumber(actualMessage);
+
+      // Assert
+      int expectedMsgTypeNumber = 59;
+
+      expect(actualMsgTypeNumber, expectedMsgTypeNumber);
+    });
+  });
+}

--- a/test/unit/trezor_protocol/shared/protobuf/protobuf_msg_serializer_test.dart
+++ b/test/unit/trezor_protocol/shared/protobuf/protobuf_msg_serializer_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-bitcoin.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-common.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-management.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/protobuf_msg_serializer.dart';
+import 'package:protobuf/protobuf.dart' as protobuf;
+
+void main() {
+  group('Tests of ProtobufMsgSerializer.deserialize()', () {
+    test('Should [return GetFeatures] from the given bytes', () {
+      // Arrange
+      String actualBytes = '003700000000';
+
+      // Act
+      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgSerializer.deserialize(actualBytes);
+
+      // Assert
+      protobuf.GeneratedMessage expectedProtobufMsg = GetFeatures();
+
+      expect(actualProtobufMsg, expectedProtobufMsg);
+    });
+
+    test('Should [return GetAddress] from the given bytes', () {
+      // Arrange
+      String actualBytes = '001d0000002108ac80808008088180808008088080808008080008001207546573746e6574280000000000000000000000000000000000000000000000';
+
+      // Act
+      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgSerializer.deserialize(actualBytes);
+
+      // Assert
+      protobuf.GeneratedMessage expectedProtobufMsg = GetAddress(
+        addressN: <int>[2147483692, 2147483649, 2147483648, 0, 0],
+        coinName: 'Testnet',
+        scriptType: InputScriptType.SPENDADDRESS,
+      );
+
+      expect(actualProtobufMsg, expectedProtobufMsg);
+    });
+  });
+
+  group('Tests of ProtobufMsgSerializer.serialize()', () {
+    test('Should [return bytes] from given message type: PassphraseRequest', () {
+      // Arrange
+      PassphraseRequest actualPassphraseRequest = PassphraseRequest();
+
+      // Act
+      String actualBytes = ProtobufMsgSerializer.serialize(actualPassphraseRequest);
+
+      // Assert
+      String expectedBytes = '002900000000';
+
+      expect(actualBytes, expectedBytes);
+    });
+
+    test('Should [return bytes] from given message type: Features', () {
+      // Arrange
+      Features actualFeatures = Features(
+        vendor: 'trezor.io',
+        majorVersion: 2,
+        minorVersion: 7,
+        patchVersion: 1,
+        deviceId: '355C817510C0EABF2F147145',
+        pinProtection: true,
+        passphraseProtection: true,
+        language: 'en-US',
+        label: 'My Trezor',
+        initialized: true,
+        revision: <int>[199, 131, 44, 57, 171, 60, 42, 156, 70, 84, 76, 87, 209, 168, 152, 5, 131, 96, 159, 71],
+        unlocked: true,
+        needsBackup: false,
+        flags: 0,
+        model: 'T',
+        fwVendor: 'EMULATOR',
+        unfinishedBackup: false,
+        noBackup: false,
+        recoveryMode: false,
+        capabilities: <Features_Capability>[
+          Features_Capability.Capability_Bitcoin,
+          Features_Capability.Capability_Bitcoin_like,
+          Features_Capability.Capability_Binance,
+          Features_Capability.Capability_Cardano,
+          Features_Capability.Capability_Crypto,
+          Features_Capability.Capability_Ethereum,
+          Features_Capability.Capability_Monero,
+          Features_Capability.Capability_Ripple,
+          Features_Capability.Capability_Stellar,
+          Features_Capability.Capability_Tezos,
+          Features_Capability.Capability_U2F,
+          Features_Capability.Capability_Shamir,
+          Features_Capability.Capability_ShamirGroups,
+          Features_Capability.Capability_PassphraseEntry,
+          Features_Capability.Capability_Solana,
+          Features_Capability.Capability_Translations,
+          Features_Capability.Capability_NEM,
+          Features_Capability.Capability_EOS,
+        ],
+        backupType: BackupType.Bip39,
+        sdCardPresent: true,
+        sdProtection: false,
+        wipeCodeProtection: false,
+        passphraseAlwaysOnDevice: false,
+        safetyChecks: SafetyCheckLevel.Strict,
+        autoLockDelayMs: 600000,
+        displayRotation: 0,
+        experimentalFeatures: false,
+        busy: false,
+        homescreenFormat: HomescreenFormat.Jpeg,
+        hidePassphraseFromHost: false,
+        internalModel: 'T2T1',
+        homescreenWidth: 240,
+        homescreenHeight: 240,
+        languageVersionMatches: true,
+      );
+
+      // Act
+      String actualBytes = ProtobufMsgSerializer.serialize(actualFeatures);
+
+      // Assert
+      String expectedBytes =
+          '0011000000e80a097472657a6f722e696f1002180720013218333535433831373531304330454142463246313437313435380140014a05656e2d555352094d79205472657a6f7260016a14c7832c39ab3c2a9c46544c57d1a8980583609f47800101980100a00100aa010154ca0108454d554c41544f52d80100e00100e80100f00101f00102f00103f00104f00105f00107f00109f0010bf0010cf0010df0010ef0010ff00110f00111f00112f00113f0010af00106f80100800201880200900200a00200a80200b002c0cf24b80200c00200c80200d00202d80200e2020454325431f802f0018003f001900301';
+
+      expect(actualBytes, expectedBytes);
+    });
+  });
+}


### PR DESCRIPTION
This branch implements serialization and deserialization functionality of the protobuf messages.

List of changes:
- created protobuf_msg_serializer.dart with the main methods “serialize()” and “deserialize()”
- created protobuf_msg_mapper.dart, which allows the convenient use of generated protobuf messages (only those that are needed for Mirage process)
- created bytes_utils.dart, which is a set of methods to facilitate operations on bytes