### PR TITLE
Feature: Basic Trezor communication

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.13.9",
+  "flutterSdkVersion": "3.16.2",
   "flavors": {}
 }

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ git clone git@github.com:snggle/mirage.git
 ```
 
 ## Usage
-The project runs on flutter version **3.13.9**. You can use [fvm](https://fvm.app/documentation/getting-started/installation)
+The project runs on flutter version **3.16.2**. You can use [fvm](https://fvm.app/documentation/getting-started/installation)
 for easy switching between versions
 ```bash
 # Install and use required flutter version
-fvm install 3.13.9
-fvm use 3.13.9
+fvm install 3.16.2
+fvm use 3.16.2
 
 # Install required packages in pubspec.yaml
 fvm flutter pub get

--- a/lib/config/locator.dart
+++ b/lib/config/locator.dart
@@ -1,0 +1,8 @@
+import 'package:get_it/get_it.dart';
+import 'package:mirage/trezor_protocol/controllers/trezor_communication_controller.dart';
+
+final GetIt globalLocator = GetIt.I;
+
+Future<void> initLocator() async {
+  globalLocator.registerLazySingleton<TrezorCommunicationController>(TrezorCommunicationController.new);
+}

--- a/lib/shared/utils/bytes_utils.dart
+++ b/lib/shared/utils/bytes_utils.dart
@@ -1,21 +1,18 @@
+import 'dart:math';
 import 'dart:typed_data';
 
 class BytesUtils {
-  static int convertHexToInt(String hex) {
-    Uint8List bytes = convertHexToBytes(hex);
-    return convertBytesToInt(bytes);
+  static BigInt convertBytesToBigInt(List<int> bytes, {Endian endian = Endian.big}) {
+    return BigInt.from(convertBytesToInt(bytes, endian: endian));
   }
 
-  static String convertBytesToHex(Uint8List bytes) {
+  static String convertBytesToHex(List<int> bytes) {
     return bytes.map((int byte) => byte.toRadixString(16).padLeft(2, '0')).join();
   }
 
-  static int convertBytesToInt(Uint8List bytes) {
-    int result = 0;
-    for (int i = 0; i < bytes.lengthInBytes; i++) {
-      result += bytes[i] << (8 * (bytes.lengthInBytes - 1 - i));
-    }
-    return result;
+  static int convertHexToInt(String hex, {Endian endian = Endian.big}) {
+    Uint8List bytes = convertHexToBytes(hex);
+    return convertBytesToInt(bytes, endian: endian);
   }
 
   static Uint8List convertHexToBytes(String hex) {
@@ -34,6 +31,20 @@ class BytesUtils {
     return result;
   }
 
+  static int convertBytesToInt(List<int> bytes, {Endian endian = Endian.big}) {
+    switch (endian) {
+      case Endian.little:
+        return (bytes[1] << 8) + bytes[0];
+      case Endian.big:
+      default:
+        int result = 0;
+        for (int i = 0; i < bytes.length; i++) {
+          result += bytes[i] << (8 * (bytes.length - 1 - i));
+        }
+        return result;
+    }
+  }
+
   static Uint8List convertIntToBytes(int intToConvert, int length) {
     Uint8List bytes = Uint8List(length);
 
@@ -44,7 +55,19 @@ class BytesUtils {
     return bytes;
   }
 
-  static Uint8List mergeUint8Lists(List<Uint8List> lists) {
-    return Uint8List.fromList(lists.expand((Uint8List list) => list).toList());
+  static List<int> generateRandomBytes(int count) {
+    Random random = Random();
+    List<int> randomIntegers = List<int>.generate(count, (_) => random.nextInt(256));
+    return randomIntegers;
+  }
+
+  static Uint8List mergeBytes(List<List<int>> bytesLists) {
+    return Uint8List.fromList(bytesLists.expand((List<int> list) => list).toList());
+  }
+
+  // TODO(Marcin): delete this method after prompt data input is replaced with Audio Protocol implementation
+  static List<int> parseStringToList(String input) {
+    String clearInput = input.replaceAll('[', '').replaceAll(']', '').replaceAll(' ', '');
+    return clearInput.split(',').map(int.parse).toList();
   }
 }

--- a/lib/trezor_protocol/controllers/trezor_communication_controller.dart
+++ b/lib/trezor_protocol/controllers/trezor_communication_controller.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:mirage/trezor_protocol/shared/protobuf/protobuf_msg_serializer.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/a_trezor_inbound_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/automated/a_trezor_automated_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/interactive/a_trezor_interactive_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/a_trezor_outbound_response.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/a_trezor_awaited_response.dart';
+import 'package:protobuf/protobuf.dart' as protobuf;
+
+class TrezorCommunicationController {
+  Future<String> handleBuffer(String inputBuffer) async {
+    protobuf.GeneratedMessage inputMsg = ProtobufMsgSerializer.deserialize(inputBuffer);
+    protobuf.GeneratedMessage responseMsg = await _handleProtobufMsg(inputMsg);
+    return ProtobufMsgSerializer.serialize(responseMsg);
+  }
+
+  Future<protobuf.GeneratedMessage> _handleProtobufMsg(protobuf.GeneratedMessage inputMsg) async {
+    ATrezorInboundRequest trezorInboundRequest = ATrezorInboundRequest.fromProtobufMsg(inputMsg);
+    ATrezorOutboundResponse trezorOutboundResponse = await _handleTrezorRequest(trezorInboundRequest);
+    return trezorOutboundResponse.toProtobufMsg();
+  }
+
+  Future<ATrezorOutboundResponse> _handleTrezorRequest(ATrezorInboundRequest trezorInboundRequest) async {
+    switch (trezorInboundRequest) {
+      case ATrezorAutomatedRequest trezorAutomatedRequest:
+        ATrezorOutboundResponse trezorOutboundResponse = trezorAutomatedRequest.getResponse();
+        return trezorOutboundResponse;
+      case ATrezorInteractiveRequest trezorInteractiveRequest:
+        // TODO(Marcin): replace prompt data input with Audio Protocol implementation
+        ATrezorAwaitedResponse trezorAwaitedResponse = trezorInteractiveRequest.getResponseFromUser();
+        return trezorAwaitedResponse;
+      default:
+        throw ArgumentError();
+    }
+  }
+}

--- a/lib/trezor_protocol/shared/protobuf/protobuf_msg_mapper.dart
+++ b/lib/trezor_protocol/shared/protobuf/protobuf_msg_mapper.dart
@@ -9,7 +9,7 @@ import 'package:protobuf/protobuf.dart' as protobuf;
 
 class ProtobufMsgMapper {
   /// This method facilitates deserialization of protobuf messages, it handles inbound messages only.
-  static protobuf.GeneratedMessage getMsgFromType(MessageType messageType, Uint8List msgContents) {
+  static protobuf.GeneratedMessage getRequestFromProtobufType(MessageType messageType, Uint8List msgContents) {
     switch (messageType) {
       case MessageType.MessageType_Initialize:
         return Initialize.fromBuffer(msgContents);
@@ -19,10 +19,12 @@ class ProtobufMsgMapper {
         return ButtonAck.fromBuffer(msgContents);
       case MessageType.MessageType_GetAddress:
         return GetAddress.fromBuffer(msgContents);
-      case MessageType.MessageType_PassphraseAck:
-        return PassphraseAck.fromBuffer(msgContents);
       case MessageType.MessageType_GetFeatures:
         return GetFeatures.fromBuffer(msgContents);
+      case MessageType.MessageType_EthereumTxAck:
+        return EthereumTxAck.fromBuffer(msgContents);
+      case MessageType.MessageType_EthereumSignMessage:
+        return EthereumSignMessage.fromBuffer(msgContents);
       case MessageType.MessageType_EthereumSignTxEIP1559:
         return EthereumSignTxEIP1559.fromBuffer(msgContents);
       default:
@@ -30,22 +32,21 @@ class ProtobufMsgMapper {
     }
   }
 
-  /// This method facilitates serialization of protobuf messages, it handles outbound messages only.
   static int getMsgTypeNumber(protobuf.GeneratedMessage msg) {
-    if (msg is PublicKey) {
-      return 12; // hex: 000c
-    } else if (msg is Features) {
-      return 17; // hex: 0011
-    } else if (msg is ButtonRequest) {
-      return 26; // hex: 001a
-    } else if (msg is Address) {
-      return 30; // hex: 001e
-    } else if (msg is PassphraseRequest) {
-      return 41; // hex: 0029
-    } else if (msg is EthereumTxRequest) {
-      return 59; // hex: 003b
-    } else {
+    MessageType messageType = getMsgType(msg);
+    return messageType.value;
+  }
+
+  static MessageType getMsgType(protobuf.GeneratedMessage msg) {
+    String msgName = msg.info_.messageName;
+
+    return MessageType.values.firstWhere((MessageType messageType) {
+      if (messageType.name.substring(12) == msgName) {
+        return true;
+      }
+      return false;
+    }, orElse: () {
       throw ArgumentError('Unknown message: $msg');
-    }
+    });
   }
 }

--- a/lib/trezor_protocol/shared/protobuf/protobuf_msg_serializer.dart
+++ b/lib/trezor_protocol/shared/protobuf/protobuf_msg_serializer.dart
@@ -32,7 +32,7 @@ class ProtobufMsgSerializer {
     Uint8List msgContents = inputBytes.sublist(6, 6 + _getMsgSize(buffer));
     try {
       MessageType? messageType = MessageType.valueOf(_getMsgType(buffer));
-      return ProtobufMsgMapper.getMsgFromType(messageType!, msgContents);
+      return ProtobufMsgMapper.getRequestFromProtobufType(messageType!, msgContents);
     } catch (e) {
       throw ArgumentError('Could not interpret bytes: $buffer');
     }
@@ -46,7 +46,7 @@ class ProtobufMsgSerializer {
     Uint8List msgTypeBytes = BytesUtils.convertIntToBytes(msgType, 2);
     Uint8List msgSizeBytes = BytesUtils.convertIntToBytes(msgSize, 4);
 
-    Uint8List mergedBytes = BytesUtils.mergeUint8Lists(<Uint8List>[msgTypeBytes, msgSizeBytes, msgBuffer]);
+    Uint8List mergedBytes = BytesUtils.mergeBytes(<Uint8List>[msgTypeBytes, msgSizeBytes, msgBuffer]);
 
     String buffer = BytesUtils.convertBytesToHex(mergedBytes);
     return buffer;

--- a/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/a_trezor_inbound_request.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/a_trezor_inbound_request.dart
@@ -1,0 +1,32 @@
+import 'package:equatable/equatable.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-bitcoin.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-management.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/automated/trezor_device_address_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/automated/trezor_init_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/automated/trezor_properties_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/interactive/trezor_eip1559_signature_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/interactive/trezor_eth_msg_signature_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/interactive/trezor_public_key_request.dart';
+import 'package:protobuf/protobuf.dart' as protobuf;
+
+abstract class ATrezorInboundRequest extends Equatable {
+  static ATrezorInboundRequest fromProtobufMsg(protobuf.GeneratedMessage incomingMsg) {
+    switch (incomingMsg) {
+      case Initialize initialize:
+        return TrezorInitRequest.fromProtobufMsg(initialize);
+      case GetFeatures _:
+        return TrezorPropertiesRequest();
+      case GetAddress _:
+        return TrezorDeviceAddressRequest();
+      case GetPublicKey getPublicKey:
+        return TrezorPublicKeyRequest.fromProtobufMsg(getPublicKey);
+      case EthereumSignMessage ethereumSignMessage:
+        return TrezorEthMsgSignatureRequest.fromProtobufMsg(ethereumSignMessage);
+      case EthereumSignTxEIP1559 ethereumSignTxEIP1559:
+        return TrezorEIP1559SignatureRequest.fromProtobufMsg(ethereumSignTxEIP1559);
+      default:
+        throw ArgumentError();
+    }
+  }
+}

--- a/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/automated/a_trezor_automated_request.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/automated/a_trezor_automated_request.dart
@@ -1,0 +1,9 @@
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/a_trezor_inbound_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/a_trezor_outbound_response.dart';
+
+abstract class ATrezorAutomatedRequest extends ATrezorInboundRequest {
+  ATrezorOutboundResponse getResponse();
+
+  @override
+  List<Object?> get props => <Object>[];
+}

--- a/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/automated/trezor_device_address_request.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/automated/trezor_device_address_request.dart
@@ -1,0 +1,10 @@
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/automated/a_trezor_automated_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/a_trezor_outbound_response.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/trezor_device_address_response.dart';
+
+class TrezorDeviceAddressRequest extends ATrezorAutomatedRequest {
+  @override
+  ATrezorOutboundResponse getResponse() {
+    return TrezorDeviceAddressResponse.defaultResponse();
+  }
+}

--- a/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/automated/trezor_init_request.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/automated/trezor_init_request.dart
@@ -1,0 +1,26 @@
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-management.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/automated/a_trezor_automated_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/a_trezor_outbound_response.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/trezor_properties_response.dart';
+
+class TrezorInitRequest extends ATrezorAutomatedRequest {
+  final List<int> sessionId;
+
+  TrezorInitRequest({
+    required this.sessionId,
+  });
+
+  factory TrezorInitRequest.fromProtobufMsg(Initialize initialize) {
+    return TrezorInitRequest(
+      sessionId: initialize.sessionId,
+    );
+  }
+
+  @override
+  ATrezorOutboundResponse getResponse() {
+    return TrezorPropertiesResponse.defaultResponse(sessionId: sessionId);
+  }
+
+  @override
+  List<Object?> get props => <Object>[sessionId];
+}

--- a/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/automated/trezor_properties_request.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/automated/trezor_properties_request.dart
@@ -1,0 +1,10 @@
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/automated/a_trezor_automated_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/a_trezor_outbound_response.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/trezor_properties_response.dart';
+
+class TrezorPropertiesRequest extends ATrezorAutomatedRequest {
+  @override
+  ATrezorOutboundResponse getResponse() {
+    return TrezorPropertiesResponse.defaultResponse();
+  }
+}

--- a/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/interactive/a_trezor_interactive_request.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/interactive/a_trezor_interactive_request.dart
@@ -1,0 +1,9 @@
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/a_trezor_inbound_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/a_trezor_awaited_response.dart';
+
+abstract class ATrezorInteractiveRequest extends ATrezorInboundRequest {
+  ATrezorAwaitedResponse getResponseFromUser();
+
+  @override
+  List<Object?> get props => <Object>[];
+}

--- a/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/interactive/trezor_eip1559_signature_request.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/interactive/trezor_eip1559_signature_request.dart
@@ -1,0 +1,108 @@
+import 'dart:typed_data';
+
+import 'package:cryptography_utils/cryptography_utils.dart' as cryptography_utils;
+import 'package:mirage/shared/utils/app_logger.dart';
+import 'package:mirage/shared/utils/bytes_utils.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum-definitions.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/interactive/a_trezor_interactive_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/a_trezor_awaited_response.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/trezor_eip1559_signature_response.dart';
+
+class TrezorEIP1559SignatureRequest extends ATrezorInteractiveRequest {
+  final bool waitingAgreedBool;
+  final cryptography_utils.EthereumEIP1559Transaction ethereumEIP1559Transaction;
+  final int dataLength;
+  final List<int> derivationPath;
+  final String? token;
+
+  TrezorEIP1559SignatureRequest({
+    required this.waitingAgreedBool,
+    required this.ethereumEIP1559Transaction,
+    required this.dataLength,
+    required this.derivationPath,
+    this.token,
+  });
+
+  factory TrezorEIP1559SignatureRequest.fromProtobufMsg(EthereumSignTxEIP1559 ethereumSignTxEIP1559) {
+    cryptography_utils.EthereumEIP1559Transaction ethereumEIP1559Transaction = cryptography_utils.EthereumEIP1559Transaction(
+      chainId: BigInt.parse(ethereumSignTxEIP1559.chainId.toString()),
+      nonce: BytesUtils.convertBytesToBigInt(ethereumSignTxEIP1559.nonce),
+      maxPriorityFeePerGas: BytesUtils.convertBytesToBigInt(ethereumSignTxEIP1559.maxPriorityFee),
+      maxFeePerGas: BytesUtils.convertBytesToBigInt(ethereumSignTxEIP1559.maxGasFee),
+      gasLimit: BytesUtils.convertBytesToBigInt(ethereumSignTxEIP1559.gasLimit),
+      to: ethereumSignTxEIP1559.to,
+      value: BytesUtils.convertBytesToBigInt(ethereumSignTxEIP1559.value),
+      data: Uint8List.fromList(ethereumSignTxEIP1559.dataInitialChunk),
+      accessList: ethereumSignTxEIP1559.accessList.map((EthereumSignTxEIP1559_EthereumAccessList accessListBytesItem) {
+        return cryptography_utils.AccessListBytesItem(
+          BytesUtils.convertHexToBytes(accessListBytesItem.address),
+          accessListBytesItem.storageKeys.map((List<int> storageKey) {
+            return Uint8List.fromList(storageKey);
+          }).toList(),
+        );
+      }).toList(),
+    );
+    return TrezorEIP1559SignatureRequest(
+      waitingAgreedBool: false,
+      ethereumEIP1559Transaction: ethereumEIP1559Transaction,
+      dataLength: ethereumSignTxEIP1559.dataLength,
+      derivationPath: ethereumSignTxEIP1559.addressN,
+      token: _getToken(ethereumSignTxEIP1559) ?? ethereumEIP1559Transaction.getAmount(cryptography_utils.TokenDenominationType.network).denomination.toString(),
+    );
+  }
+
+  @override
+  ATrezorAwaitedResponse getResponseFromUser() {
+    _logRequestData();
+    return TrezorEIP1559SignatureResponse.getDataFromUser();
+  }
+
+  void _logRequestData() {
+    String amount = ethereumEIP1559Transaction.getAmount(cryptography_utils.TokenDenominationType.network).amount.toString();
+    AppLogger().log(message: '*** Signing EIP1559 Transaction ***');
+    AppLogger().log(message: '*** Token: $token ***');
+    AppLogger().log(message: '*** Sending $amount to 0x${ethereumEIP1559Transaction.to} ***');
+    AppLogger().log(message: 'derivation path: ${derivationPath}');
+    AppLogger().log(message: 'sign data: ${ethereumEIP1559Transaction.serialize()}');
+    AppLogger().log(message: 'Enter the values');
+  }
+
+  static String? _getToken(EthereumSignTxEIP1559 ethereumSignTxEIP1559) {
+    String? token;
+
+    List<int> encodedNetwork = ethereumSignTxEIP1559.definitions.encodedNetwork;
+    List<int> encodedToken = ethereumSignTxEIP1559.definitions.encodedToken;
+
+    if (encodedNetwork.isNotEmpty) {
+      token = _getNetworkInfo(encodedNetwork);
+    }
+
+    if (encodedToken.isNotEmpty) {
+      token = _getTokenInfo(encodedToken);
+    }
+
+    return token;
+  }
+
+  static String _getNetworkInfo(List<int> encodedNetwork) {
+    Uint8List protobufPayloadLengthBytes = Uint8List.fromList(encodedNetwork.sublist(10, 12));
+    int protobufPayloadLength = BytesUtils.convertBytesToInt(protobufPayloadLengthBytes, endian: Endian.little);
+
+    List<int> protobufPayload = encodedNetwork.sublist(12, 12 + protobufPayloadLength);
+    EthereumNetworkInfo ethereumNetworkInfo = EthereumNetworkInfo.fromBuffer(protobufPayload);
+    return '${ethereumNetworkInfo.name} ${ethereumNetworkInfo.symbol}';
+  }
+
+  static String _getTokenInfo(List<int> encodedToken) {
+    Uint8List protobufPayloadLengthBytes = Uint8List.fromList(encodedToken.sublist(10, 12));
+    int protobufPayloadLength = BytesUtils.convertBytesToInt(protobufPayloadLengthBytes, endian: Endian.little);
+
+    List<int> protobufPayload = encodedToken.sublist(12, 12 + protobufPayloadLength);
+    EthereumTokenInfo ethereumTokenInfo = EthereumTokenInfo.fromBuffer(protobufPayload);
+    return '${ethereumTokenInfo.name} ${ethereumTokenInfo.symbol}';
+  }
+
+  @override
+  List<Object?> get props => <Object?>[ethereumEIP1559Transaction, dataLength, derivationPath, token];
+}

--- a/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/interactive/trezor_eth_msg_signature_request.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/interactive/trezor_eth_msg_signature_request.dart
@@ -1,0 +1,41 @@
+import 'package:mirage/shared/utils/app_logger.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/interactive/a_trezor_interactive_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/a_trezor_awaited_response.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/trezor_eth_msg_signature_response.dart';
+
+class TrezorEthMsgSignatureRequest extends ATrezorInteractiveRequest {
+  final bool waitingAgreedBool;
+  final List<int> derivationPath;
+  final List<int> message;
+
+  TrezorEthMsgSignatureRequest({
+    required this.waitingAgreedBool,
+    required this.derivationPath,
+    required this.message,
+  });
+
+  factory TrezorEthMsgSignatureRequest.fromProtobufMsg(EthereumSignMessage ethereumSignMessage) {
+    return TrezorEthMsgSignatureRequest(
+      waitingAgreedBool: false,
+      derivationPath: ethereumSignMessage.addressN,
+      message: ethereumSignMessage.message,
+    );
+  }
+
+  @override
+  ATrezorAwaitedResponse getResponseFromUser() {
+    _logRequestData();
+    return TrezorEthMsgSignatureResponse.getDataFromUser();
+  }
+
+  void _logRequestData() {
+    AppLogger().log(message: '*** Signing Ethereum Message ***');
+    AppLogger().log(message: 'derivation path: ${derivationPath}');
+    AppLogger().log(message: 'message: $message');
+    AppLogger().log(message: 'Enter the values');
+  }
+
+  @override
+  List<Object?> get props => <Object>[derivationPath, message];
+}

--- a/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/interactive/trezor_public_key_request.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_inbound_requests/interactive/trezor_public_key_request.dart
@@ -1,0 +1,37 @@
+import 'package:mirage/shared/utils/app_logger.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-bitcoin.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_inbound_requests/interactive/a_trezor_interactive_request.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/a_trezor_awaited_response.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/trezor_public_key_response.dart';
+
+class TrezorPublicKeyRequest extends ATrezorInteractiveRequest {
+  final bool waitingAgreedBool;
+  final List<int> derivationPath;
+
+  TrezorPublicKeyRequest({
+    required this.waitingAgreedBool,
+    required this.derivationPath,
+  });
+
+  factory TrezorPublicKeyRequest.fromProtobufMsg(GetPublicKey getPublicKey) {
+    return TrezorPublicKeyRequest(
+      waitingAgreedBool: false,
+      derivationPath: getPublicKey.addressN,
+    );
+  }
+
+  @override
+  ATrezorAwaitedResponse getResponseFromUser() {
+    _logRequestData();
+    return TrezorPublicKeyResponse.getDataFromUser();
+  }
+
+  void _logRequestData() {
+    AppLogger().log(message: '*** Exporting Public Key ***');
+    AppLogger().log(message: 'derivation path: ${derivationPath}');
+    AppLogger().log(message: 'Enter the values');
+  }
+
+  @override
+  List<Object?> get props => <Object>[derivationPath];
+}

--- a/lib/trezor_protocol/shared/protobuf/trezor_outbound_responses/a_trezor_outbound_response.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_outbound_responses/a_trezor_outbound_response.dart
@@ -1,0 +1,6 @@
+import 'package:equatable/equatable.dart';
+import 'package:protobuf/protobuf.dart' as protobuf;
+
+abstract class ATrezorOutboundResponse extends Equatable {
+  protobuf.GeneratedMessage toProtobufMsg();
+}

--- a/lib/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/a_trezor_awaited_response.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/a_trezor_awaited_response.dart
@@ -1,0 +1,6 @@
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/a_trezor_outbound_response.dart';
+
+abstract class ATrezorAwaitedResponse extends ATrezorOutboundResponse {
+  @override
+  List<Object?> get props => <Object>[];
+}

--- a/lib/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/trezor_eip1559_signature_response.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/trezor_eip1559_signature_response.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:mirage/shared/utils/bytes_utils.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/a_trezor_awaited_response.dart';
+import 'package:protobuf/protobuf.dart';
+
+class TrezorEIP1559SignatureResponse extends ATrezorAwaitedResponse {
+  final int signatureV;
+  final List<int> signatureR;
+  final List<int> signatureS;
+
+  TrezorEIP1559SignatureResponse({
+    required this.signatureV,
+    required this.signatureR,
+    required this.signatureS,
+  });
+
+  factory TrezorEIP1559SignatureResponse.getDataFromUser() {
+    stdout.write('Enter signatureV: ');
+    String signatureVLine = stdin.readLineSync()!;
+
+    stdout.write('Enter signatureR: ');
+    String signatureRLine = stdin.readLineSync()!;
+
+    stdout.write('Enter signatureS: ');
+    String signatureSLine = stdin.readLineSync()!;
+
+    return TrezorEIP1559SignatureResponse(
+      signatureV: int.parse(signatureVLine),
+      signatureR: BytesUtils.parseStringToList(signatureRLine),
+      signatureS: BytesUtils.parseStringToList(signatureSLine),
+    );
+  }
+
+  @override
+  GeneratedMessage toProtobufMsg() {
+    return EthereumTxRequest(
+      signatureV: signatureV,
+      signatureR: signatureR,
+      signatureS: signatureS,
+    );
+  }
+
+  @override
+  List<Object?> get props => <Object>[signatureV, signatureR, signatureS];
+}

--- a/lib/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/trezor_eth_msg_signature_response.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/trezor_eth_msg_signature_response.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:mirage/shared/utils/bytes_utils.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-ethereum.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/a_trezor_awaited_response.dart';
+import 'package:protobuf/protobuf.dart';
+
+class TrezorEthMsgSignatureResponse extends ATrezorAwaitedResponse {
+  final String address;
+  final List<int> signature;
+
+  TrezorEthMsgSignatureResponse({
+    required this.address,
+    required this.signature,
+  });
+
+  factory TrezorEthMsgSignatureResponse.getDataFromUser() {
+    stdout.write('Enter signature: ');
+    String signatureLine = stdin.readLineSync()!;
+
+    stdout.write('Enter address: ');
+    String addressLine = stdin.readLineSync()!;
+
+    return TrezorEthMsgSignatureResponse(
+      address: addressLine,
+      signature: BytesUtils.parseStringToList(signatureLine),
+    );
+  }
+
+  @override
+  GeneratedMessage toProtobufMsg() {
+    return EthereumMessageSignature(
+      address: address,
+      signature: signature,
+    );
+  }
+
+  @override
+  List<Object?> get props => <Object>[address, signature];
+}

--- a/lib/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/trezor_public_key_response.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/trezor_public_key_response.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+import 'package:mirage/shared/utils/bytes_utils.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-bitcoin.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-common.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/awaited/a_trezor_awaited_response.dart';
+import 'package:protobuf/protobuf.dart';
+
+class TrezorPublicKeyResponse extends ATrezorAwaitedResponse {
+  final int depth;
+  final int fingerprint;
+  final List<int> chainCode;
+  final List<int> publicKey;
+  final String xpub;
+
+  TrezorPublicKeyResponse({
+    required this.depth,
+    required this.fingerprint,
+    required this.chainCode,
+    required this.publicKey,
+    required this.xpub,
+  });
+
+  factory TrezorPublicKeyResponse.getDataFromUser() {
+    stdout.write('Enter depth: ');
+    String depthLine = stdin.readLineSync()!;
+
+    stdout.write('Enter fingerprint: ');
+    String fingerprintLine = stdin.readLineSync()!;
+
+    stdout.write('Enter chainCode: ');
+    String chainCodeLine = stdin.readLineSync()!;
+
+    stdout.write('Enter publicKey: ');
+    String publicKeyLine = stdin.readLineSync()!;
+
+    stdout.write('Enter xpub: ');
+    String xpubLine = stdin.readLineSync()!;
+
+    return TrezorPublicKeyResponse(
+      depth: int.parse(depthLine),
+      fingerprint: int.parse(fingerprintLine),
+      chainCode: BytesUtils.parseStringToList(chainCodeLine),
+      publicKey: BytesUtils.parseStringToList(publicKeyLine),
+      xpub: xpubLine,
+    );
+  }
+
+  @override
+  GeneratedMessage toProtobufMsg() {
+    return PublicKey(
+      node: HDNodeType(
+        depth: depth,
+        fingerprint: fingerprint,
+        childNum: 0,
+        chainCode: chainCode,
+        publicKey: publicKey,
+      ),
+      xpub: xpub,
+    );
+  }
+
+  @override
+  List<Object?> get props => <Object>[depth, fingerprint, chainCode, publicKey, xpub];
+}

--- a/lib/trezor_protocol/shared/protobuf/trezor_outbound_responses/trezor_device_address_response.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_outbound_responses/trezor_device_address_response.dart
@@ -1,0 +1,21 @@
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-bitcoin.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/a_trezor_outbound_response.dart';
+import 'package:protobuf/protobuf.dart';
+
+class TrezorDeviceAddressResponse extends ATrezorOutboundResponse {
+  final String address;
+
+  TrezorDeviceAddressResponse({required this.address});
+
+  factory TrezorDeviceAddressResponse.defaultResponse() {
+    return TrezorDeviceAddressResponse(address: '');
+  }
+
+  @override
+  GeneratedMessage toProtobufMsg() {
+    return Address(address: address);
+  }
+
+  @override
+  List<Object?> get props => <Object>[address];
+}

--- a/lib/trezor_protocol/shared/protobuf/trezor_outbound_responses/trezor_properties_response.dart
+++ b/lib/trezor_protocol/shared/protobuf/trezor_outbound_responses/trezor_properties_response.dart
@@ -1,0 +1,233 @@
+import 'package:mirage/shared/utils/bytes_utils.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/messages_compiled/messages-management.pb.dart';
+import 'package:mirage/trezor_protocol/shared/protobuf/trezor_outbound_responses/a_trezor_outbound_response.dart';
+import 'package:protobuf/protobuf.dart';
+
+class TrezorPropertiesResponse extends ATrezorOutboundResponse {
+  final bool busy;
+  final bool experimentalFeatures;
+  final bool hidePassphraseFromHost;
+  final bool initialized;
+  final bool languageVersionMatches;
+  final bool needsBackup;
+  final bool noBackup;
+  final bool passphraseAlwaysOnDevice;
+  final bool passphraseProtection;
+  final bool pinProtection;
+  final bool recoveryMode;
+  final bool sdCardPresent;
+  final bool sdProtection;
+  final bool unfinishedBackup;
+  final bool unlocked;
+  final bool wipeCodeProtection;
+  final int autoLockDelayMs;
+  final int displayRotation;
+  final int flags;
+  final int homescreenHeight;
+  final int homescreenWidth;
+  final int majorVersion;
+  final int minorVersion;
+  final int patchVersion;
+  final String deviceId;
+  final String fwVendor;
+  final String internalModel;
+  final String label;
+  final String language;
+  final String model;
+  final String vendor;
+  final BackupType backupType;
+  final HomescreenFormat homescreenFormat;
+  final Iterable<Features_Capability> capabilities;
+  final List<int> revision;
+  final SafetyCheckLevel safetyChecks;
+
+  final List<int>? sessionId;
+
+  TrezorPropertiesResponse({
+    required this.busy,
+    required this.experimentalFeatures,
+    required this.hidePassphraseFromHost,
+    required this.initialized,
+    required this.languageVersionMatches,
+    required this.needsBackup,
+    required this.noBackup,
+    required this.passphraseAlwaysOnDevice,
+    required this.passphraseProtection,
+    required this.pinProtection,
+    required this.recoveryMode,
+    required this.sdCardPresent,
+    required this.sdProtection,
+    required this.unfinishedBackup,
+    required this.unlocked,
+    required this.wipeCodeProtection,
+    required this.autoLockDelayMs,
+    required this.displayRotation,
+    required this.flags,
+    required this.homescreenHeight,
+    required this.homescreenWidth,
+    required this.majorVersion,
+    required this.minorVersion,
+    required this.patchVersion,
+    required this.deviceId,
+    required this.fwVendor,
+    required this.internalModel,
+    required this.label,
+    required this.language,
+    required this.model,
+    required this.vendor,
+    required this.backupType,
+    required this.homescreenFormat,
+    required this.capabilities,
+    required this.revision,
+    required this.safetyChecks,
+    this.sessionId,
+  });
+
+  factory TrezorPropertiesResponse.defaultResponse({List<int>? sessionId}) {
+    if (sessionId != null && sessionId.isEmpty) {
+      sessionId = BytesUtils.generateRandomBytes(32);
+    }
+    return TrezorPropertiesResponse(
+      busy: false,
+      experimentalFeatures: false,
+      hidePassphraseFromHost: false,
+      initialized: true,
+      languageVersionMatches: true,
+      needsBackup: false,
+      noBackup: false,
+      passphraseAlwaysOnDevice: false,
+      passphraseProtection: true,
+      pinProtection: true,
+      recoveryMode: false,
+      sdCardPresent: true,
+      sdProtection: false,
+      unfinishedBackup: false,
+      unlocked: true,
+      wipeCodeProtection: false,
+      autoLockDelayMs: 600000,
+      displayRotation: 0,
+      flags: 0,
+      homescreenHeight: 240,
+      homescreenWidth: 240,
+      majorVersion: 2,
+      minorVersion: 8,
+      patchVersion: 1,
+      deviceId: '355C817510C0EABF2F147145',
+      fwVendor: 'EMULATOR',
+      internalModel: 'T2T1',
+      label: 'My Trezor',
+      language: 'en-US',
+      model: 'T',
+      vendor: 'trezor.io',
+      backupType: BackupType.Bip39,
+      homescreenFormat: HomescreenFormat.Jpeg,
+      capabilities: const <Features_Capability>[
+        Features_Capability.Capability_Bitcoin,
+        Features_Capability.Capability_Bitcoin_like,
+        Features_Capability.Capability_Binance,
+        Features_Capability.Capability_Cardano,
+        Features_Capability.Capability_Crypto,
+        Features_Capability.Capability_Ethereum,
+        Features_Capability.Capability_Monero,
+        Features_Capability.Capability_Ripple,
+        Features_Capability.Capability_Stellar,
+        Features_Capability.Capability_Tezos,
+        Features_Capability.Capability_U2F,
+        Features_Capability.Capability_Shamir,
+        Features_Capability.Capability_ShamirGroups,
+        Features_Capability.Capability_PassphraseEntry,
+        Features_Capability.Capability_Solana,
+        Features_Capability.Capability_Translations,
+        Features_Capability.Capability_NEM,
+        Features_Capability.Capability_EOS,
+      ],
+      revision: const <int>[199, 131, 44, 57, 171, 60, 42, 156, 70, 84, 76, 87, 209, 168, 152, 5, 131, 96, 159, 71],
+      safetyChecks: SafetyCheckLevel.Strict,
+      sessionId: sessionId,
+    );
+  }
+
+  @override
+  GeneratedMessage toProtobufMsg() {
+    return Features(
+      busy: busy,
+      experimentalFeatures: experimentalFeatures,
+      hidePassphraseFromHost: hidePassphraseFromHost,
+      initialized: initialized,
+      languageVersionMatches: languageVersionMatches,
+      needsBackup: needsBackup,
+      noBackup: noBackup,
+      passphraseAlwaysOnDevice: passphraseAlwaysOnDevice,
+      passphraseProtection: passphraseProtection,
+      pinProtection: pinProtection,
+      recoveryMode: recoveryMode,
+      sdCardPresent: sdCardPresent,
+      sdProtection: sdProtection,
+      unfinishedBackup: unfinishedBackup,
+      unlocked: unlocked,
+      wipeCodeProtection: wipeCodeProtection,
+      autoLockDelayMs: autoLockDelayMs,
+      displayRotation: displayRotation,
+      flags: flags,
+      homescreenHeight: homescreenHeight,
+      homescreenWidth: homescreenWidth,
+      majorVersion: majorVersion,
+      minorVersion: minorVersion,
+      patchVersion: patchVersion,
+      deviceId: deviceId,
+      fwVendor: fwVendor,
+      internalModel: internalModel,
+      label: label,
+      language: language,
+      model: model,
+      vendor: vendor,
+      backupType: backupType,
+      homescreenFormat: homescreenFormat,
+      capabilities: capabilities,
+      revision: revision,
+      safetyChecks: safetyChecks,
+      sessionId: sessionId,
+    );
+  }
+
+  @override
+  List<Object?> get props => <Object?>[
+        busy,
+        experimentalFeatures,
+        hidePassphraseFromHost,
+        initialized,
+        languageVersionMatches,
+        needsBackup,
+        noBackup,
+        passphraseAlwaysOnDevice,
+        passphraseProtection,
+        pinProtection,
+        recoveryMode,
+        sdCardPresent,
+        sdProtection,
+        unfinishedBackup,
+        unlocked,
+        wipeCodeProtection,
+        autoLockDelayMs,
+        displayRotation,
+        flags,
+        homescreenHeight,
+        homescreenWidth,
+        majorVersion,
+        minorVersion,
+        patchVersion,
+        deviceId,
+        fwVendor,
+        internalModel,
+        label,
+        language,
+        model,
+        vendor,
+        backupType,
+        homescreenFormat,
+        capabilities,
+        revision,
+        safetyChecks,
+        sessionId
+      ];
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
+  bech32:
+    dependency: transitive
+    description:
+      name: bech32
+      sha256: "156cbace936f7720c79a79d16a03efad343b1ef17106716e04b8b8e39f99f7f7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   bloc:
     dependency: transitive
     description:
@@ -161,6 +169,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
+  compute:
+    dependency: transitive
+    description:
+      name: compute
+      sha256: b70190d59352a267a9765a77b97d0f619874c84d30c5193ae71050ee22ab2ef7
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   convert:
     dependency: transitive
     description:
@@ -185,6 +201,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  cryptography_utils:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: HEAD
+      resolved-ref: acf04c5451fcecbc376ecec627ac599f0ed8655e
+      url: "https://github.com/snggle/cryptography_utils.git"
+    source: git
+    version: "0.0.13"
   dart_style:
     dependency: transitive
     description:
@@ -193,6 +218,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  decimal:
+    dependency: transitive
+    description:
+      name: decimal
+      sha256: "24a261d5d5c87e86c7651c417a5dbdf8bcd7080dd592533910e8d0505a279f21"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
   diff_match_patch:
     dependency: transitive
     description:
@@ -411,6 +444,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "43ac87de6e10afabc85c445745a7b799e04de84cebaa4fd7bf55a5e1e9604d29"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.7.4"
   pool:
     dependency: transitive
     description:
@@ -451,6 +492,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
+  rational:
+    dependency: transitive
+    description:
+      name: rational
+      sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mirage
 description: Desktop application connecting SNGGLE with PC
 publish_to: 'none'
-version: 0.0.3
+version: 0.0.4
 
 environment:
   sdk: ">=3.1.5"
@@ -15,6 +15,11 @@ dependencies:
   # https://pub.dev/packages/flutter_bloc
   flutter_bloc: ^8.1.3
   bloc_test: ^9.1.4
+
+  # Dart package containing utility methods for common cryptographic and blockchain-specific operations.
+  cryptography_utils:
+    git:
+      url: https://github.com/snggle/cryptography_utils.git
 
   # A Dart package that helps to implement value based equality without needing to explicitly override == and hashCode.
   # https://pub.dev/packages/equatable

--- a/test/unit/shared/utils/bytes_utils_test.dart
+++ b/test/unit/shared/utils/bytes_utils_test.dart
@@ -4,18 +4,18 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mirage/shared/utils/bytes_utils.dart';
 
 void main() {
-  group('Tests of BytesUtils.convertHexToInt()', () {
-    test('Should [return int] calculated from HEX', () {
+  group('Tests of BytesUtils.convertBytesToBigInt()', () {
+    test('Should [return BigInt] calculated from List<int>', () {
       // Arrange
-      String actualHexInput = '1a2b3c';
+      List<int> actualInputList = <int>[5, 10, 15];
 
       // Act
-      int actualInt = BytesUtils.convertHexToInt(actualHexInput);
+      BigInt actualBigInt = BytesUtils.convertBytesToBigInt(actualInputList);
 
       // Assert
-      int expectedInt = 1715004;
+      BigInt expectedBigInt = BigInt.from(330255);
 
-      expect(actualInt, expectedInt);
+      expect(actualBigInt, expectedBigInt);
     });
   });
 
@@ -34,16 +34,16 @@ void main() {
     });
   });
 
-  group('Tests of BytesUtils.convertBytesToInt()', () {
-    test('Should [return int] calculated from BYTES', () {
+  group('Tests of BytesUtils.convertHexToInt()', () {
+    test('Should [return int] calculated from HEX', () {
       // Arrange
-      Uint8List actualBytesInput = Uint8List.fromList(<int>[215, 21, 5, 90]);
+      String actualHexInput = '1a2b3c';
 
       // Act
-      int actualInt = BytesUtils.convertBytesToInt(actualBytesInput);
+      int actualInt = BytesUtils.convertHexToInt(actualHexInput);
 
       // Assert
-      int expectedInt = 3608479066;
+      int expectedInt = 1715004;
 
       expect(actualInt, expectedInt);
     });
@@ -61,6 +61,34 @@ void main() {
       Uint8List expectedBytes = Uint8List.fromList(<int>[77, 94, 111]);
 
       expect(actualBytes, expectedBytes);
+    });
+  });
+
+  group('Tests of BytesUtils.convertBytesToInt()', () {
+    test('Should [return int] calculated from Big Endian BYTES', () {
+      // Arrange
+      Uint8List actualBytesInput = Uint8List.fromList(<int>[0, 19]);
+
+      // Act
+      int actualInt = BytesUtils.convertBytesToInt(actualBytesInput, endian: Endian.big);
+
+      // Assert
+      int expectedInt = 19;
+
+      expect(actualInt, expectedInt);
+    });
+
+    test('Should [return int] calculated from Little Endian BYTES', () {
+      // Arrange
+      Uint8List actualBytesInput = Uint8List.fromList(<int>[0, 19]);
+
+      // Act
+      int actualInt = BytesUtils.convertBytesToInt(actualBytesInput, endian: Endian.little);
+
+      // Assert
+      int expectedInt = 4864;
+
+      expect(actualInt, expectedInt);
     });
   });
 
@@ -94,22 +122,68 @@ void main() {
     });
   });
 
-  group('Tests of BytesUtils.mergeUint8Lists()', () {
-    test('Should [return merged Uint8List] from multiple Uint8Lists', () {
+  group('Tests of BytesUtils.generateRandomBytes()', () {
+    test('Should [return 5 random bytes] given (count = 5)', () {
       // Arrange
-      Uint8List actualUint8listA = Uint8List.fromList(<int>[1, 2, 3, 4]);
-      Uint8List actualUint8listB = Uint8List.fromList(<int>[5, 6, 7, 8]);
-      Uint8List actualUint8listC = Uint8List.fromList(<int>[9, 10, 11, 12]);
-
-      List<Uint8List> actualUint8listsToMerge = <Uint8List>[actualUint8listA, actualUint8listB, actualUint8listC];
+      int actualCount = 5;
 
       // Act
-      Uint8List actualMergedUint8List = BytesUtils.mergeUint8Lists(actualUint8listsToMerge);
+      List<int> actualRandomBytes = BytesUtils.generateRandomBytes(actualCount);
+      int actualLength = actualRandomBytes.length;
 
       // Assert
-      Uint8List expectedMergedUint8List = Uint8List.fromList(<int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      int expectedLength = 5;
 
-      expect(actualMergedUint8List, expectedMergedUint8List);
+      expect(actualLength, expectedLength);
+    });
+
+    test('Should [return 32 random bytes] given (count = 32)', () {
+      // Arrange
+      int actualCount = 32;
+
+      // Act
+      List<int> actualRandomBytes = BytesUtils.generateRandomBytes(actualCount);
+      int actualLength = actualRandomBytes.length;
+
+      // Assert
+      int expectedLength = 32;
+
+      expect(actualLength, expectedLength);
+    });
+  });
+
+  group('Tests of BytesUtils.mergeBytes()', () {
+    test('Should [return merged Uint8List] from multiple Uint8Lists', () {
+      // Arrange
+      Uint8List actualBytesA = Uint8List.fromList(<int>[1, 2, 3, 4]);
+      Uint8List actualBytesB = Uint8List.fromList(<int>[5, 6, 7, 8]);
+      Uint8List actualBytesC = Uint8List.fromList(<int>[9, 10, 11, 12]);
+
+      List<Uint8List> actualBytesToMerge = <Uint8List>[actualBytesA, actualBytesB, actualBytesC];
+
+      // Act
+      Uint8List actualMergedBytes = BytesUtils.mergeBytes(actualBytesToMerge);
+
+      // Assert
+      Uint8List expectedMergedBytes = Uint8List.fromList(<int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+
+      expect(actualMergedBytes, expectedMergedBytes);
+    });
+  });
+
+  // TODO(Marcin): delete this method after prompt data input is replaced with Audio Protocol implementation
+  group('Tests of BytesUtils.parseStringToList()', () {
+    test('Should [return List<int>] given String input', () {
+      // Arrange
+      String actualString = '[2, 8, 500, 400, 17]';
+
+      // Act
+      List<int> actualList = BytesUtils.parseStringToList(actualString);
+
+      // Assert
+      List<int> expectedList = <int>[2, 8, 500, 400, 17];
+
+      expect(actualList, expectedList);
     });
   });
 }

--- a/test/unit/trezor_protocol/controllers/trezor_communication_controller_test.dart
+++ b/test/unit/trezor_protocol/controllers/trezor_communication_controller_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mirage/config/locator.dart';
+import 'package:mirage/trezor_protocol/controllers/trezor_communication_controller.dart';
+
+void main() {
+  initLocator();
+  TrezorCommunicationController actualTrezorCommunicationController = globalLocator<TrezorCommunicationController>();
+
+  group('Tests of ProtobufController.handleBuffer()', () {
+    test('Should [return Features buffer] with [FILLED sessionId], if input starts with 0000 and [sessionId EXISTS] (Initialize -> Features)', () async {
+      // Arrange
+      // Buffer for [Initialize]
+      String actualInputBuffer = '0000000000070a050102030405';
+
+      // Act
+      String actualOutputBuffer = await actualTrezorCommunicationController.handleBuffer(actualInputBuffer);
+
+      // Assert
+      // Buffer for [Features]
+      String expectedOutputBuffer =
+          '0011000000f00a097472657a6f722e696f1002180820013218333535433831373531304330454142463246313437313435380140014a05656e2d555352094d79205472657a6f7260016a14c7832c39ab3c2a9c46544c57d1a8980583609f47800101980100a00100aa010154ca0108454d554c41544f52d80100e00100e80100f00101f00102f00103f00104f00105f00107f00109f0010bf0010cf0010df0010ef0010ff00110f00111f00112f00113f0010af00106f801008002018802009002009a02050102030405a00200a80200b002c0cf24b80200c00200c80200d00202d80200e2020454325431f802f0018003f001900301';
+
+      expect(actualOutputBuffer, expectedOutputBuffer);
+    });
+
+    test('Should [return Features buffer] with [RANDOM sessionId] if input starts with 0000 [sessionId NOT EXISTS] (Initialize -> Features)', () async {
+      // Arrange
+      // Buffer for [Initialize]
+      String actualInputBuffer = '000000000000';
+
+      // Act
+      // The random sessionId affects the middle part of the buffer, therefore the second part of the buffer is expected not to be equal.
+      String actualOutputBuffer = await actualTrezorCommunicationController.handleBuffer(actualInputBuffer);
+      String actualOutputBufferPart1 = actualOutputBuffer.substring(0, 394); // expected equal
+      String actualOutputBufferPart2 = actualOutputBuffer.substring(395, 457); // expected not equal (random sessionId)
+      String actualOutputBufferPart3 = actualOutputBuffer.substring(458, actualOutputBuffer.length); // expected equal
+
+      // Assert
+      // Buffer for [Features]
+      String expectedOutputBuffer =
+          '00110000010b0a097472657a6f722e696f1002180820013218333535433831373531304330454142463246313437313435380140014a05656e2d555352094d79205472657a6f7260016a14c7832c39ab3c2a9c46544c57d1a8980583609f47800101980100a00100aa010154ca0108454d554c41544f52d80100e00100e80100f00101f00102f00103f00104f00105f00107f00109f0010bf0010cf0010df0010ef0010ff00110f00111f00112f00113f0010af00106f801008002018802009002009a02203b5803f0b2a5a4dd6de7f846a8e087ba4e41ceeb01f3f6ccef30db4369638084a00200a80200b002c0cf24b80200c00200c80200d00202d80200e2020454325431f802f0018003f001900301';
+      String expectedBufferPart1 = expectedOutputBuffer.substring(0, 394);
+      String expectedBufferPart2 = expectedOutputBuffer.substring(395, 457);
+      String expectedBufferPart3 = expectedOutputBuffer.substring(458, expectedOutputBuffer.length);
+
+      expect(actualOutputBufferPart1, expectedBufferPart1);
+      expect(actualOutputBufferPart2, isNot(equals(expectedBufferPart2)));
+      expect(actualOutputBufferPart3, expectedBufferPart3);
+    });
+
+    test('Should [return Address buffer] if input starts with 001d (GetAddress -> Address)', () async {
+      // Arrange
+      String actualInputBuffer = '001d00000000';
+
+      // Act
+      String actualOutputBuffer = await actualTrezorCommunicationController.handleBuffer(actualInputBuffer);
+
+      // Assert
+      String expectedOutputBuffer = '001e000000020a00';
+
+      expect(actualOutputBuffer, expectedOutputBuffer);
+    });
+
+    test('Should [return Features buffer] with [EMPTY sessionId] if input starts with 0037 (GetFeatures -> Features)', () async {
+      // Arrange
+      // Buffer for [GetFeatures]
+      String actualInputBuffer = '003700000000';
+
+      // Act
+      String actualOutputBuffer = await actualTrezorCommunicationController.handleBuffer(actualInputBuffer);
+
+      // Assert
+      // Buffer for [Features]
+      String expectedOutputBuffer =
+          '0011000000e80a097472657a6f722e696f1002180820013218333535433831373531304330454142463246313437313435380140014a05656e2d555352094d79205472657a6f7260016a14c7832c39ab3c2a9c46544c57d1a8980583609f47800101980100a00100aa010154ca0108454d554c41544f52d80100e00100e80100f00101f00102f00103f00104f00105f00107f00109f0010bf0010cf0010df0010ef0010ff00110f00111f00112f00113f0010af00106f80100800201880200900200a00200a80200b002c0cf24b80200c00200c80200d00202d80200e2020454325431f802f0018003f001900301';
+
+      expect(actualOutputBuffer, expectedOutputBuffer);
+    });
+  });
+}

--- a/test/unit/trezor_protocol/shared/protobuf/protobuf_msg_mapper_test.dart
+++ b/test/unit/trezor_protocol/shared/protobuf/protobuf_msg_mapper_test.dart
@@ -12,13 +12,13 @@ import 'package:protobuf/protobuf.dart' as protobuf;
 void main() {
   Uint8List actualMsgEmptyContents = Uint8List.fromList(<int>[]);
 
-  group('Tests of ProtobufMsgMapper.getMsgFromType() (for incoming messages)', () {
+  group('Tests of ProtobufMsgMapper.getRequestFromProtobufType() (for incoming messages)', () {
     test('Should [return Initialize] from given message type and contents', () {
       // Arrange
       MessageType actualMessageType = MessageType.MessageType_Initialize;
 
       // Act
-      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getMsgFromType(actualMessageType, actualMsgEmptyContents);
+      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getRequestFromProtobufType(actualMessageType, actualMsgEmptyContents);
 
       // Assert
       protobuf.GeneratedMessage expectedProtobufMsg = Initialize();
@@ -31,7 +31,7 @@ void main() {
       MessageType actualMessageType = MessageType.MessageType_GetPublicKey;
 
       // Act
-      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getMsgFromType(actualMessageType, actualMsgEmptyContents);
+      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getRequestFromProtobufType(actualMessageType, actualMsgEmptyContents);
 
       // Assert
       protobuf.GeneratedMessage expectedProtobufMsg = GetPublicKey();
@@ -44,7 +44,7 @@ void main() {
       MessageType actualMessageType = MessageType.MessageType_ButtonAck;
 
       // Act
-      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getMsgFromType(actualMessageType, actualMsgEmptyContents);
+      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getRequestFromProtobufType(actualMessageType, actualMsgEmptyContents);
 
       // Assert
       protobuf.GeneratedMessage expectedProtobufMsg = ButtonAck();
@@ -57,23 +57,10 @@ void main() {
       MessageType actualMessageType = MessageType.MessageType_GetAddress;
 
       // Act
-      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getMsgFromType(actualMessageType, actualMsgEmptyContents);
+      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getRequestFromProtobufType(actualMessageType, actualMsgEmptyContents);
 
       // Assert
       protobuf.GeneratedMessage expectedProtobufMsg = GetAddress();
-
-      expect(actualProtobufMsg, expectedProtobufMsg);
-    });
-
-    test('Should [return PassphraseAck] from given message type and contents', () {
-      // Arrange
-      MessageType actualMessageType = MessageType.MessageType_PassphraseAck;
-
-      // Act
-      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getMsgFromType(actualMessageType, actualMsgEmptyContents);
-
-      // Assert
-      protobuf.GeneratedMessage expectedProtobufMsg = PassphraseAck();
 
       expect(actualProtobufMsg, expectedProtobufMsg);
     });
@@ -83,7 +70,7 @@ void main() {
       MessageType actualMessageType = MessageType.MessageType_GetFeatures;
 
       // Act
-      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getMsgFromType(actualMessageType, actualMsgEmptyContents);
+      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getRequestFromProtobufType(actualMessageType, actualMsgEmptyContents);
 
       // Assert
       protobuf.GeneratedMessage expectedProtobufMsg = GetFeatures();
@@ -96,7 +83,7 @@ void main() {
       MessageType actualMessageType = MessageType.MessageType_EthereumSignTxEIP1559;
 
       // Act
-      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getMsgFromType(actualMessageType, actualMsgEmptyContents);
+      protobuf.GeneratedMessage actualProtobufMsg = ProtobufMsgMapper.getRequestFromProtobufType(actualMessageType, actualMsgEmptyContents);
 
       // Assert
       protobuf.GeneratedMessage expectedProtobufMsg = EthereumSignTxEIP1559();
@@ -105,7 +92,33 @@ void main() {
     });
   });
 
-  group('Tests of ProtobufMsgMapper.getMsgTypeNumber() (for outgoing messages)', () {
+  group('Tests of ProtobufMsgMapper.getMsgTypeNumber() (for all messages)', () {
+    test('Should [return 0] if the message is Initialize', () {
+      // Arrange
+      Initialize actualMessage = Initialize();
+
+      // Act
+      int actualMsgTypeNumber = ProtobufMsgMapper.getMsgTypeNumber(actualMessage);
+
+      // Assert
+      int expectedMsgTypeNumber = 0;
+
+      expect(actualMsgTypeNumber, expectedMsgTypeNumber);
+    });
+
+    test('Should [return 11] if the message is GetPublicKey', () {
+      // Arrange
+      GetPublicKey actualMessage = GetPublicKey();
+
+      // Act
+      int actualMsgTypeNumber = ProtobufMsgMapper.getMsgTypeNumber(actualMessage);
+
+      // Assert
+      int expectedMsgTypeNumber = 11;
+
+      expect(actualMsgTypeNumber, expectedMsgTypeNumber);
+    });
+
     test('Should [return 12] if the message is PublicKey', () {
       // Arrange
       PublicKey actualMessage = PublicKey();
@@ -145,7 +158,33 @@ void main() {
       expect(actualMsgTypeNumber, expectedMsgTypeNumber);
     });
 
-    test('Should [return 26] if the message is Address', () {
+    test('Should [return 27] if the message is ButtonAck', () {
+      // Arrange
+      ButtonAck actualMessage = ButtonAck();
+
+      // Act
+      int actualMsgTypeNumber = ProtobufMsgMapper.getMsgTypeNumber(actualMessage);
+
+      // Assert
+      int expectedMsgTypeNumber = 27;
+
+      expect(actualMsgTypeNumber, expectedMsgTypeNumber);
+    });
+
+    test('Should [return 29] if the message is GetAddress', () {
+      // Arrange
+      GetAddress actualMessage = GetAddress();
+
+      // Act
+      int actualMsgTypeNumber = ProtobufMsgMapper.getMsgTypeNumber(actualMessage);
+
+      // Assert
+      int expectedMsgTypeNumber = 29;
+
+      expect(actualMsgTypeNumber, expectedMsgTypeNumber);
+    });
+
+    test('Should [return 30] if the message is Address', () {
       // Arrange
       Address actualMessage = Address();
 
@@ -158,20 +197,20 @@ void main() {
       expect(actualMsgTypeNumber, expectedMsgTypeNumber);
     });
 
-    test('Should [return 26] if the message is PassphraseRequest', () {
+    test('Should [return 55] if the message is GetFeatures', () {
       // Arrange
-      PassphraseRequest actualMessage = PassphraseRequest();
+      GetFeatures actualMessage = GetFeatures();
 
       // Act
       int actualMsgTypeNumber = ProtobufMsgMapper.getMsgTypeNumber(actualMessage);
 
       // Assert
-      int expectedMsgTypeNumber = 41;
+      int expectedMsgTypeNumber = 55;
 
       expect(actualMsgTypeNumber, expectedMsgTypeNumber);
     });
 
-    test('Should [return 26] if the message is EthereumTxRequest', () {
+    test('Should [return 59] if the message is EthereumTxRequest', () {
       // Arrange
       EthereumTxRequest actualMessage = EthereumTxRequest();
 
@@ -182,6 +221,164 @@ void main() {
       int expectedMsgTypeNumber = 59;
 
       expect(actualMsgTypeNumber, expectedMsgTypeNumber);
+    });
+
+    test('Should [return 452] if the message is EthereumSignTxEIP1559', () {
+      // Arrange
+      EthereumSignTxEIP1559 actualMessage = EthereumSignTxEIP1559();
+
+      // Act
+      int actualMsgTypeNumber = ProtobufMsgMapper.getMsgTypeNumber(actualMessage);
+
+      // Assert
+      int expectedMsgTypeNumber = 452;
+
+      expect(actualMsgTypeNumber, expectedMsgTypeNumber);
+    });
+  });
+
+  group('Tests of ProtobufMsgMapper.getMsgType() (for outgoing messages)', () {
+    test('Should [MessageType.MessageType_Features] if the message is Initialize', () {
+      // Arrange
+      Initialize actualMessage = Initialize();
+
+      // Act
+      MessageType actualMsgType = ProtobufMsgMapper.getMsgType(actualMessage);
+
+      // Assert
+      MessageType expectedMsgType = MessageType.MessageType_Initialize;
+
+      expect(actualMsgType, expectedMsgType);
+    });
+
+    test('Should [MessageType.MessageType_GetPublicKey] if the message is GetPublicKey', () {
+      // Arrange
+      GetPublicKey actualMessage = GetPublicKey();
+
+      // Act
+      MessageType actualMsgType = ProtobufMsgMapper.getMsgType(actualMessage);
+
+      // Assert
+      MessageType expectedMsgType = MessageType.MessageType_GetPublicKey;
+
+      expect(actualMsgType, expectedMsgType);
+    });
+
+    test('Should [MessageType.MessageType_PublicKey] if the message is PublicKey', () {
+      // Arrange
+      PublicKey actualMessage = PublicKey();
+
+      // Act
+      MessageType actualMsgType = ProtobufMsgMapper.getMsgType(actualMessage);
+
+      // Assert
+      MessageType expectedMsgType = MessageType.MessageType_PublicKey;
+
+      expect(actualMsgType, expectedMsgType);
+    });
+
+    test('Should [MessageType.MessageType_Features] if the message is Features', () {
+      // Arrange
+      Features actualMessage = Features();
+
+      // Act
+      MessageType actualMsgType = ProtobufMsgMapper.getMsgType(actualMessage);
+
+      // Assert
+      MessageType expectedMsgType = MessageType.MessageType_Features;
+
+      expect(actualMsgType, expectedMsgType);
+    });
+
+    test('Should [MessageType.MessageType_ButtonRequest] if the message is ButtonRequest', () {
+      // Arrange
+      ButtonRequest actualMessage = ButtonRequest();
+
+      // Act
+      MessageType actualMsgType = ProtobufMsgMapper.getMsgType(actualMessage);
+
+      // Assert
+      MessageType expectedMsgType = MessageType.MessageType_ButtonRequest;
+
+      expect(actualMsgType, expectedMsgType);
+    });
+
+    test('Should [MessageType.MessageType_ButtonAck] if the message is ButtonAck', () {
+      // Arrange
+      ButtonAck actualMessage = ButtonAck();
+
+      // Act
+      MessageType actualMsgType = ProtobufMsgMapper.getMsgType(actualMessage);
+
+      // Assert
+      MessageType expectedMsgType = MessageType.MessageType_ButtonAck;
+
+      expect(actualMsgType, expectedMsgType);
+    });
+
+    test('Should [MessageType.MessageType_GetAddress] if the message is GetAddress', () {
+      // Arrange
+      GetAddress actualMessage = GetAddress();
+
+      // Act
+      MessageType actualMsgType = ProtobufMsgMapper.getMsgType(actualMessage);
+
+      // Assert
+      MessageType expectedMsgType = MessageType.MessageType_GetAddress;
+
+      expect(actualMsgType, expectedMsgType);
+    });
+
+    test('Should [MessageType.MessageType_Address] if the message is Address', () {
+      // Arrange
+      Address actualMessage = Address();
+
+      // Act
+      MessageType actualMsgType = ProtobufMsgMapper.getMsgType(actualMessage);
+
+      // Assert
+      MessageType expectedMsgType = MessageType.MessageType_Address;
+
+      expect(actualMsgType, expectedMsgType);
+    });
+
+    test('Should [MessageType.MessageType_GetFeatures] if the message is GetFeatures', () {
+      // Arrange
+      GetFeatures actualMessage = GetFeatures();
+
+      // Act
+      MessageType actualMsgType = ProtobufMsgMapper.getMsgType(actualMessage);
+
+      // Assert
+      MessageType expectedMsgType = MessageType.MessageType_GetFeatures;
+
+      expect(actualMsgType, expectedMsgType);
+    });
+
+    test('Should [MessageType.MessageType_EthereumTxRequest] if the message is EthereumTxRequest', () {
+      // Arrange
+      EthereumTxRequest actualMessage = EthereumTxRequest();
+
+      // Act
+      MessageType actualMsgType = ProtobufMsgMapper.getMsgType(actualMessage);
+
+      // Assert
+      MessageType expectedMsgType = MessageType.MessageType_EthereumTxRequest;
+
+      expect(actualMsgType, expectedMsgType);
+    });
+
+    test('Should [MessageType.MessageType_EthereumSignTxEIP1559] if the message is EthereumSignTxEIP1559', () {
+      // Arrange
+      EthereumSignTxEIP1559 actualMessage = EthereumSignTxEIP1559();
+
+      // Act
+      MessageType actualMsgType = ProtobufMsgMapper.getMsgType(actualMessage);
+
+      // Assert
+      MessageType expectedMsgType = MessageType.MessageType_EthereumSignTxEIP1559;
+
+      expect(actualMsgType, expectedMsgType);
     });
   });
 }


### PR DESCRIPTION
This branch implements the functionality of responding to received messages, according to the Trezor protocol. This is a simplified form that lacks the feature of storing the requests and asking for additional data before responding. Therefore, it cannot handle large EIP1559 transactions (>1024 data bytes) and there may be a limited time for user interaction. Because of work organization reasons, these features will be added later.

List of changes:
- updated Flutter version to 3.16.2 to resolve dependencies conflicts caused by cryptography_utils, updated the version in README.md
- created trezor_communication_controller.dart to manage the protobuf message responding
- created a_trezor_inbound_request.dart and a_trezor_outbound_response.dart and the extending classes. These are custom objects that represent the protobuf messages used by Mirage. They allow to reduce fields and implement our own abstract methods.
- created locator.dart as implementation of GetIt and assigned TrezorCommunicationController as a global singleton, so it can track the whole communication process
- optimized protobuf_msg_mapper.dart for using compiled protobuf code and added new method "getMsgType()" that returns a msg type (enum) given the msg object
- deleted PassphraseRequest and PassphraseAck msg handling, since this feature will not be used on Mirage (standard wallet only)